### PR TITLE
[ui] TextInput: add `wrapperClassName`prop, cleanup

### DIFF
--- a/libs/juno-ui-components/src/components/ComboBox/ComboBox.component.js
+++ b/libs/juno-ui-components/src/components/ComboBox/ComboBox.component.js
@@ -3,29 +3,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useId, useMemo, createContext } from "react"
-import PropTypes from "prop-types"
-import { Combobox } from "@headlessui/react"
-import { Float } from "@headlessui-float/react"
-import { Label } from "../Label/index.js"
-import { FormHint } from "../FormHint/index.js"
-import { Icon } from "../Icon/index.js"
-import { Spinner } from "../Spinner/index.js"
-import { flip, offset, shift, size } from '@floating-ui/react-dom'
-import { usePortalRef } from "../PortalProvider/index"
-import { createPortal } from "react-dom"
+import React, {
+  useState,
+  useEffect,
+  useId,
+  useMemo,
+  createContext,
+} from "react";
+import PropTypes from "prop-types";
+import { Combobox } from "@headlessui/react";
+import { Float } from "@headlessui-float/react";
+import { Label } from "../Label/index.js";
+import { FormHint } from "../FormHint/index.js";
+import { Icon } from "../Icon/index.js";
+import { Spinner } from "../Spinner/index.js";
+import { flip, offset, shift, size } from "@floating-ui/react-dom";
+import { usePortalRef } from "../PortalProvider/index";
+import { createPortal } from "react-dom";
 
 // STYLES
 
 const inputWrapperStyles = `
   jn-relative
-`
+`;
 
 const labelStyles = `
   jn-pointer-events-none
   jn-top-2
   jn-left-[0.9375rem]
-`
+`;
 
 const inputStyles = `
   jn-rounded-3px
@@ -44,34 +50,34 @@ const inputStyles = `
   focus:jn-outline-none
   focus:jn-ring-2
   focus:jn-ring-theme-focus
-`
+`;
 
 const withLabelInputStyles = `
   jn-pt-[1.125rem] 
   jn-pb-1
-`
+`;
 
 const noLabelInputStyles = `
   jn-py-4
-`
+`;
 
 const disabledInputStyles = `
   jn-cursor-not-allowed
   jn-pointer-events-none
   jn-opacity-50
-`
+`;
 
 const defaultBorderStyles = `
   jn-border-theme-textinput-default
-`
+`;
 
 const validStyles = `
   jn-border-theme-success
-`
+`;
 
 const invalidStyles = `
   jn-border-theme-error
-`
+`;
 
 const buttonStyles = `
   jn-absolute
@@ -88,39 +94,39 @@ const buttonStyles = `
   jn-appearance-none
   jn-bg-theme-textinput
   jn-text-theme-textinput
-`
+`;
 
 const defaultButtonStyles = `
   jn-border-theme-textinput-default
-`
+`;
 
 const invalidButtonStyles = `
   jn-border-theme-error
-`
+`;
 
 const validButtonStyles = `
   jn-border-theme-success
-`
+`;
 
 const disabledButtonStyles = `
   jn-cursor-not-allowed
   jn-pointer-events-none
   jn-bg-transparent
   jn-opacity-50
-`
+`;
 
 const menuStyles = `
   jn-rounded
   jn-bg-theme-background-lvl-1
   jn-w-full
   jn-overflow-y-auto
-`
+`;
 
 const iconContainerStyles = `
   jn-absolute
   jn-top-[.4rem]
   jn-right-6
-`
+`;
 
 const centeredIconStyles = `
   jn-absolute
@@ -128,10 +134,10 @@ const centeredIconStyles = `
   jn-left-1/2
   jn-translate-y-[-50%]
   jn-translate-x-[-0.75rem]
-`
+`;
 
 // CONTEXT
-export const ComboBoxContext = createContext()
+export const ComboBoxContext = createContext();
 
 // COMBOBOX
 export const ComboBox = ({
@@ -161,293 +167,318 @@ export const ComboBox = ({
   value,
   valueLabel,
   width,
+  wrapperClassName,
   ...props
 }) => {
-  
   const isNotEmptyString = (str) => {
-    return !(typeof str === 'string' && str.trim().length === 0)
-  }
-    
-  const theId = id || "juno-combobox-" + useId()    
-  const helptextId = "juno-combobox-helptext-" + useId()
-  
-  const [optionValuesAndLabels, setOptionValuesAndLabels] = useState(new Map())
-  const [query, setQuery] = useState("")
-  const [selectedValue, setSelectedValue] = useState(value)
-  const [isLoading, setIsLoading] = useState(false)
-  const [hasError, setHasError] = useState(false)
-  const [hasFocus, setFocus] = useState(false)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
-  
+    return !(typeof str === "string" && str.trim().length === 0);
+  };
+
+  const theId = id || "juno-combobox-" + useId();
+  const helptextId = "juno-combobox-helptext-" + useId();
+
+  const [optionValuesAndLabels, setOptionValuesAndLabels] = useState(new Map());
+  const [query, setQuery] = useState("");
+  const [selectedValue, setSelectedValue] = useState(value);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [hasFocus, setFocus] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [isValid, setIsValid] = useState(false);
+
   // This callback is for all ComboBoxOptions to send us their value, label and children so we can save them as a map in our state.
   // We need this because the Select component wants to display the selected value, label or children in the ComboBox input field
-  // but from the eventHandler we only get the value, not the label or children 
+  // but from the eventHandler we only get the value, not the label or children
   const addOptionValueAndLabel = (value, label, children) => {
     // append new entry to optionValuesAndLabels map containing the passed value, label and children
     // use callback syntax of setState function here since we want to merge the old state with the new entry
-    setOptionValuesAndLabels(oldMap => (new Map(oldMap).set(value || children, { val: value, label: label, children: children })))
-  }
-  
+    setOptionValuesAndLabels((oldMap) =>
+      new Map(oldMap).set(value || children, {
+        val: value,
+        label: label,
+        children: children,
+      })
+    );
+  };
+
   const invalidated = useMemo(
     () => invalid || (errortext && isNotEmptyString(errortext) ? true : false),
     [invalid, errortext]
-  )
+  );
   const validated = useMemo(
-    () => valid || (successtext && isNotEmptyString(successtext) ? true : false),
+    () =>
+      valid || (successtext && isNotEmptyString(successtext) ? true : false),
     [valid, successtext]
-  )
-  
+  );
+
   useEffect(() => {
-    setSelectedValue(value)
-  }, [value] )
-  
+    setSelectedValue(value);
+  }, [value]);
+
   useEffect(() => {
-    setHasError(error)
-  }, [error])
-  
+    setHasError(error);
+  }, [error]);
+
   useEffect(() => {
-    setIsLoading(loading)
-  }, [loading])
-  
+    setIsLoading(loading);
+  }, [loading]);
+
   useEffect(() => {
-    setIsInvalid(invalidated)
-  }, [invalidated])
-  
+    setIsInvalid(invalidated);
+  }, [invalidated]);
+
   useEffect(() => {
-    setIsValid(validated)
-  }, [validated])
-  
+    setIsValid(validated);
+  }, [validated]);
+
   const handleChange = (value) => {
-    setSelectedValue(value)
-    onChange && onChange(value)
-  }
-  
+    setSelectedValue(value);
+    onChange && onChange(value);
+  };
+
   const handleInputChange = (event) => {
-    setQuery(event?.target?.value)
-    onInputChange && onInputChange(event)
-  }
-  
+    setQuery(event?.target?.value);
+    onInputChange && onInputChange(event);
+  };
+
   const handleFocus = (event) => {
-    setFocus(true)
-    onFocus && onFocus(event)
-  }
-  
+    setFocus(true);
+    onFocus && onFocus(event);
+  };
+
   const handleBlur = (event) => {
-    setFocus(false)
-    onBlur && onBlur(event)
-  }
-  
-  const portalContainerRef = usePortalRef()
-  
+    setFocus(false);
+    onBlur && onBlur(event);
+  };
+
+  const portalContainerRef = usePortalRef();
+
   // Headless-UI-Float Middleware
   const middleware = [
     offset(4),
     shift(),
     flip(),
     size({
-      boundary: 'viewport',
-      apply({availableWidth, availableHeight, elements}) {
+      boundary: "viewport",
+      apply({ availableWidth, availableHeight, elements }) {
         Object.assign(elements.floating.style, {
           maxWidth: `${availableWidth}px`,
           maxHeight: `${availableHeight}px`,
-          overflowY: "auto"
-        })
-      }
-    })
-  ]
-  
-  const filteredChildren = 
-    query === ""
-    ? children
-    : children.filter((child) => {
-        // ensure that we filter on the value that is displayed to the user. Apply the same logic as when rendering
-        // the options, i.e. match children if present, if not match label, lastly if neither label nor children exist, then check value
-        const optionDisplayValue = child.props.children?.toString() || child.props.label ||  child.props.value
-        return optionDisplayValue?.toLowerCase().includes(query.toLowerCase())
-      }
-      )
+          overflowY: "auto",
+        });
+      },
+    }),
+  ];
 
-  
+  const filteredChildren =
+    query === ""
+      ? children
+      : children.filter((child) => {
+          // ensure that we filter on the value that is displayed to the user. Apply the same logic as when rendering
+          // the options, i.e. match children if present, if not match label, lastly if neither label nor children exist, then check value
+          const optionDisplayValue =
+            child.props.children?.toString() ||
+            child.props.label ||
+            child.props.value;
+          return optionDisplayValue
+            ?.toLowerCase()
+            .includes(query.toLowerCase());
+        });
+
   return (
-    
-    
-    <ComboBoxContext.Provider value={{
+    <ComboBoxContext.Provider
+      value={{
         selectedValue: selectedValue,
         truncateOptions: truncateOptions,
-        addOptionValueAndLabel: addOptionValueAndLabel
+        addOptionValueAndLabel: addOptionValueAndLabel,
       }}
     >
-    
       <div
         className={`
           juno-combobox-wrapper
           jn-relative
-          ${ width == "auto" ? "jn-inline-block" : "jn-block" }
-          ${ width == "auto" ? "jn-w-auto" : "jn-w-full" }
+          ${width == "auto" ? "jn-inline-block" : "jn-block"}
+          ${width == "auto" ? "jn-w-auto" : "jn-w-full"}
+          ${wrapperClassName}
         `}
       >
         <Combobox
           defaultValue={defaultValue}
-          disabled={ disabled || isLoading || hasError }
+          disabled={disabled || isLoading || hasError}
           name={name}
           nullable={nullable}
           onChange={handleChange}
-          value={ selectedValue || defaultValue }
+          value={selectedValue || defaultValue}
           {...props}
         >
-        
-          <Float
-            composable
-            adaptiveWidth
-            middleware={middleware}
-          >
-          
-          <Float.Reference>
-            <div
-              className={`
+          <Float composable adaptiveWidth middleware={middleware}>
+            <Float.Reference>
+              <div
+                className={`
                 juno-combobox-input-wrapper
-                ${ inputWrapperStyles }
-                ${ disabled ? "jn-cursor-not-allowed" : "" }
+                ${inputWrapperStyles}
+                ${disabled ? "jn-cursor-not-allowed" : ""}
               `}
-            >
-            
-              { label && isNotEmptyString(label) && !isLoading && !hasError ?
-                  <Label 
+              >
+                {label && isNotEmptyString(label) && !isLoading && !hasError ? (
+                  <Label
                     text={label}
                     disabled={disabled}
                     required={required}
                     htmlFor={theId}
                     className={`${labelStyles}`}
                     floating
-                    minimized={ placeholder || hasFocus || (query && isNotEmptyString(query) || (selectedValue && isNotEmptyString(selectedValue)) ) ? true : false}
+                    minimized={
+                      placeholder ||
+                      hasFocus ||
+                      (query && isNotEmptyString(query)) ||
+                      (selectedValue && isNotEmptyString(selectedValue))
+                        ? true
+                        : false
+                    }
                   />
-                :
+                ) : (
                   ""
-              }
-            
-              <Combobox.Input
-                autoComplete="off"
-                aria-label={ ariaLabel || label }
-                aria-describedby={ helptext ? helptextId : "" }
-                disabled={ disabled || isLoading || hasError }
-                id={theId}
-                onBlur={handleBlur}
-                onChange={handleInputChange}
-                onFocus={handleFocus}
-                placeholder={ !isLoading && !hasError ? placeholder : ""} 
-                displayValue={ 
-                  (val) => 
-                  optionValuesAndLabels.get(val)?.children || optionValuesAndLabels.get(val)?.label || valueLabel || val 
-                  
-                  
-                } // Headless-UI expects a callback here
-                className={`
+                )}
+
+                <Combobox.Input
+                  autoComplete="off"
+                  aria-label={ariaLabel || label}
+                  aria-describedby={helptext ? helptextId : ""}
+                  disabled={disabled || isLoading || hasError}
+                  id={theId}
+                  onBlur={handleBlur}
+                  onChange={handleInputChange}
+                  onFocus={handleFocus}
+                  placeholder={!isLoading && !hasError ? placeholder : ""}
+                  displayValue={(val) =>
+                    optionValuesAndLabels.get(val)?.children ||
+                    optionValuesAndLabels.get(val)?.label ||
+                    valueLabel ||
+                    val
+                  } // Headless-UI expects a callback here
+                  className={`
                   juno-combobox-input 
                   ${inputStyles} 
-                  ${ label && isNotEmptyString(label) ? withLabelInputStyles : noLabelInputStyles }
-                  ${ disabled ? disabledInputStyles : "" }
-                  ${ isInvalid ? "juno-combobox-invalid " + invalidStyles : "" } 
-                  ${ isValid ? "juno-combobox-valid " + validStyles : "" }  
-                  ${ isValid || isInvalid ? "" : defaultBorderStyles } 
-                  ${ isLoading ? "juno-combobox-loading jn-cursor-not-allowed" : "" }
-                  ${ hasError ? "juno-combobox-error jn-cursor-not-allowed" : "" }
+                  ${
+                    label && isNotEmptyString(label)
+                      ? withLabelInputStyles
+                      : noLabelInputStyles
+                  }
+                  ${disabled ? disabledInputStyles : ""}
+                  ${isInvalid ? "juno-combobox-invalid " + invalidStyles : ""} 
+                  ${isValid ? "juno-combobox-valid " + validStyles : ""}  
+                  ${isValid || isInvalid ? "" : defaultBorderStyles} 
+                  ${
+                    isLoading
+                      ? "juno-combobox-loading jn-cursor-not-allowed"
+                      : ""
+                  }
+                  ${hasError ? "juno-combobox-error jn-cursor-not-allowed" : ""}
                   ${className}
                 `}
-              />
-              
-              { 
-                isLoading || hasError ? 
+                />
+
+                {isLoading || hasError ? (
                   <span className={`${centeredIconStyles}`}>
-                    { isLoading ? 
-                        <Spinner className={"jn-cursor-not-allowed"} />
-                      :
-                        <Icon icon="errorOutline" color="jn-text-theme-error" className={"jn-cursor-not-allowed"} />
-                    }
+                    {isLoading ? (
+                      <Spinner className={"jn-cursor-not-allowed"} />
+                    ) : (
+                      <Icon
+                        icon="errorOutline"
+                        color="jn-text-theme-error"
+                        className={"jn-cursor-not-allowed"}
+                      />
+                    )}
                   </span>
-                :
-                    isValid || isInvalid  ?
-                      <span className={`
+                ) : isValid || isInvalid ? (
+                  <span
+                    className={`
                         juno-combobox-icon-container 
                         ${iconContainerStyles} 
-                        ${ disabled ? "jn-opacity-50" : "" }
-                      `}>
-                        <Icon 
-                          icon={ isValid ? "checkCircle" : "dangerous" }
-                          color={ isValid ? "jn-text-theme-success" : "jn-text-theme-error"  }
-                        />
-                      </span>
-                    :
-                      ""
-              }
-              
-              { !hasError && !isLoading ?
-                  
-                    <Combobox.Button
-                      disabled={disabled} 
-                      className={`
+                        ${disabled ? "jn-opacity-50" : ""}
+                      `}
+                  >
+                    <Icon
+                      icon={isValid ? "checkCircle" : "dangerous"}
+                      color={
+                        isValid
+                          ? "jn-text-theme-success"
+                          : "jn-text-theme-error"
+                      }
+                    />
+                  </span>
+                ) : (
+                  ""
+                )}
+
+                {!hasError && !isLoading ? (
+                  <Combobox.Button
+                    disabled={disabled}
+                    className={`
                         juno-combobox-toggle 
                         ${buttonStyles}
-                        ${ disabled ? disabledButtonStyles : "" }
-                        ${ isInvalid ? "juno-combobox-toggle-invalid " + invalidButtonStyles : "" } 
-                        ${ isValid ? "juno-combobox-toggle-valid " + validButtonStyles : "" }  
-                        ${ isValid || isInvalid ? "" : defaultButtonStyles } 
+                        ${disabled ? disabledButtonStyles : ""}
+                        ${
+                          isInvalid
+                            ? "juno-combobox-toggle-invalid " +
+                              invalidButtonStyles
+                            : ""
+                        } 
+                        ${
+                          isValid
+                            ? "juno-combobox-toggle-valid " + validButtonStyles
+                            : ""
+                        }  
+                        ${isValid || isInvalid ? "" : defaultButtonStyles} 
                       `}
-                    >
-                      {({open}) => (
-                        <Icon icon={ open ? "expandLess": "expandMore"} />
-                      )}
-                    </Combobox.Button>
-                 
-                : ""
-              }
-            </div>
-          </Float.Reference>
-            
-            
-            { createPortal(
+                  >
+                    {({ open }) => (
+                      <Icon icon={open ? "expandLess" : "expandMore"} />
+                    )}
+                  </Combobox.Button>
+                ) : (
+                  ""
+                )}
+              </div>
+            </Float.Reference>
+
+            {createPortal(
               <Float.Content>
                 <Combobox.Options
                   unmount={false}
                   className={`
                     juno-combobox-options 
                     ${menuStyles}
-                  `} 
+                  `}
                 >
-                  { filteredChildren }
+                  {filteredChildren}
                 </Combobox.Options>
-              </Float.Content>
-            , portalContainerRef ? portalContainerRef : document.body
+              </Float.Content>,
+              portalContainerRef ? portalContainerRef : document.body
             )}
-            
           </Float>
-          
         </Combobox>
-        
-        { errortext && isNotEmptyString(errortext) ?
-            <FormHint text={errortext} variant="error"/>
-          :
-            ""
-        }
-        { successtext && isNotEmptyString(successtext) ?
-            <FormHint text={successtext} variant="success"/>
-          :
-            ""
-        }
-        { helptext && isNotEmptyString(helptext) ?
-            <FormHint text={helptext} id={helptextId} />
-          :
-            ""
-         }
-        
-      </div>
-      
-    </ComboBoxContext.Provider>
-      
-  )
-  
-}
 
+        {errortext && isNotEmptyString(errortext) ? (
+          <FormHint text={errortext} variant="error" />
+        ) : (
+          ""
+        )}
+        {successtext && isNotEmptyString(successtext) ? (
+          <FormHint text={successtext} variant="success" />
+        ) : (
+          ""
+        )}
+        {helptext && isNotEmptyString(helptext) ? (
+          <FormHint text={helptext} id={helptextId} />
+        ) : (
+          ""
+        )}
+      </div>
+    </ComboBoxContext.Provider>
+  );
+};
 
 ComboBox.propTypes = {
   /** The aria-label of the ComboBox. Defaults to the label if label was passed. */
@@ -472,7 +503,7 @@ ComboBox.propTypes = {
   invalid: PropTypes.bool,
   /** The label of the ComboBox */
   label: PropTypes.string,
-  /** Whether the ComboBox is busy loading options */ 
+  /** Whether the ComboBox is busy loading options */
   loading: PropTypes.bool,
   /** The name attribute of the ComboBox when used as part of a form  */
   name: PropTypes.string,
@@ -501,8 +532,10 @@ ComboBox.propTypes = {
   /** The label of the passed value or defaultValue. If you want to use controlled mode or pass as defaultValue in uncontrolled mode and additionally use labels for human-readable SelectOptions, you need to also pass the matching label for the passed value/defaultValue so that the Select component can render itself properly */
   valueLabel: PropTypes.string,
   /** The width of the text input. Either 'full' (default) or 'auto'. */
-  width: PropTypes.oneOf(["full", "auto"])
-}
+  width: PropTypes.oneOf(["full", "auto"]),
+  /** Pass a className to the outer wrapping <div> element */
+  wrapperClassName: PropTypes.string,
+};
 
 ComboBox.defaultProps = {
   ariaLabel: undefined,
@@ -531,4 +564,5 @@ ComboBox.defaultProps = {
   value: "",
   valueLabel: undefined,
   width: "full",
-}
+  wrapperClassName: "",
+};

--- a/libs/juno-ui-components/src/components/ComboBox/ComboBox.test.js
+++ b/libs/juno-ui-components/src/components/ComboBox/ComboBox.test.js
@@ -3,208 +3,208 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as React from "react"
-import { cleanup, render, screen, waitFor } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import { ComboBox } from "./index"
-import { ComboBoxOption } from "../ComboBoxOption/index"
+import * as React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ComboBox } from "./index";
+import { ComboBoxOption } from "../ComboBoxOption/index";
 
-const mockOnBlur = jest.fn()
-const mockOnChange = jest.fn()
-const mockOnFocus = jest.fn()
-const mockOnInputChange = jest.fn()
+const mockOnBlur = jest.fn();
+const mockOnChange = jest.fn();
+const mockOnFocus = jest.fn();
+const mockOnInputChange = jest.fn();
 
 describe("ComboBox", () => {
   afterEach(() => {
-    cleanup()
-    jest.clearAllMocks()
-  })
+    cleanup();
+    jest.clearAllMocks();
+  });
 
   test("renders a ComboBox", async () => {
-    render(<ComboBox />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveAttribute("type", "text")
-    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-input")
-  })
+    render(<ComboBox />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveAttribute("type", "text");
+    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-input");
+  });
 
   test("renders a ComboBox with a name as passed", async () => {
     render(
       <ComboBox name="my-wonderful-combobox">
         <ComboBoxOption value="Option 1">Option 1</ComboBoxOption>
       </ComboBox>
-    )
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    );
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
     /* Here we need to directly select the input, since headless 
       a) does not add the name to the visible input element but to another, hidden input element it keeps in sync, and
       b) react-testing fails when trying to access hidden elements by role: */
     expect(
       document.querySelector("input[name='my-wonderful-combobox']")
-    ).toBeInTheDocument()
-  })
+    ).toBeInTheDocument();
+  });
 
   test("renders a ComboBox with a label as passed", async () => {
-    render(<ComboBox label="My Label" />)
-    expect(document.querySelector(".juno-label")).toBeInTheDocument()
-    expect(document.querySelector(".juno-label")).toHaveTextContent("My Label")
-  })
+    render(<ComboBox label="My Label" />);
+    expect(document.querySelector(".juno-label")).toBeInTheDocument();
+    expect(document.querySelector(".juno-label")).toHaveTextContent("My Label");
+  });
 
   test("renders options as passed", async () => {
     render(
       <ComboBox>
         <ComboBoxOption value="Option 1">Option 1</ComboBoxOption>
       </ComboBox>
-    )
-    const user = userEvent.setup()
-    const cbox = screen.getByRole("combobox")
-    const cbutton = screen.getByRole("button")
-    expect(cbox).toBeInTheDocument()
-    expect(cbutton).toBeInTheDocument()
+    );
+    const user = userEvent.setup();
+    const cbox = screen.getByRole("combobox");
+    const cbutton = screen.getByRole("button");
+    expect(cbox).toBeInTheDocument();
+    expect(cbutton).toBeInTheDocument();
     waitFor(() => {
-      user.click(cbutton)
-      expect(screen.getByRole("listbox")).toBeInTheDocument()
-      expect(screen.getByRole("option")).toBeInTheDocument()
-      expect(screen.getByRole("option")).toHaveTextContent("Option 1")
-    })
-  })
+      user.click(cbutton);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      expect(screen.getByRole("option")).toBeInTheDocument();
+      expect(screen.getByRole("option")).toHaveTextContent("Option 1");
+    });
+  });
 
   test("renders an id as passed", async () => {
-    render(<ComboBox id="My Id" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveAttribute("id", "My Id")
-  })
+    render(<ComboBox id="My Id" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveAttribute("id", "My Id");
+  });
 
   test("renders the id of the ComboBox input as the for attribute of the label", async () => {
-    render(<ComboBox label="the label" />)
-    const cbox = screen.getByRole("combobox")
-    const label = document.querySelector(".juno-label")
-    expect(cbox).toBeInTheDocument()
-    expect(label).toBeInTheDocument()
-    expect(label.getAttribute("for")).toMatch(cbox.getAttribute("id"))
-    expect(screen.getByLabelText("the label")).toBeInTheDocument()
-  })
+    render(<ComboBox label="the label" />);
+    const cbox = screen.getByRole("combobox");
+    const label = document.querySelector(".juno-label");
+    expect(cbox).toBeInTheDocument();
+    expect(label).toBeInTheDocument();
+    expect(label.getAttribute("for")).toMatch(cbox.getAttribute("id"));
+    expect(screen.getByLabelText("the label")).toBeInTheDocument();
+  });
 
   test("renders an aria-label as passed", async () => {
-    render(<ComboBox ariaLabel="my aria-label" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    render(<ComboBox ariaLabel="my aria-label" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
     expect(screen.getByRole("combobox")).toHaveAttribute(
       "aria-label",
       "my aria-label"
-    )
-  })
+    );
+  });
 
   test("renders the label as an aria-label if no aria-label was passed", async () => {
-    render(<ComboBox label="My Label" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    render(<ComboBox label="My Label" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
     expect(screen.getByRole("combobox")).toHaveAttribute(
       "aria-label",
       "My Label"
-    )
-  })
+    );
+  });
 
   test("renders a ComboBox with a placeholder as passed", async () => {
-    render(<ComboBox placeholder="My Placeholder" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    render(<ComboBox placeholder="My Placeholder" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
     expect(screen.getByRole("combobox")).toHaveAttribute(
       "placeholder",
       "My Placeholder"
-    )
-  })
+    );
+  });
 
   test("renders a disabled ComboBox as passed", async () => {
-    render(<ComboBox disabled />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toBeDisabled()
-  })
+    render(<ComboBox disabled />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
 
   test("renders a required ComboBox as passed", async () => {
-    render(<ComboBox label="My Required ComboBox" required />)
-    expect(document.querySelector(".juno-label")).toBeInTheDocument()
-    expect(document.querySelector(".juno-required")).toBeInTheDocument()
-  })
+    render(<ComboBox label="My Required ComboBox" required />);
+    expect(document.querySelector(".juno-label")).toBeInTheDocument();
+    expect(document.querySelector(".juno-required")).toBeInTheDocument();
+  });
 
   test("renders a validated ComboBox as passed", async () => {
-    render(<ComboBox valid />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-valid")
-    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-  })
+    render(<ComboBox valid />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-valid");
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
 
   test("renders a validated ComboBox when a successtext was passed", async () => {
-    render(<ComboBox successtext="Great Success!" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-valid")
-    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-  })
+    render(<ComboBox successtext="Great Success!" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-valid");
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
 
   test("renders an invalidated ComboBox as passed", async () => {
-    render(<ComboBox invalid />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-invalid")
-    expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-  })
+    render(<ComboBox invalid />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-invalid");
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
 
   test("renders an invalidated ComboBox when an errortext was passed", async () => {
-    render(<ComboBox errortext="Oh Snap!" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-invalid")
-    expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-  })
+    render(<ComboBox errortext="Oh Snap!" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-invalid");
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
 
   test("renders a helptext as passed", async () => {
-    render(<ComboBox helptext="A helptext goes here" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
+    render(<ComboBox helptext="A helptext goes here" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
     expect(document.querySelector(".juno-form-hint")).toHaveClass(
       "juno-form-hint-help"
-    )
+    );
     expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
       "A helptext goes here"
-    )
-  })
+    );
+  });
 
   test("renders an errortext as passed", async () => {
-    render(<ComboBox errortext="An errortext goes here" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
+    render(<ComboBox errortext="An errortext goes here" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
     expect(document.querySelector(".juno-form-hint")).toHaveClass(
       "juno-form-hint-error"
-    )
+    );
     expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
       "An errortext goes here"
-    )
-  })
+    );
+  });
 
   test("renders a successtext as passed", async () => {
-    render(<ComboBox successtext="A successtext goes here" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
+    render(<ComboBox successtext="A successtext goes here" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
     expect(document.querySelector(".juno-form-hint")).toHaveClass(
       "juno-form-hint-success"
-    )
+    );
     expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
       "A successtext goes here"
-    )
-  })
+    );
+  });
 
   test("renders a loading ComboBox with a Spinner as passed", async () => {
-    render(<ComboBox loading />)
-    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-loading")
-    expect(document.querySelector(".juno-spinner")).toBeInTheDocument()
-  })
+    render(<ComboBox loading />);
+    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-loading");
+    expect(document.querySelector(".juno-spinner")).toBeInTheDocument();
+  });
 
   test("renders a ComboBox in error state with an Error icon as passed", async () => {
-    render(<ComboBox error />)
-    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-error")
-    expect(screen.getByTitle("Error")).toBeInTheDocument()
-  })
+    render(<ComboBox error />);
+    expect(screen.getByRole("combobox")).toHaveClass("juno-combobox-error");
+    expect(screen.getByTitle("Error")).toBeInTheDocument();
+  });
 
   test("fires an onBlur handler as passed when the ComboBox looses focus", async () => {
-    render(<ComboBox onBlur={mockOnBlur} />)
-    const user = userEvent.setup()
-    const cbox = screen.getByRole("combobox")
+    render(<ComboBox onBlur={mockOnBlur} />);
+    const user = userEvent.setup();
+    const cbox = screen.getByRole("combobox");
     waitFor(() => {
-      user.click(cbox) // focus the element
-      user.tab() // blur the element
-      expect(mockOnBlur).toHaveBeenCalled()
-    })
-  })
+      user.click(cbox); // focus the element
+      user.tab(); // blur the element
+      expect(mockOnBlur).toHaveBeenCalled();
+    });
+  });
 
   test("fires an onChange handler as passed when the user selects an option", async () => {
     render(
@@ -212,29 +212,29 @@ describe("ComboBox", () => {
         <ComboBoxOption value="option 1">Option 1</ComboBoxOption>
         <ComboBoxOption value="option 2">Option 2</ComboBoxOption>
       </ComboBox>
-    )
-    const user = userEvent.setup()
-    const cbox = screen.getByRole("combobox")
-    const cbutton = screen.getByRole("button")
-    expect(cbox).toBeInTheDocument()
-    expect(cbutton).toBeInTheDocument()
+    );
+    const user = userEvent.setup();
+    const cbox = screen.getByRole("combobox");
+    const cbutton = screen.getByRole("button");
+    expect(cbox).toBeInTheDocument();
+    expect(cbutton).toBeInTheDocument();
     waitFor(() => {
-      user.click(cbutton)
-      expect(screen.getByRole("listbox")).toBeInTheDocument()
-      user.click(screen.getByRole("option", { name: "Option 2" }))
-      expect(mockOnChange).toHaveBeenCalled()
-    })    
-  })
+      user.click(cbutton);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      user.click(screen.getByRole("option", { name: "Option 2" }));
+      expect(mockOnChange).toHaveBeenCalled();
+    });
+  });
 
   test("fires an onFocus handler as passed when the ComboBox receives focus", async () => {
-    render(<ComboBox onFocus={mockOnFocus} />)
-    const user = userEvent.setup()
-    const cbox = screen.getByRole("combobox")
+    render(<ComboBox onFocus={mockOnFocus} />);
+    const user = userEvent.setup();
+    const cbox = screen.getByRole("combobox");
     waitFor(() => {
-      user.click(cbox)
-      expect(mockOnFocus).toHaveBeenCalled()
-    })
-  })
+      user.click(cbox);
+      expect(mockOnFocus).toHaveBeenCalled();
+    });
+  });
 
   test("fires an onInputChange handler when the user types into the ComboBox", async () => {
     render(
@@ -242,14 +242,14 @@ describe("ComboBox", () => {
         <ComboBoxOption value="something">Something</ComboBoxOption>
         <ComboBoxOption value="something else">Something else</ComboBoxOption>
       </ComboBox>
-    )
-    const user = userEvent.setup()
-    const cbox = screen.getByRole("combobox")
+    );
+    const user = userEvent.setup();
+    const cbox = screen.getByRole("combobox");
     waitFor(() => {
-      user.type(cbox, "a")
-      expect(mockOnInputChange).toHaveBeenCalled()
-    })
-  })
+      user.type(cbox, "a");
+      expect(mockOnInputChange).toHaveBeenCalled();
+    });
+  });
 
   test("filters options as the user types", async () => {
     render(
@@ -267,48 +267,48 @@ describe("ComboBox", () => {
           123
         </ComboBoxOption>
       </ComboBox>
-    )
-    const user = userEvent.setup()
-    const cbox = screen.getByRole("combobox")
-    expect(cbox).toBeInTheDocument()
+    );
+    const user = userEvent.setup();
+    const cbox = screen.getByRole("combobox");
+    expect(cbox).toBeInTheDocument();
     waitFor(() => {
-      user.type(cbox, "a")
-      expect(screen.getByRole("listbox")).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "aaa" })).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "aab" })).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "abc" })).toBeInTheDocument()
+      user.type(cbox, "a");
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "aaa" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "aab" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "abc" })).toBeInTheDocument();
       expect(
         screen.queryByRole("option", { name: "123" })
-      ).not.toBeInTheDocument()
-    })
+      ).not.toBeInTheDocument();
+    });
     waitFor(() => {
-      user.type(cbox, "b")
+      user.type(cbox, "b");
       expect(
         screen.queryByRole("option", { name: "aaa" })
-      ).not.toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "aab" })).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "abc" })).toBeInTheDocument()
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "aab" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "abc" })).toBeInTheDocument();
       expect(
         screen.queryByRole("option", { name: "123" })
-      ).not.toBeInTheDocument()
-      user.clear(cbox)
-      expect(screen.getByRole("option", { name: "aaa" })).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "aab" })).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "abc" })).toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "123" })).toBeInTheDocument()
-      user.type(cbox, "1")
+      ).not.toBeInTheDocument();
+      user.clear(cbox);
+      expect(screen.getByRole("option", { name: "aaa" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "aab" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "abc" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "123" })).toBeInTheDocument();
+      user.type(cbox, "1");
       expect(
         screen.queryByRole("option", { name: "aaa" })
-      ).not.toBeInTheDocument()
+      ).not.toBeInTheDocument();
       expect(
         screen.queryByRole("option", { name: "aab" })
-      ).not.toBeInTheDocument()
+      ).not.toBeInTheDocument();
       expect(
         screen.queryByRole("option", { name: "abc" })
-      ).not.toBeInTheDocument()
-      expect(screen.getByRole("option", { name: "123" })).toBeInTheDocument()
-    })
-  })
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "123" })).toBeInTheDocument();
+    });
+  });
 
   test("selects an option when the user clicks it and closes the menu", async () => {
     render(
@@ -326,23 +326,23 @@ describe("ComboBox", () => {
           123
         </ComboBoxOption>
       </ComboBox>
-    )
-    const user = userEvent.setup()
-    const cbox = screen.getByRole("combobox")
-    const cbutton = screen.getByRole("button")
-    expect(cbox).toBeInTheDocument()
-    expect(cbutton).toBeInTheDocument()
+    );
+    const user = userEvent.setup();
+    const cbox = screen.getByRole("combobox");
+    const cbutton = screen.getByRole("button");
+    expect(cbox).toBeInTheDocument();
+    expect(cbutton).toBeInTheDocument();
     waitFor(() => {
-      user.click(cbutton)
-      expect(screen.getByRole("listbox")).toBeInTheDocument()
-    })
+      user.click(cbutton);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
 
     waitFor(() => {
-      user.click(screen.getByRole("option", { name: "abc" }))
-      expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
-      expect(cbox).toHaveValue("abc")
-    })
-  })
+      user.click(screen.getByRole("option", { name: "abc" }));
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      expect(cbox).toHaveValue("abc");
+    });
+  });
 
   test("works as a controlled component with a value as passed", async () => {
     render(
@@ -360,22 +360,22 @@ describe("ComboBox", () => {
           123
         </ComboBoxOption>
       </ComboBox>
-    )
-    const user = userEvent.setup()
-    const cbox = screen.getByRole("combobox")
-    const toggle = screen.getByRole("button")
-    expect(cbox).toBeInTheDocument()
-    expect(toggle).toBeInTheDocument()
-    expect(cbox).toHaveValue("aab")
+    );
+    const user = userEvent.setup();
+    const cbox = screen.getByRole("combobox");
+    const toggle = screen.getByRole("button");
+    expect(cbox).toBeInTheDocument();
+    expect(toggle).toBeInTheDocument();
+    expect(cbox).toHaveValue("aab");
     waitFor(() => {
-      user.click(toggle)
-      expect(screen.getByRole("listbox")).toBeInTheDocument()
-      const option123 = screen.getAllByRole("option")[3]
-      expect(option123).toHaveTextContent("123")
-      user.click(option123)
-      expect(cbox).toHaveValue("123")
-    })
-  })
+      user.click(toggle);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      const option123 = screen.getAllByRole("option")[3];
+      expect(option123).toHaveTextContent("123");
+      user.click(option123);
+      expect(cbox).toHaveValue("123");
+    });
+  });
 
   test("works as an uncontrolled component with a defaultValue as passed", async () => {
     render(
@@ -385,26 +385,26 @@ describe("ComboBox", () => {
         <ComboBoxOption>abc</ComboBoxOption>
         <ComboBoxOption>123</ComboBoxOption>
       </ComboBox>
-    )
-    const user = userEvent.setup()
-    const cbox = screen.getByRole("combobox")
-    const toggle = screen.getByRole("button")
-    expect(cbox).toBeInTheDocument()
-    expect(toggle).toBeInTheDocument()
-    expect(cbox).toHaveValue("abc")
+    );
+    const user = userEvent.setup();
+    const cbox = screen.getByRole("combobox");
+    const toggle = screen.getByRole("button");
+    expect(cbox).toBeInTheDocument();
+    expect(toggle).toBeInTheDocument();
+    expect(cbox).toHaveValue("abc");
     waitFor(() => {
-      user.click(toggle)
-      expect(screen.getByRole("listbox")).toBeInTheDocument()
-    })
+      user.click(toggle);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
     waitFor(() => {
-      const option123 = screen.getAllByRole("option")[3]
-      expect(option123).toHaveTextContent("123")
-    })
+      const option123 = screen.getAllByRole("option")[3];
+      expect(option123).toHaveTextContent("123");
+    });
     waitFor(() => {
-      user.click(option123)
-      expect(cbox).toHaveValue("123")
-    })
-  })
+      user.click(option123);
+      expect(cbox).toHaveValue("123");
+    });
+  });
 
   // Caution: The below test basically tests headless-ui behaviour, not our logic. This is here only for testing consistency and so that we know should headless ever change their behaviour:
   test("works as a controlled component using value when both value and defaultValue have been passed", async () => {
@@ -413,22 +413,32 @@ describe("ComboBox", () => {
         <ComboBoxOption value="option 1" />
         <ComboBoxOption value="option 2" />
       </ComboBox>
-    )
-    const cbox = screen.getByRole("combobox")
-    expect(cbox).toBeInTheDocument()
-    expect(cbox).toHaveValue("option 2")
-  })
+    );
+    const cbox = screen.getByRole("combobox");
+    expect(cbox).toBeInTheDocument();
+    expect(cbox).toHaveValue("option 2");
+  });
+
+  test("renders a wrapperClassName to the outer wrapping <div> element", async () => {
+    render(<ComboBox wrapperClassName="my-wrapper-class" />);
+    expect(
+      document.querySelector(".juno-combobox-wrapper")
+    ).toBeInTheDocument();
+    expect(document.querySelector(".juno-combobox-wrapper")).toHaveClass(
+      "my-wrapper-class"
+    );
+  });
 
   test("renders a ComboBox with a custom className as passed", async () => {
-    render(<ComboBox className="my-combobox" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveClass("my-combobox")
-  })
+    render(<ComboBox className="my-combobox" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveClass("my-combobox");
+  });
 
   // Skipping because if we pass generic props to the ComboBox component it will be passed to the abstract headless Combobox component, but will not end up in the DOM:
   test.skip("renders all props as passed", async () => {
-    render(<ComboBox data-lolo="1234" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveAttribute("data-lolo", "1234")
-  })
-})
+    render(<ComboBox data-lolo="1234" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveAttribute("data-lolo", "1234");
+  });
+});

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.component.js
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useRef, useId, useMemo, useState } from "react"
-import PropTypes from "prop-types"
-import flatpickr from "flatpickr"
-import { FormHint } from "../FormHint/"
-import { Icon } from "../Icon/"
-import { Label } from "../Label/"
-import "./datetimepicker.scss"
+import React, { useEffect, useRef, useId, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import flatpickr from "flatpickr";
+import { FormHint } from "../FormHint/";
+import { Icon } from "../Icon/";
+import { Label } from "../Label/";
+import "./datetimepicker.scss";
 
 /* 
 TODO:
@@ -20,7 +20,7 @@ TODO:
 
 const inputWrapperStyles = `
   jn-relative
-`
+`;
 
 const inputStyles = `
   jn-bg-theme-textinput
@@ -41,35 +41,35 @@ const inputStyles = `
   disabled:jn-cursor-not-allowed
   autofill:jn-bg-theme-textinput-autofill
   autofill:jn-text-theme-textinput-autofill
-`
+`;
 
 const inputWithLabelStyles = `
   jn-pt-[1.125rem] 
   jn-pb-1
-`
+`;
 
 const inputWithoutLabelStyles = `
   jn-py-4
-`
+`;
 
 const inputDefaultBorderStyles = `
   jn-border-theme-textinput-default
-`
+`;
 
 const inputInvalidStyles = `
   jn-border-theme-error
-`
+`;
 
 const inputValidStyles = `
   jn-border-theme-success
-`
+`;
 
 const labelStyles = `
   peer-autofill:jn-text-theme-textinput-autofill-label
   jn-pointer-events-none
   jn-top-2
   jn-left-[0.9375rem]
-`
+`;
 
 const iconContainerStyles = `
   jn-absolute
@@ -77,7 +77,7 @@ const iconContainerStyles = `
   jn-top-2
   jn-right-[2.75rem]
   jn-gap-1.5
-`
+`;
 
 /** A all-purpose date and time picker component. Highly configurable, based on Flatpickr. */
 
@@ -129,97 +129,98 @@ export const DateTimePicker = ({
   value,
   weekNumbers,
   width,
+  wrapperClassName,
   ...props
 }) => {
   // always generate auto-id string using the useId hook to avoid "more hooks than in previous render" error when removing custom id:
-  const autoId = "juno-datetimepicker-" + useId()
-  const theId = id && id.length ? id : autoId
+  const autoId = "juno-datetimepicker-" + useId();
+  const theId = id && id.length ? id : autoId;
 
-  const fpRef = useRef(null) // the dom node flatpickr instance will be bound to
-  let flatpickrInstanceRef = useRef({}) // The actual flatpickr instance
-  const calendarTargetRef = useRef(null) // The DOM node the flatpickr calendar should be rendered to
+  const fpRef = useRef(null); // the dom node flatpickr instance will be bound to
+  let flatpickrInstanceRef = useRef({}); // The actual flatpickr instance
+  const calendarTargetRef = useRef(null); // The DOM node the flatpickr calendar should be rendered to
 
-  const [theDate, setTheDate] = useState({})
-  const [hasFocus, setHasFocus] = useState(false)
-  const [isOpen, setIsOpen] = useState(false)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
+  const [theDate, setTheDate] = useState({});
+  const [hasFocus, setHasFocus] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [isValid, setIsValid] = useState(false);
 
   const updateFlatpickrInstance = (newKeys) =>
     (flatpickrInstanceRef.current = {
       ...flatpickrInstanceRef.current,
       ...Object.keys(newKeys).reduce((a, key) => {
-        a[key] = newKeys[key]
-        return a
+        a[key] = newKeys[key];
+        return a;
       }, {}),
-    })
+    });
 
   const invalidated = useMemo(
     () => (invalid || (errortext && errortext.length) ? true : false),
     [invalid, errortext]
-  )
+  );
   const validated = useMemo(
     () => (valid || (successtext && successtext.length) ? true : false),
     [valid, successtext]
-  )
+  );
 
   useEffect(() => {
-    setIsInvalid(invalidated)
-  }, [invalidated])
+    setIsInvalid(invalidated);
+  }, [invalidated]);
 
   useEffect(() => {
-    setIsValid(validated)
-  }, [validated])
+    setIsValid(validated);
+  }, [validated]);
 
   const handleBlur = () => {
-    setHasFocus(false)
-    onBlur && onBlur(theDate.selectedDate, theDate.selectedDateStr)
-  }
+    setHasFocus(false);
+    onBlur && onBlur(theDate.selectedDate, theDate.selectedDateStr);
+  };
 
   const handleChange = (selectedDate, dateStr, instance) => {
-    setTheDate({ selectedDate: selectedDate, selectedDateStr: dateStr })
-    onChange && onChange(selectedDate, dateStr)
-  }
+    setTheDate({ selectedDate: selectedDate, selectedDateStr: dateStr });
+    onChange && onChange(selectedDate, dateStr);
+  };
 
   const handleClose = (selectedDate, dateStr, instance) => {
-    setIsOpen(false)
-    onClose && onClose(selectedDate, dateStr)
-  }
+    setIsOpen(false);
+    onClose && onClose(selectedDate, dateStr);
+  };
 
   const handleMonthChange = (selectedDate, dateStr, instance) => {
-    setTheDate({ selectedDate: selectedDate, selectedDateStr: dateStr })
-    onMonthChange && onMonthChange(selectedDate, dateStr)
-  }
+    setTheDate({ selectedDate: selectedDate, selectedDateStr: dateStr });
+    onMonthChange && onMonthChange(selectedDate, dateStr);
+  };
 
   const handleOpen = (selectedDate, dateStr, instance) => {
-    setIsOpen(true)
-    onOpen && onOpen(selectedDate, dateStr)
-  }
+    setIsOpen(true);
+    onOpen && onOpen(selectedDate, dateStr);
+  };
 
   const handleReady = (selectedDate, dateStr, instance) => {
-    onReady && onReady(selectedDate, dateStr)
-  }
+    onReady && onReady(selectedDate, dateStr);
+  };
 
   const handleYearChange = (selectedDate, dateStr, instance) => {
-    setTheDate({ selectedDate: selectedDate, selectedDateStr: dateStr })
-    onYearChange && onYearChange(selectedDate, dateStr)
-  }
+    setTheDate({ selectedDate: selectedDate, selectedDateStr: dateStr });
+    onYearChange && onYearChange(selectedDate, dateStr);
+  };
 
   const handleInputFocus = () => {
-    setHasFocus(true)
-    onFocus && onFocus(theDate.selectedDate, theDate.selectedDateStr)
-  }
+    setHasFocus(true);
+    onFocus && onFocus(theDate.selectedDate, theDate.selectedDateStr);
+  };
 
   const handleClearIconClick = () => {
-    setTheDate({})
-    flatpickrInstanceRef.current?.clear()
-    onClear && onClear([], "")
-  }
+    setTheDate({});
+    flatpickrInstanceRef.current?.clear();
+    onClear && onClear([], "");
+  };
 
   // Create stringified versions of the value prop and its aliases in order to use them in a useEffect dependency array later.
-  const stringifiedValue = JSON.stringify(value)
-  const stringifiedDefaultDate = JSON.stringify(defaultDate)
-  const stringifiedDefaultValue = JSON.stringify(defaultValue)
+  const stringifiedValue = JSON.stringify(value);
+  const stringifiedDefaultDate = JSON.stringify(defaultDate);
+  const stringifiedDefaultValue = JSON.stringify(defaultValue);
 
   // Function to determine the date format. Will return the dateFormat if passed as a prop, or a useful defaultFormat depending on whether the DateTimePicker is set to show the time, seconds, or no calendar at all (time picker only).
   const getDateFormat = () => {
@@ -231,15 +232,15 @@ export const DateTimePicker = ({
         : enableSeconds
         ? "Y-m-d H:i:S"
         : "Y-m-d H:i"
-      : "Y-m-d"
+      : "Y-m-d";
 
     const theDateFormat =
-      dateFormat === undefined ? defaultDateFormat : dateFormat
+      dateFormat === undefined ? defaultDateFormat : dateFormat;
 
-    return theDateFormat
-  }
+    return theDateFormat;
+  };
 
-  const theDateFormat = getDateFormat()
+  const theDateFormat = getDateFormat();
 
   const createFlatpickrInstance = () => {
     const options = {
@@ -274,24 +275,24 @@ export const DateTimePicker = ({
       showMonths: showMonths,
       time_24hr: time_24hr,
       weekNumbers: weekNumbers,
-    }
+    };
     const FP =
-      calendarTargetRef && fpRef.current && flatpickr(fpRef.current, options)
-    updateFlatpickrInstance(FP)
-  }
+      calendarTargetRef && fpRef.current && flatpickr(fpRef.current, options);
+    updateFlatpickrInstance(FP);
+  };
 
   const destroyFlatpickrInstance = () => {
-    flatpickrInstanceRef.current.destroy()
-    setTheDate({})
-    flatpickrInstanceRef = null // Not sure if this is actually necessary?
-  }
+    flatpickrInstanceRef.current.destroy();
+    setTheDate({});
+    flatpickrInstanceRef = null; // Not sure if this is actually necessary?
+  };
 
   useEffect(() => {
-    createFlatpickrInstance()
+    createFlatpickrInstance();
     return () => {
-      destroyFlatpickrInstance()
-    }
-  }, [])
+      destroyFlatpickrInstance();
+    };
+  }, []);
 
   /* 
   Some config options on the flatpickr instance can not be set with immediate effect, a new instance needs to be created.
@@ -310,16 +311,16 @@ export const DateTimePicker = ({
     mode: mode,
     noCalendar: noCalendar,
     weekNumbers: weekNumbers,
-  })
+  });
 
   // Apply a use effect to handle the logic bound to the props that require creating a new faltpickr instance:
   useEffect(() => {
     // set a variable to be set to true once we know we need to destroy the current instance and create  a new one:
-    let hasChanged = false
+    let hasChanged = false;
 
     // For each of the props…
     Object.keys(prevRerenderingProps.current).forEach((propKey) => {
-      const prevValue = prevRerenderingProps.current[propKey]
+      const prevValue = prevRerenderingProps.current[propKey];
       const currentValue = {
         allowInput,
         defaultHour,
@@ -333,18 +334,18 @@ export const DateTimePicker = ({
         noCalendar,
         showMonths,
         weekNumbers,
-      }[propKey]
+      }[propKey];
 
       // … we need to check whether their value has actually changed
       if (prevValue !== currentValue) {
-        hasChanged = true
+        hasChanged = true;
       }
-    })
+    });
 
     // After we have checked if any one or multiple of the relevant props have changed, we actually destroy the curent instance and create a new one:
     if (hasChanged) {
-      flatpickrInstanceRef?.current?.destroy()
-      createFlatpickrInstance()
+      flatpickrInstanceRef?.current?.destroy();
+      createFlatpickrInstance();
     }
 
     // Also make sure we update our stored props in order to be ready for the next update:
@@ -361,7 +362,7 @@ export const DateTimePicker = ({
       noCalendar: noCalendar,
       showMonths: showMonths,
       weekNumbers: weekNumbers,
-    }
+    };
   }, [
     allowInput,
     defaultHour,
@@ -375,71 +376,71 @@ export const DateTimePicker = ({
     noCalendar,
     showMonths,
     weekNumbers,
-  ])
+  ]);
 
   // useEffects for props that represent config options that can be set on an existing flatpickr instance with immediate effect:
   useEffect(() => {
     flatpickrInstanceRef.current?.set(
       "allowInvalidPreload",
       allowInvalidPreload
-    )
-  }, [allowInvalidPreload])
+    );
+  }, [allowInvalidPreload]);
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("ariaDateFormat", ariaDateFormat)
-  }, [ariaDateFormat])
+    flatpickrInstanceRef.current?.set("ariaDateFormat", ariaDateFormat);
+  }, [ariaDateFormat]);
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("conjunction", conjunction)
-  }, [conjunction])
+    flatpickrInstanceRef.current?.set("conjunction", conjunction);
+  }, [conjunction]);
 
   useEffect(() => {
-    const newDateFormat = getDateFormat()
-    flatpickrInstanceRef.current?.set("dateFormat", newDateFormat)
-  }, [dateFormat])
+    const newDateFormat = getDateFormat();
+    flatpickrInstanceRef.current?.set("dateFormat", newDateFormat);
+  }, [dateFormat]);
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("disable", disable)
-  }, [disable])
+    flatpickrInstanceRef.current?.set("disable", disable);
+  }, [disable]);
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("hourIncrement", hourIncrement)
-  }, [hourIncrement])
+    flatpickrInstanceRef.current?.set("hourIncrement", hourIncrement);
+  }, [hourIncrement]);
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("locale", locale)
-  }, [locale])
+    flatpickrInstanceRef.current?.set("locale", locale);
+  }, [locale]);
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("maxDate", maxDate)
-  }, [maxDate])
+    flatpickrInstanceRef.current?.set("maxDate", maxDate);
+  }, [maxDate]);
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("minDate", minDate)
-  }, [minDate])
+    flatpickrInstanceRef.current?.set("minDate", minDate);
+  }, [minDate]);
 
   useEffect(() => {
     flatpickrInstanceRef.current?.set(
       "shorthandCurrentMonth",
       shorthandCurrentMonth
-    )
-  }, [shorthandCurrentMonth])
+    );
+  }, [shorthandCurrentMonth]);
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("time_24hr", time_24hr)
-  }, [time_24hr])
+    flatpickrInstanceRef.current?.set("time_24hr", time_24hr);
+  }, [time_24hr]);
 
   // Update the flatpickr instance whenever the value prop (or any of its aliases) changes, and force the flatpickr instance to fire onChange event. These props may contain an array of one or multiple objects. These will never pass React's identity comparison, and will be regarded as a new object with any render regardless of their contents, thus creating an endless loop by updating the flatpickr instance updating the parent state (via onChange above) updating the flatpickr instance (…). We prevent this by checking on the stringified versions of the props in the dependency array.
   useEffect(() => {
     flatpickrInstanceRef.current?.setDate(
       value || defaultDate || defaultValue,
       true // enforce firing change event that in turn will update our state via handleChange.
-    )
-  }, [stringifiedValue, stringifiedDefaultDate, stringifiedDefaultValue])
+    );
+  }, [stringifiedValue, stringifiedDefaultDate, stringifiedDefaultValue]);
 
   useEffect(() => {
-    flatpickrInstanceRef.current?.set("weekNumbers", weekNumbers)
-  }, [weekNumbers])
+    flatpickrInstanceRef.current?.set("weekNumbers", weekNumbers);
+  }, [weekNumbers]);
 
   return (
     <div
@@ -447,6 +448,7 @@ export const DateTimePicker = ({
       juno-datetimepicker-wrapper
       ${width == "auto" ? "jn-inline-block" : "jn-block"}
       ${width == "auto" ? "jn-w-auto" : "jn-w-full"}
+      ${wrapperClassName}
     `}
     >
       <div
@@ -553,15 +555,15 @@ export const DateTimePicker = ({
         ""
       )}
     </div>
-  )
-}
+  );
+};
 
 const datePropType = PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.array,
   PropTypes.object,
   PropTypes.number,
-])
+]);
 
 DateTimePicker.propTypes = {
   /** Whether the DateTimePicker input element allows direct user keyboard input. Default is `false`. */
@@ -658,7 +660,9 @@ DateTimePicker.propTypes = {
   weekNumbers: PropTypes.bool,
   /** The width of the datepicker input. Either 'full' (default) or 'auto'. */
   width: PropTypes.oneOf(["full", "auto"]),
-}
+  /** Pass a className to the outer wrapping element */
+  wrapperClassName: PropTypes.string,
+};
 
 DateTimePicker.defaultProps = {
   allowInput: false,
@@ -708,4 +712,5 @@ DateTimePicker.defaultProps = {
   value: "",
   weekNumbers: false,
   width: "full",
-}
+  wrapperClassName: "",
+};

--- a/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.test.js
+++ b/libs/juno-ui-components/src/components/DateTimePicker/DateTimePicker.test.js
@@ -3,407 +3,418 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as React from "react"
-import { cleanup, render, screen, fireEvent } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import { DateTimePicker } from "./index"
+import * as React from "react";
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DateTimePicker } from "./index";
 
-const mockOnOpen = jest.fn()
-const mockOnClear = jest.fn()
-const mockOnClose = jest.fn()
-const mockOnChange = jest.fn()
-const mockOnMonthChange = jest.fn()
-const mockOnYearChange = jest.fn()
-const mockOnValueUpdate = jest.fn()
+const mockOnOpen = jest.fn();
+const mockOnClear = jest.fn();
+const mockOnClose = jest.fn();
+const mockOnChange = jest.fn();
+const mockOnMonthChange = jest.fn();
+const mockOnYearChange = jest.fn();
+const mockOnValueUpdate = jest.fn();
 
 describe("DateTimePicker", () => {
   afterEach(() => {
-    cleanup()
-    jest.clearAllMocks()
-  })
+    cleanup();
+    jest.clearAllMocks();
+  });
 
   test("renders a DateTimePicker", async () => {
-    render(<DateTimePicker />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("type", "text")
-    expect(screen.getByRole("textbox")).toHaveClass("juno-datetimepicker-input")
-  })
+    render(<DateTimePicker />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("type", "text");
+    expect(screen.getByRole("textbox")).toHaveClass(
+      "juno-datetimepicker-input"
+    );
+  });
 
   test("renders a label as passed", async () => {
     render(
       <DateTimePicker label="The DateTimePicker Label" id="my-textinput" />
-    )
-    expect(document.querySelector(".juno-label")).toBeInTheDocument()
+    );
+    expect(document.querySelector(".juno-label")).toBeInTheDocument();
     expect(document.querySelector(".juno-label")).toHaveTextContent(
       "The DateTimePicker Label"
-    )
-  })
+    );
+  });
 
   test("renders an id as passed", async () => {
-    render(<DateTimePicker id="my-datetimepicker" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    render(<DateTimePicker id="my-datetimepicker" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "id",
       "my-datetimepicker"
-    )
-  })
+    );
+  });
 
   test("renders a name as passed", async () => {
-    render(<DateTimePicker name="my-name" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("name", "my-name")
-  })
+    render(<DateTimePicker name="my-name" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("name", "my-name");
+  });
 
   test("renders a DateTimePicker with an auto-generated id if no id is passed", async () => {
-    render(<DateTimePicker />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("id")
+    render(<DateTimePicker />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("id");
     expect(screen.getByRole("textbox").getAttribute("id")).toMatch(
       "juno-datetimepicker"
-    )
-  })
+    );
+  });
 
   test("renders a DateTimePicker with a label associated by an id as passed", async () => {
-    render(<DateTimePicker label="The DateTimePicker Label" id="dp-1" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("id")
-    expect(screen.getByRole("textbox").getAttribute("id")).toMatch("dp-1")
+    render(<DateTimePicker label="The DateTimePicker Label" id="dp-1" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("id");
+    expect(screen.getByRole("textbox").getAttribute("id")).toMatch("dp-1");
     expect(
       screen.getByLabelText("The DateTimePicker Label")
-    ).toBeInTheDocument()
-  })
+    ).toBeInTheDocument();
+  });
 
   test("renders a DateTimePicker with a label associated by an auto-generated id if no id was passed ", async () => {
-    render(<DateTimePicker label="This is a DateTimePicker" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    render(<DateTimePicker label="This is a DateTimePicker" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
     expect(
       screen.getByLabelText("This is a DateTimePicker")
-    ).toBeInTheDocument()
-  })
+    ).toBeInTheDocument();
+  });
 
   test("renders a DateTimePicker with a placholder as passed", async () => {
-    render(<DateTimePicker placeholder="This is a placeholder" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    render(<DateTimePicker placeholder="This is a placeholder" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "placeholder",
       "This is a placeholder"
-    )
-  })
+    );
+  });
 
   test("renders a disabled DateTimePicker as passed", async () => {
-    render(<DateTimePicker disabled />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toBeDisabled()
-  })
+    render(<DateTimePicker disabled />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
 
   test("renders a Clear button if passed and when a date is set", async () => {
-    render(<DateTimePicker value="2027-01-12" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByTitle("Clear")).toBeInTheDocument()
-  })
+    render(<DateTimePicker value="2027-01-12" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByTitle("Clear")).toBeInTheDocument();
+  });
 
   test("does not render a Clear button when no date is set", async () => {
-    render(<DateTimePicker />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.queryByTitle("Clear")).not.toBeInTheDocument()
-  })
+    render(<DateTimePicker />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.queryByTitle("Clear")).not.toBeInTheDocument();
+  });
 
   test("renders a DateTimePicker marked as required", async () => {
     // DateTimePicker needs a label passed since the Label subcomponent is responsible for rendering the Required marker:
-    render(<DateTimePicker label="Required DateTimePicker" required />)
-    expect(document.querySelector(".juno-required")).toBeInTheDocument()
-  })
+    render(<DateTimePicker label="Required DateTimePicker" required />);
+    expect(document.querySelector(".juno-required")).toBeInTheDocument();
+  });
 
   test("renders a helptext as passed", async () => {
-    render(<DateTimePicker helptext="this is a helptext" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
+    render(<DateTimePicker helptext="this is a helptext" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
     expect(document.querySelector(".juno-form-hint")).toHaveClass(
       "juno-form-hint-help"
-    )
+    );
     expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
       "this is a helptext"
-    )
-  })
+    );
+  });
 
   test("renders a valid DateTimePicker as passed", async () => {
-    render(<DateTimePicker valid />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    render(<DateTimePicker valid />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toHaveClass(
       "juno-datetimepicker-input-valid"
-    )
-    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
 
   test("renders an invalid DateTimePicker as passed", async () => {
-    render(<DateTimePicker invalid />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    render(<DateTimePicker invalid />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toHaveClass(
       "juno-datetimepicker-input-invalid"
-    )
-    expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
 
   test("renders a successtext as passed and validates the element", async () => {
-    render(<DateTimePicker successtext="great success!" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
+    render(<DateTimePicker successtext="great success!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
     expect(document.querySelector(".juno-form-hint")).toHaveClass(
       "juno-form-hint-success"
-    )
+    );
     expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
       "great success!"
-    )
+    );
     expect(screen.getByRole("textbox")).toHaveClass(
       "juno-datetimepicker-input-valid"
-    )
-    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
 
   test("renders an errortext as passed and invalidates the element", async () => {
-    render(<DateTimePicker errortext="this is an error!" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
+    render(<DateTimePicker errortext="this is an error!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
     expect(document.querySelector(".juno-form-hint")).toHaveClass(
       "juno-form-hint-error"
-    )
+    );
     expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
       "this is an error!"
-    )
+    );
     expect(screen.getByRole("textbox")).toHaveClass(
       "juno-datetimepicker-input-invalid"
-    )
-    expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
 
   test("renders a DateTimePicker with a time picker as passed", async () => {
-    render(<DateTimePicker enableTime={true} dateFormat="Y-m-d H:i:S" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(document.querySelector(".flatpickr-time")).toBeInTheDocument()
-    expect(screen.getByLabelText("Hour")).toBeInTheDocument()
-    expect(screen.getByLabelText("Minute")).toBeInTheDocument()
-  })
+    render(<DateTimePicker enableTime={true} dateFormat="Y-m-d H:i:S" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(document.querySelector(".flatpickr-time")).toBeInTheDocument();
+    expect(screen.getByLabelText("Hour")).toBeInTheDocument();
+    expect(screen.getByLabelText("Minute")).toBeInTheDocument();
+  });
 
   test("renders a DateTimePicker with a time picker with seconds as passed", async () => {
-    render(<DateTimePicker enableTime={true} enableSeconds={true} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(document.querySelector(".flatpickr-time")).toBeInTheDocument()
-    expect(screen.getByLabelText("Hour")).toBeInTheDocument()
-    expect(screen.getByLabelText("Minute")).toBeInTheDocument()
+    render(<DateTimePicker enableTime={true} enableSeconds={true} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(document.querySelector(".flatpickr-time")).toBeInTheDocument();
+    expect(screen.getByLabelText("Hour")).toBeInTheDocument();
+    expect(screen.getByLabelText("Minute")).toBeInTheDocument();
     // We need to check for the flatpickr className as flatpickr does not assign an aria-label to the seconds input:
-    expect(document.querySelector(".flatpickr-second")).toBeInTheDocument()
-  })
+    expect(document.querySelector(".flatpickr-second")).toBeInTheDocument();
+  });
 
   test("displays the date as passed as a date object", async () => {
-    render(<DateTimePicker value={new Date(2099, 0, 1)} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2099-01-01")
-  })
+    render(<DateTimePicker value={new Date(2099, 0, 1)} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2099-01-01");
+  });
 
   test("displays the date as passed as a date string", async () => {
-    render(<DateTimePicker value="2024-01-26" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2024-01-26")
-  })
+    render(<DateTimePicker value="2024-01-26" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2024-01-26");
+  });
 
   test("diplays the date as passed as an ISO date string", async () => {
-    render(<DateTimePicker value="2034-02-26T19:40:03.243Z" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2034-02-26")
-  })
+    render(<DateTimePicker value="2034-02-26T19:40:03.243Z" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2034-02-26");
+  });
 
   test("displays the date as passed as a timestamp", async () => {
-    render(<DateTimePicker value={1706273787000} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2024-01-26")
-  })
+    render(<DateTimePicker value={1706273787000} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2024-01-26");
+  });
 
   test("displays the date as passed by shortcut 'today'", async () => {
-    render(<DateTimePicker value="today" />)
-    const today = new Date()
-    const year = today.getFullYear()
-    const month = (today.getMonth() + 1).toString().padStart(2, "0")
-    const day = today.getDate().toString().padStart(2, "0")
-    const todayAsString = `${year}-${month}-${day}`
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue(todayAsString)
-  })
+    render(<DateTimePicker value="today" />);
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = (today.getMonth() + 1).toString().padStart(2, "0");
+    const day = today.getDate().toString().padStart(2, "0");
+    const todayAsString = `${year}-${month}-${day}`;
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue(todayAsString);
+  });
 
   test("displays the date in a custom format as passed", async () => {
-    render(<DateTimePicker dateFormat="F d Y" value={1706273787000} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("January 26 2024")
-  })
+    render(<DateTimePicker dateFormat="F d Y" value={1706273787000} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("January 26 2024");
+  });
 
   test("uses the default dateFormat (Y-m-d) in default (non-time picker) mode)", async () => {
-    const today = new Date()
-    const fullYear = today.getFullYear()
-    const month = (today.getMonth() + 1).toString().padStart(2, "0")
-    const day = today.getDate().toString().padStart(2, "0")
-    const todayAsString = `${fullYear}-${month}-${day}`
-    render(<DateTimePicker value={today} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue(todayAsString)
-  })
+    const today = new Date();
+    const fullYear = today.getFullYear();
+    const month = (today.getMonth() + 1).toString().padStart(2, "0");
+    const day = today.getDate().toString().padStart(2, "0");
+    const todayAsString = `${fullYear}-${month}-${day}`;
+    render(<DateTimePicker value={today} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue(todayAsString);
+  });
 
   test("uses the correct default dateFormat (Y-m-d H:i) in date-time-picker mode without seconds", async () => {
-    const now = new Date()
-    const fullYear = now.getFullYear()
-    const month = (now.getMonth() + 1).toString().padStart(2, "0")
-    const day = now.getDate().toString().padStart(2, "0")
-    const hours = now.getHours().toString().padStart(2, "0")
-    const minutes = now.getMinutes().toString().padStart(2, "0")
-    const nowAsString = `${fullYear}-${month}-${day} ${hours}:${minutes}`
-    render(<DateTimePicker enableTime value={now} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue(nowAsString)
-  })
+    const now = new Date();
+    const fullYear = now.getFullYear();
+    const month = (now.getMonth() + 1).toString().padStart(2, "0");
+    const day = now.getDate().toString().padStart(2, "0");
+    const hours = now.getHours().toString().padStart(2, "0");
+    const minutes = now.getMinutes().toString().padStart(2, "0");
+    const nowAsString = `${fullYear}-${month}-${day} ${hours}:${minutes}`;
+    render(<DateTimePicker enableTime value={now} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue(nowAsString);
+  });
 
   test("uses the correct default dateFormat (Y-m-d H:i:S) in date-time-picker mode with seconds enabled", async () => {
-    const now = new Date()
-    const fullYear = now.getFullYear()
-    const month = (now.getMonth() + 1).toString().padStart(2, "0")
-    const day = now.getDate().toString().padStart(2, "0")
-    const hours = now.getHours().toString().padStart(2, "0")
-    const minutes = now.getMinutes().toString().padStart(2, "0")
-    const seconds = now.getSeconds().toString().padStart(2, "0")
-    const nowAsStringWithSeconds = `${fullYear}-${month}-${day} ${hours}:${minutes}:${seconds}`
-    render(<DateTimePicker enableTime enableSeconds value={now} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue(nowAsStringWithSeconds)
-  })
+    const now = new Date();
+    const fullYear = now.getFullYear();
+    const month = (now.getMonth() + 1).toString().padStart(2, "0");
+    const day = now.getDate().toString().padStart(2, "0");
+    const hours = now.getHours().toString().padStart(2, "0");
+    const minutes = now.getMinutes().toString().padStart(2, "0");
+    const seconds = now.getSeconds().toString().padStart(2, "0");
+    const nowAsStringWithSeconds = `${fullYear}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+    render(<DateTimePicker enableTime enableSeconds value={now} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue(nowAsStringWithSeconds);
+  });
 
   test("uses the correct default dateFormat (H:i) in time-picker-only mode without seconds", async () => {
-    const now = new Date()
-    const hours = now.getHours().toString().padStart(2, "0")
-    const minutes = now.getMinutes().toString().padStart(2, "0")
-    const nowAsStringWithOnlyHoursAndMinutes = `${hours}:${minutes}`
-    render(<DateTimePicker enableTime noCalendar value={now} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    const now = new Date();
+    const hours = now.getHours().toString().padStart(2, "0");
+    const minutes = now.getMinutes().toString().padStart(2, "0");
+    const nowAsStringWithOnlyHoursAndMinutes = `${hours}:${minutes}`;
+    render(<DateTimePicker enableTime noCalendar value={now} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toHaveValue(
       nowAsStringWithOnlyHoursAndMinutes
-    )
-  })
+    );
+  });
 
   test("uses the correct defaultDateFormat (H:i:S) in time-picker-only mode with seconds enabled", async () => {
-    const now = new Date()
-    const hours = now.getHours().toString().padStart(2, "0")
-    const minutes = now.getMinutes().toString().padStart(2, "0")
-    const seconds = now.getSeconds().toString().padStart(2, "0")
-    const nowAsStringWithOnlyHoursMinutesAndSeconds = `${hours}:${minutes}:${seconds}`
-    render(<DateTimePicker enableTime enableSeconds noCalendar value={now} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
+    const now = new Date();
+    const hours = now.getHours().toString().padStart(2, "0");
+    const minutes = now.getMinutes().toString().padStart(2, "0");
+    const seconds = now.getSeconds().toString().padStart(2, "0");
+    const nowAsStringWithOnlyHoursMinutesAndSeconds = `${hours}:${minutes}:${seconds}`;
+    render(<DateTimePicker enableTime enableSeconds noCalendar value={now} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toHaveValue(
       nowAsStringWithOnlyHoursMinutesAndSeconds
-    )
-  })
+    );
+  });
 
   test("displays the date as passed as defaultDate instead of value or defaultDate", async () => {
-    render(<DateTimePicker defaultDate={new Date(2099, 0, 1)} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2099-01-01")
-  })
+    render(<DateTimePicker defaultDate={new Date(2099, 0, 1)} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2099-01-01");
+  });
 
   test("displays the date as passed as defaultValue instead of value or defaultDate", async () => {
-    render(<DateTimePicker defaultValue={new Date(2099, 0, 1)} />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2099-01-01")
-  })
+    render(<DateTimePicker defaultValue={new Date(2099, 0, 1)} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2099-01-01");
+  });
 
   test("updates the date accordingly when value changes", async () => {
     const { rerender } = render(
       <DateTimePicker value={new Date(2024, 0, 12)} />
-    )
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2024-01-12")
-    rerender(<DateTimePicker value={new Date(2025, 7, 18)} />)
-    expect(screen.getByRole("textbox")).toHaveValue("2025-08-18")
-  })
+    );
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2024-01-12");
+    rerender(<DateTimePicker value={new Date(2025, 7, 18)} />);
+    expect(screen.getByRole("textbox")).toHaveValue("2025-08-18");
+  });
 
   test("updates the date accordingly when defaultValue changes", async () => {
     const { rerender } = render(
       <DateTimePicker defaultValue={new Date(2024, 0, 12)} />
-    )
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2024-01-12")
-    rerender(<DateTimePicker defaultValue={new Date(2025, 7, 18)} />)
-    expect(screen.getByRole("textbox")).toHaveValue("2025-08-18")
-  })
+    );
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2024-01-12");
+    rerender(<DateTimePicker defaultValue={new Date(2025, 7, 18)} />);
+    expect(screen.getByRole("textbox")).toHaveValue("2025-08-18");
+  });
 
   test("updates the date accordingly when defaultDate changes", async () => {
     const { rerender } = render(
       <DateTimePicker defaultDate={new Date(2024, 0, 12)} />
-    )
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2024-01-12")
-    rerender(<DateTimePicker defaultDate={new Date(2025, 7, 18)} />)
-    expect(screen.getByRole("textbox")).toHaveValue("2025-08-18")
-  })
+    );
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2024-01-12");
+    rerender(<DateTimePicker defaultDate={new Date(2025, 7, 18)} />);
+    expect(screen.getByRole("textbox")).toHaveValue("2025-08-18");
+  });
 
   test("allows typing in the field when configured to do so", async () => {
-    render(<DateTimePicker allowInput />)
-    const input = screen.getByRole("textbox")
-    const user = userEvent.setup()
-    expect(input).toBeInTheDocument()
-    expect(input).toHaveValue("")
-    await userEvent.click(input)
-    await user.type(input, "12")
-    expect(input).toHaveValue("12")
-  })
+    render(<DateTimePicker allowInput />);
+    const input = screen.getByRole("textbox");
+    const user = userEvent.setup();
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("");
+    await userEvent.click(input);
+    await user.type(input, "12");
+    expect(input).toHaveValue("12");
+  });
 
   test("updates accordingly when the allowInput prop changes", async () => {
-    const { rerender } = render(<DateTimePicker />)
-    const input = screen.getByRole("textbox")
-    const user = userEvent.setup()
-    expect(input).toBeInTheDocument()
-    expect(input).toHaveValue("")
-    expect(input).toHaveAttribute("readonly", "readonly")
-    rerender(<DateTimePicker allowInput />)
-    expect(input).toBeInTheDocument()
-    expect(input).toHaveValue("")
-    expect(input).not.toHaveAttribute("readonly")
-    await userEvent.click(input)
-    await user.type(input, "123")
-    expect(input).toHaveValue("123")
-  })
+    const { rerender } = render(<DateTimePicker />);
+    const input = screen.getByRole("textbox");
+    const user = userEvent.setup();
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("readonly", "readonly");
+    rerender(<DateTimePicker allowInput />);
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("");
+    expect(input).not.toHaveAttribute("readonly");
+    await userEvent.click(input);
+    await user.type(input, "123");
+    expect(input).toHaveValue("123");
+  });
 
   test("renders a DateTimePicker with week numbers as passed", async () => {
-    render(<DateTimePicker weekNumbers />)
-    const input = screen.getByRole("textbox")
-    const user = userEvent.setup()
-    expect(input).toBeInTheDocument()
+    render(<DateTimePicker weekNumbers />);
+    const input = screen.getByRole("textbox");
+    const user = userEvent.setup();
+    expect(input).toBeInTheDocument();
     // click to open the calendar:
-    await user.click(input)
-    expect(document.querySelector(".flatpickr-weekwrapper")).toBeInTheDocument()
-    expect(document.querySelector(".flatpickr-weekday")).toBeInTheDocument()
-    expect(document.querySelector(".flatpickr-weekday")).toHaveTextContent("Wk")
-    expect(document.querySelector(".flatpickr-weeks")).toBeInTheDocument()
-    expect(document.querySelector(".flatpickr-weeks").childElementCount).toBe(6)
-  })
+    await user.click(input);
+    expect(
+      document.querySelector(".flatpickr-weekwrapper")
+    ).toBeInTheDocument();
+    expect(document.querySelector(".flatpickr-weekday")).toBeInTheDocument();
+    expect(document.querySelector(".flatpickr-weekday")).toHaveTextContent(
+      "Wk"
+    );
+    expect(document.querySelector(".flatpickr-weeks")).toBeInTheDocument();
+    expect(document.querySelector(".flatpickr-weeks").childElementCount).toBe(
+      6
+    );
+  });
 
   test("renders a DateTimePicker in single mode per default", async () => {
-    render(<DateTimePicker />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("data-mode", "single")
-  })
+    render(<DateTimePicker />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("data-mode", "single");
+  });
 
   test("renders a DateTimePicker in multiple mode as passed", async () => {
-    render(<DateTimePicker mode="multiple" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("data-mode", "multiple")
-  })
+    render(<DateTimePicker mode="multiple" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "data-mode",
+      "multiple"
+    );
+  });
 
   test("renders a DateTimePicker in range mode as passed", async () => {
-    render(<DateTimePicker mode="range" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("data-mode", "range")
-  })
+    render(<DateTimePicker mode="range" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("data-mode", "range");
+  });
 
   test("Updates the mode accordingly when the mode prop changes", async () => {
-    const { rerender } = render(<DateTimePicker />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("data-mode", "single")
-    rerender(<DateTimePicker mode="range" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("data-mode", "range")
-  })
+    const { rerender } = render(<DateTimePicker />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("data-mode", "single");
+    rerender(<DateTimePicker mode="range" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("data-mode", "range");
+  });
 
   test("allows setting an otherwise invalid value on first load as configured ", async () => {
     render(
@@ -412,35 +423,35 @@ describe("DateTimePicker", () => {
         disable={["2024-01-30"]}
         allowInvalidPreload
       />
-    )
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("2024-01-30")
-  })
+    );
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("2024-01-30");
+  });
 
   test("clicking the clear button clears the input", async () => {
-    render(<DateTimePicker value="2024-01-31" />)
-    const input = screen.getByRole("textbox")
-    const clearButton = screen.getByTitle("Clear")
-    const user = userEvent.setup()
-    expect(input).toBeInTheDocument()
-    expect(input).toHaveValue("2024-01-31")
-    expect(clearButton).toBeInTheDocument()
-    await user.click(clearButton)
-    expect(input).toHaveValue("")
-  })
+    render(<DateTimePicker value="2024-01-31" />);
+    const input = screen.getByRole("textbox");
+    const clearButton = screen.getByTitle("Clear");
+    const user = userEvent.setup();
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("2024-01-31");
+    expect(clearButton).toBeInTheDocument();
+    await user.click(clearButton);
+    expect(input).toHaveValue("");
+  });
 
   test("sets a custom aria-label format for calendar dates as passed", async () => {
-    render(<DateTimePicker ariaDateFormat="l, F j, Y" />)
-    const input = screen.getByRole("textbox")
-    const user = userEvent.setup()
-    expect(input).toBeInTheDocument()
+    render(<DateTimePicker ariaDateFormat="l, F j, Y" />);
+    const input = screen.getByRole("textbox");
+    const user = userEvent.setup();
+    expect(input).toBeInTheDocument();
     // click to open the calendar:
-    await user.click(input)
+    await user.click(input);
     //Match something like "Monday, January 31, 2024" to pattern like [word, comma, space, word, space, one or two-digit number, comma, space, four-digit number] assuming this is precise enough:
     expect(
       document.querySelectorAll(".flatpickr-day")[0].getAttribute("aria-label")
-    ).toMatch(new RegExp(/^\b\w+\b, \b\w+\b \d{1,2}, \d{4}$/))
-  })
+    ).toMatch(new RegExp(/^\b\w+\b, \b\w+\b \d{1,2}, \d{4}$/));
+  });
 
   test("uses a custom conjunction between dates in multiple mode as passed", async () => {
     render(
@@ -449,28 +460,28 @@ describe("DateTimePicker", () => {
         conjunction=" || "
         value={["2024-02-01", "2099-03-12"]}
       />
-    )
-    const input = screen.getByRole("textbox")
-    expect(input).toBeInTheDocument()
-    expect(input).toHaveValue("2024-02-01 || 2099-03-12")
-  })
+    );
+    const input = screen.getByRole("textbox");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("2024-02-01 || 2099-03-12");
+  });
 
   test("updates the displayed value accordingly when the conjunction prop changes", async () => {
     const { rerender } = render(
       <DateTimePicker mode="multiple" value={["2024-02-01", "2099-03-12"]} />
-    )
-    const input = screen.getByRole("textbox")
-    expect(input).toBeInTheDocument()
-    expect(input).toHaveValue("2024-02-01, 2099-03-12")
+    );
+    const input = screen.getByRole("textbox");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("2024-02-01, 2099-03-12");
     rerender(
       <DateTimePicker
         mode="multiple"
         value={["2024-02-01", "2099-03-12"]}
         conjunction=" --- "
       />
-    )
-    expect(input).toHaveValue("2024-02-01 --- 2099-03-12")
-  })
+    );
+    expect(input).toHaveValue("2024-02-01 --- 2099-03-12");
+  });
 
   test("sets a default hour as passed", async () => {
     render(
@@ -479,206 +490,218 @@ describe("DateTimePicker", () => {
         dateFormat="Y-m-d H:i"
         defaultHour={5}
       />
-    )
-    const input = screen.getByRole("textbox")
-    const user = userEvent.setup()
-    expect(input).toBeInTheDocument()
-    await user.click(input)
-    const hourInput = document.querySelector("input.flatpickr-hour")
-    expect(hourInput).toHaveValue(5)
-  })
+    );
+    const input = screen.getByRole("textbox");
+    const user = userEvent.setup();
+    expect(input).toBeInTheDocument();
+    await user.click(input);
+    const hourInput = document.querySelector("input.flatpickr-hour");
+    expect(hourInput).toHaveValue(5);
+  });
 
   test("sets a default minute as passed", async () => {
     render(
       <DateTimePicker enableTime dateFormat="Y-m-d H:i" defaultMinute={13} />
-    )
-    const input = screen.getByRole("textbox")
-    const user = userEvent.setup()
-    expect(input).toBeInTheDocument()
-    await user.click(input)
-    const minuteInput = document.querySelector("input.flatpickr-minute")
-    expect(minuteInput).toHaveValue(13)
-  })
+    );
+    const input = screen.getByRole("textbox");
+    const user = userEvent.setup();
+    expect(input).toBeInTheDocument();
+    await user.click(input);
+    const minuteInput = document.querySelector("input.flatpickr-minute");
+    expect(minuteInput).toHaveValue(13);
+  });
 
   test("opens a calendar when clicking in the datepicker field", async () => {
-    render(<DateTimePicker />)
-    const input = screen.getByRole("textbox")
-    const calendar = document.querySelector(".flatpickr-calendar")
-    const user = userEvent.setup()
-    expect(input).toBeInTheDocument()
-    expect(calendar).toBeInTheDocument()
-    expect(calendar).not.toHaveClass("open")
-    await user.click(input)
-    expect(calendar).toHaveClass("open")
-  })
+    render(<DateTimePicker />);
+    const input = screen.getByRole("textbox");
+    const calendar = document.querySelector(".flatpickr-calendar");
+    const user = userEvent.setup();
+    expect(input).toBeInTheDocument();
+    expect(calendar).toBeInTheDocument();
+    expect(calendar).not.toHaveClass("open");
+    await user.click(input);
+    expect(calendar).toHaveClass("open");
+  });
 
   test("uses a custom hour increment as passed", async () => {
     render(
       <DateTimePicker enableTime dateFormat="Y-m-d H:i" hourIncrement={6} />
-    )
-    const hourInput = document.querySelector("input.flatpickr-hour")
-    expect(hourInput).toHaveAttribute("step", "6")
-  })
+    );
+    const hourInput = document.querySelector("input.flatpickr-hour");
+    expect(hourInput).toHaveAttribute("step", "6");
+  });
 
   test("uses a custom minute increment as passed", async () => {
     render(
       <DateTimePicker enableTime dateFormat="Y-m-d H:i" minuteIncrement={7} />
-    )
-    const hourInput = document.querySelector("input.flatpickr-minute")
-    expect(hourInput).toHaveAttribute("step", "7")
-  })
+    );
+    const hourInput = document.querySelector("input.flatpickr-minute");
+    expect(hourInput).toHaveAttribute("step", "7");
+  });
 
   test("does not allow selection of dates before a minDate as passed", async () => {
     // Select yesterday element in calendar by label (formed like "January 31, 2024"), and test if disabled.
-    const user = userEvent.setup()
-    const today = new Date()
-    const yesterday = new Date()
-    yesterday.setDate(yesterday.getDate() - 1)
-    const fullMonth = yesterday.toLocaleString("default", { month: "long" })
-    const day = yesterday.getDate()
-    const fullYear = yesterday.getFullYear()
-    const yesterdayLabel = `${fullMonth} ${day}, ${fullYear}`
-    render(<DateTimePicker minDate={today} />)
-    const input = screen.getByRole("textbox")
-    await user.click(input)
-    const yesterdayEl = screen.getByLabelText(yesterdayLabel)
-    expect(yesterdayEl).toHaveClass("flatpickr-disabled")
-  })
+    const user = userEvent.setup();
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const fullMonth = yesterday.toLocaleString("default", { month: "long" });
+    const day = yesterday.getDate();
+    const fullYear = yesterday.getFullYear();
+    const yesterdayLabel = `${fullMonth} ${day}, ${fullYear}`;
+    render(<DateTimePicker minDate={today} />);
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    const yesterdayEl = screen.getByLabelText(yesterdayLabel);
+    expect(yesterdayEl).toHaveClass("flatpickr-disabled");
+  });
 
   test("allows selection of dates after a minDate as passed", async () => {
-    const user = userEvent.setup()
-    const today = new Date()
-    const tomorrow = new Date()
-    tomorrow.setDate(tomorrow.getDate() + 1)
-    const fullMonth = tomorrow.toLocaleString("default", { month: "long" })
-    const day = tomorrow.getDate()
-    const fullYear = tomorrow.getFullYear()
-    const tomorrowLabel = `${fullMonth} ${day}, ${fullYear}`
-    render(<DateTimePicker minDate={today} />)
-    const input = screen.getByRole("textbox")
-    await user.click(input)
-    const yesterdayEl = screen.getByLabelText(tomorrowLabel)
-    expect(yesterdayEl).not.toHaveClass("flatpickr-disabled")
-  })
+    const user = userEvent.setup();
+    const today = new Date();
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const fullMonth = tomorrow.toLocaleString("default", { month: "long" });
+    const day = tomorrow.getDate();
+    const fullYear = tomorrow.getFullYear();
+    const tomorrowLabel = `${fullMonth} ${day}, ${fullYear}`;
+    render(<DateTimePicker minDate={today} />);
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    const yesterdayEl = screen.getByLabelText(tomorrowLabel);
+    expect(yesterdayEl).not.toHaveClass("flatpickr-disabled");
+  });
 
   test("does not allow selection of dates after a maxDate as passed", async () => {
-    const user = userEvent.setup()
-    const today = new Date()
-    const tomorrow = new Date()
-    tomorrow.setDate(tomorrow.getDate() + 1)
+    const user = userEvent.setup();
+    const today = new Date();
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
     const tomorrowFullMonth = tomorrow.toLocaleString("default", {
       month: "long",
-    })
-    const tomorrowDay = tomorrow.getDate()
-    const tomorrowFullYear = tomorrow.getFullYear()
-    const tomorrowLabel = `${tomorrowFullMonth} ${tomorrowDay}, ${tomorrowFullYear}`
-    render(<DateTimePicker maxDate={today} />)
-    const input = screen.getByRole("textbox")
-    await user.click(input)
-    const tomorrowEl = screen.getByLabelText(tomorrowLabel)
-    expect(tomorrowEl).toHaveClass("flatpickr-disabled")
-  })
+    });
+    const tomorrowDay = tomorrow.getDate();
+    const tomorrowFullYear = tomorrow.getFullYear();
+    const tomorrowLabel = `${tomorrowFullMonth} ${tomorrowDay}, ${tomorrowFullYear}`;
+    render(<DateTimePicker maxDate={today} />);
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    const tomorrowEl = screen.getByLabelText(tomorrowLabel);
+    expect(tomorrowEl).toHaveClass("flatpickr-disabled");
+  });
 
   test("allows selection of dates before a maxDate as passed", async () => {
-    const user = userEvent.setup()
-    const today = new Date()
-    const tomorrow = new Date()
-    tomorrow.setDate(tomorrow.getDate() + 1)
-    const todayFullMonth = today.toLocaleString("default", { month: "long" })
-    const todayDay = today.getDate()
-    const todayFullYear = today.getFullYear()
-    const todayLabel = `${todayFullMonth} ${todayDay}, ${todayFullYear}`
-    render(<DateTimePicker maxDate={tomorrow} />)
-    const input = screen.getByRole("textbox")
-    await user.click(input)
-    const todayEl = screen.getByLabelText(todayLabel)
-    expect(todayEl).not.toHaveClass("flatpickr-disabled")
-  })
+    const user = userEvent.setup();
+    const today = new Date();
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const todayFullMonth = today.toLocaleString("default", { month: "long" });
+    const todayDay = today.getDate();
+    const todayFullYear = today.getFullYear();
+    const todayLabel = `${todayFullMonth} ${todayDay}, ${todayFullYear}`;
+    render(<DateTimePicker maxDate={tomorrow} />);
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    const todayEl = screen.getByLabelText(todayLabel);
+    expect(todayEl).not.toHaveClass("flatpickr-disabled");
+  });
 
   test("renders a time picker only if configured to do so", async () => {
-    render(<DateTimePicker enableTime noCalendar />)
-    expect(document.querySelector(".flatpickr-days")).not.toBeInTheDocument()
-    expect(document.querySelector("input.flatpickr-hour")).toBeInTheDocument()
-    expect(document.querySelector("input.flatpickr-minute")).toBeInTheDocument()
-  })
+    render(<DateTimePicker enableTime noCalendar />);
+    expect(document.querySelector(".flatpickr-days")).not.toBeInTheDocument();
+    expect(document.querySelector("input.flatpickr-hour")).toBeInTheDocument();
+    expect(
+      document.querySelector("input.flatpickr-minute")
+    ).toBeInTheDocument();
+  });
 
   test("executes an onOpen handler when the user clicks the Datepicker and the calendar opens", async () => {
-    const user = userEvent.setup()
-    render(<DateTimePicker onOpen={mockOnOpen} />)
-    const input = screen.getByRole("textbox")
-    await user.click(input)
-    expect(mockOnOpen).toHaveBeenCalled()
-  })
+    const user = userEvent.setup();
+    render(<DateTimePicker onOpen={mockOnOpen} />);
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    expect(mockOnOpen).toHaveBeenCalled();
+  });
 
   test("closes the calendar and executes an onClose handler when the user clicks outside the calendar", async () => {
-    const user = userEvent.setup()
-    render(<DateTimePicker onClose={mockOnClose} />)
-    const input = screen.getByRole("textbox")
-    await user.click(input)
-    await user.click(document.body)
-    expect(mockOnClose).toHaveBeenCalled()
-  })
+    const user = userEvent.setup();
+    render(<DateTimePicker onClose={mockOnClose} />);
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    await user.click(document.body);
+    expect(mockOnClose).toHaveBeenCalled();
+  });
 
   test("executes an onClear handler when the user clears the DateTimePicker by clicking the clear icon", async () => {
-    render(<DateTimePicker value="2024-01-31" onClear={mockOnClear} />)
-    const input = screen.getByRole("textbox")
-    const clearButton = screen.getByTitle("Clear")
-    const user = userEvent.setup()
-    expect(input).toBeInTheDocument()
-    expect(input).toHaveValue("2024-01-31")
-    expect(clearButton).toBeInTheDocument()
-    await user.click(clearButton)
-    expect(mockOnClear).toHaveBeenCalled()
-  })
+    render(<DateTimePicker value="2024-01-31" onClear={mockOnClear} />);
+    const input = screen.getByRole("textbox");
+    const clearButton = screen.getByTitle("Clear");
+    const user = userEvent.setup();
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("2024-01-31");
+    expect(clearButton).toBeInTheDocument();
+    await user.click(clearButton);
+    expect(mockOnClear).toHaveBeenCalled();
+  });
 
   test("executes an onChange handler when the user changes the selected date", async () => {
-    const user = userEvent.setup()
-    const today = new Date()
-    const tomorrow = new Date()
-    tomorrow.setDate(tomorrow.getDate() + 1)
+    const user = userEvent.setup();
+    const today = new Date();
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
     const tomorrowFullMonth = tomorrow.toLocaleString("default", {
       month: "long",
-    })
-    const tomorrowDay = tomorrow.getDate()
-    const tomorrowFullYear = tomorrow.getFullYear()
-    const tomorrowLabel = `${tomorrowFullMonth} ${tomorrowDay}, ${tomorrowFullYear}`
-    render(<DateTimePicker value={today} onChange={mockOnChange} />)
-    const input = screen.getByRole("textbox")
-    await user.click(input)
-    const tomorrowEl = screen.getByLabelText(tomorrowLabel)
-    await user.click(tomorrowEl)
-    expect(mockOnChange).toHaveBeenCalled()
-  })
+    });
+    const tomorrowDay = tomorrow.getDate();
+    const tomorrowFullYear = tomorrow.getFullYear();
+    const tomorrowLabel = `${tomorrowFullMonth} ${tomorrowDay}, ${tomorrowFullYear}`;
+    render(<DateTimePicker value={today} onChange={mockOnChange} />);
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    const tomorrowEl = screen.getByLabelText(tomorrowLabel);
+    await user.click(tomorrowEl);
+    expect(mockOnChange).toHaveBeenCalled();
+  });
 
   test("executes an onYearChange handler when the user changes the year", async () => {
-    const user = userEvent.setup()
-    render(<DateTimePicker onYearChange={mockOnYearChange} />)
-    const input = screen.getByRole("textbox")
-    await user.click(input)
-    const yearInputUp = document.querySelector(".numInputWrapper > .arrowUp")
-    await user.click(yearInputUp)
-    expect(mockOnYearChange).toHaveBeenCalled()
-  })
+    const user = userEvent.setup();
+    render(<DateTimePicker onYearChange={mockOnYearChange} />);
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    const yearInputUp = document.querySelector(".numInputWrapper > .arrowUp");
+    await user.click(yearInputUp);
+    expect(mockOnYearChange).toHaveBeenCalled();
+  });
 
   test("executes an onMonthChange handler when the user changes the month by clicking an arrow", async () => {
-    const user = userEvent.setup()
-    render(<DateTimePicker onMonthChange={mockOnMonthChange} />)
-    const input = screen.getByRole("textbox")
-    await user.click(input)
-    const nextMonthButton = document.querySelector(".flatpickr-next-month")
-    await user.click(nextMonthButton)
-    expect(mockOnMonthChange).toHaveBeenCalled()
-  })
+    const user = userEvent.setup();
+    render(<DateTimePicker onMonthChange={mockOnMonthChange} />);
+    const input = screen.getByRole("textbox");
+    await user.click(input);
+    const nextMonthButton = document.querySelector(".flatpickr-next-month");
+    await user.click(nextMonthButton);
+    expect(mockOnMonthChange).toHaveBeenCalled();
+  });
 
   test("renders a className as passed", async () => {
-    render(<DateTimePicker className="my-custom-class" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveClass("my-custom-class")
-  })
+    render(<DateTimePicker className="my-custom-class" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveClass("my-custom-class");
+  });
+
+  test("renders a wrapperClassName to the outer wrapping element", async () => {
+    render(<DateTimePicker wrapperClassName="my-wrapper-class" />);
+    expect(
+      document.querySelector(".juno-datetimepicker-wrapper")
+    ).toBeInTheDocument();
+    expect(document.querySelector(".juno-datetimepicker-wrapper")).toHaveClass(
+      "my-wrapper-class"
+    );
+  });
 
   test("renders other props as passed", async () => {
-    render(<DateTimePicker data-lolol="527" />)
-    expect(screen.getByRole("textbox")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveAttribute("data-lolol", "527")
-  })
-})
+    render(<DateTimePicker data-lolol="527" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("data-lolol", "527");
+  });
+});

--- a/libs/juno-ui-components/src/components/NativeSelect/NativeSelect.component.js
+++ b/libs/juno-ui-components/src/components/NativeSelect/NativeSelect.component.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect } from "react"
-import PropTypes from "prop-types"
-import { Icon } from "../Icon/index.js"
-import { Spinner } from "../Spinner/Spinner.component"
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { Icon } from "../Icon/index.js";
+import { Spinner } from "../Spinner/Spinner.component";
 
 const selectstyles = `
 	jn-w-full
@@ -24,11 +24,11 @@ const selectstyles = `
 	focus:jn-ring-2
 	focus:jn-ring-theme-focus
 	disabled:jn-opacity-50
-`
+`;
 
 const wrapperstyles = `
 	jn-relative
-`
+`;
 
 const iconstyles = `
 	jn-absolute
@@ -36,21 +36,21 @@ const iconstyles = `
 	jn-right-2
 	jn-top-1.5
 	jn-pointer-events-none
-`
+`;
 
 const disablediconstyles = `
 	jn-opacity-50
-`
+`;
 
 const errorstyles = `
 	jn-border
 	jn-border-theme-error
-`
+`;
 
 const successstyles = `
 	jn-border
 	jn-border-theme-success
-`
+`;
 
 const loadingStyles = `
 	jn-absolute
@@ -68,7 +68,7 @@ const loadingStyles = `
 	jn-justify-center
 	jn-select-none
 	jn-cursor-not-allowed
-`
+`;
 
 const errorStyles = `
 	jn-absolute
@@ -86,25 +86,25 @@ const errorStyles = `
 	jn-justify-center
 	jn-select-none
 	jn-cursor-not-allowed
-`
+`;
 
 const loadingSpinnerStyles = `
 	jn-ml-auto
 	jn-mr-auto
-`
+`;
 
 const errorIconStyles = `
 	jn-ml-auto
 	jn-mr-auto
-`
+`;
 
 const iconpaddingright = `
 	jn-pr-[3.75rem]
-`
+`;
 
 const defaultpaddingright = `
 	jn-pr-9
-`
+`;
 
 /** A basic, uncontrolled, native html Select. Takes SelectOption and SelectOptionGroup as children. */
 export const NativeSelect = ({
@@ -119,36 +119,37 @@ export const NativeSelect = ({
   error,
   onChange,
   onClick,
+  wrapperClassName,
   ...props
 }) => {
-  const [isLoading, setIsLoading] = useState(false)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
-  const [hasError, setHasError] = useState(false)
+  const [isLoading, setIsLoading] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [isValid, setIsValid] = useState(false);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
-    setIsLoading(loading)
-  }, [loading])
+    setIsLoading(loading);
+  }, [loading]);
 
   useEffect(() => {
-    setIsInvalid(invalid)
-  }, [invalid])
+    setIsInvalid(invalid);
+  }, [invalid]);
 
   useEffect(() => {
-    setIsValid(valid)
-  }, [valid])
+    setIsValid(valid);
+  }, [valid]);
 
   useEffect(() => {
-    setHasError(error)
-  }, [error])
+    setHasError(error);
+  }, [error]);
 
   const handleChange = (event) => {
-    onChange && onChange(event)
-  }
+    onChange && onChange(event);
+  };
 
   const handleClick = (event) => {
-    onClick && onClick(event)
-  }
+    onClick && onClick(event);
+  };
 
   const SelectIcons = ({ disabled }) => {
     if (isLoading) {
@@ -156,7 +157,7 @@ export const NativeSelect = ({
         <div className={`juno-select-loading ${loadingStyles}`}>
           <Spinner className={`${loadingSpinnerStyles}`} />
         </div>
-      )
+      );
     } else if (hasError) {
       return (
         <div className={`juno-select-errortext ${errorStyles}`}>
@@ -166,7 +167,7 @@ export const NativeSelect = ({
             className={`${errorIconStyles}`}
           />
         </div>
-      )
+      );
     } else {
       return (
         <div className={`${iconstyles} ${disabled ? disablediconstyles : ""} `}>
@@ -178,20 +179,26 @@ export const NativeSelect = ({
           ) : null}
           <Icon icon={"expandMore"} />
         </div>
-      )
+      );
     }
-  }
+  };
 
   const selectPadding = () => {
     if (isValid || isInvalid) {
-      return iconpaddingright
+      return iconpaddingright;
     } else {
-      return defaultpaddingright
+      return defaultpaddingright;
     }
-  }
+  };
 
   return (
-    <div className={`juno-select-wrapper ${wrapperstyles}`}>
+    <div
+      className={`
+      juno-select-wrapper 
+      ${wrapperstyles}
+      ${wrapperClassName}
+    `}
+    >
       <select
         name={name || "Unnamed Select"}
         id={id}
@@ -209,8 +216,8 @@ export const NativeSelect = ({
       </select>
       <SelectIcons disabled={disabled} />
     </div>
-  )
-}
+  );
+};
 
 NativeSelect.propTypes = {
   /** Pass a name. */
@@ -235,7 +242,9 @@ NativeSelect.propTypes = {
   onChange: PropTypes.func,
   /** Pass a click handler */
   onClick: PropTypes.func,
-}
+  /** Pass a className to the outer wrapping element */
+  wrapperClassName: PropTypes.string,
+};
 
 NativeSelect.defaultProps = {
   name: null,
@@ -248,4 +257,5 @@ NativeSelect.defaultProps = {
   error: false,
   onChange: undefined,
   onClick: undefined,
-}
+  wrapperClassName: "",
+};

--- a/libs/juno-ui-components/src/components/NativeSelect/NativeSelect.test.js
+++ b/libs/juno-ui-components/src/components/NativeSelect/NativeSelect.test.js
@@ -3,121 +3,129 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
-import { NativeSelect } from "./index"
+import * as React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NativeSelect } from "./index";
 
 describe("NativeSelect", () => {
   test("renders a native html select element", async () => {
-    render(<NativeSelect />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-  })
+    render(<NativeSelect />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
 
   test("renders a select element with a name as passed", async () => {
-    render(<NativeSelect name="my-select" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveAttribute("name", "my-select")
-  })
+    render(<NativeSelect name="my-select" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveAttribute("name", "my-select");
+  });
 
   test("renders a select element with an id as passed", async () => {
-    render(<NativeSelect id="my-select" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveAttribute("id", "my-select")
-  })
+    render(<NativeSelect id="my-select" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveAttribute("id", "my-select");
+  });
 
   test("renders a custom className", async () => {
-    render(<NativeSelect className="my-custom-class" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveClass("my-custom-class")
-  })
+    render(<NativeSelect className="my-custom-class" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveClass("my-custom-class");
+  });
 
   test("renders a disabled select as passed", async () => {
-    render(<NativeSelect disabled />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toBeDisabled()
-  })
+    render(<NativeSelect disabled />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeDisabled();
+  });
 
   test("renders an invalid Select as passed", async () => {
-    render(<NativeSelect invalid />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveClass("juno-select-invalid")
-    expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-  })
+    render(<NativeSelect invalid />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveClass("juno-select-invalid");
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
 
   test("renders a valid Select as passed", async () => {
-    render(<NativeSelect valid />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toHaveClass("juno-select-valid")
-    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-  })
+    render(<NativeSelect valid />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveClass("juno-select-valid");
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
 
   test("renders a Select with an error as passed", async () => {
-    render(<NativeSelect error />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByRole("combobox")).toBeDisabled()
-    expect(screen.getByRole("combobox")).toHaveClass("juno-select-error")
-    expect(screen.getByTitle("Error")).toBeInTheDocument()
-  })
+    render(<NativeSelect error />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeDisabled();
+    expect(screen.getByRole("combobox")).toHaveClass("juno-select-error");
+    expect(screen.getByTitle("Error")).toBeInTheDocument();
+  });
 
   test("renders children as passed", async () => {
     render(
       <NativeSelect>
         <option data-testid="option">Option</option>
       </NativeSelect>
-    )
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
-    expect(screen.getByTestId("option")).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getByTestId("option")).toBeInTheDocument();
+  });
 
   test("executes onClick handler as passed", async () => {
-    const onClickSpy = jest.fn()
-    render(<NativeSelect onClick={onClickSpy} />)
-    const select = screen.getByRole("combobox")
-    select.click()
-    expect(onClickSpy).toHaveBeenCalled()
-  })
+    const onClickSpy = jest.fn();
+    render(<NativeSelect onClick={onClickSpy} />);
+    const select = screen.getByRole("combobox");
+    select.click();
+    expect(onClickSpy).toHaveBeenCalled();
+  });
 
   test("executes onChange handler as passed", async () => {
-    const handleChange = jest.fn()
-    const { container } = render(<NativeSelect onChange={handleChange} />)
-    const select = screen.getByRole("combobox")
-    fireEvent.change(select, { target: { value: "a" } })
-    expect(handleChange).toHaveBeenCalledTimes(1)
-  })
+    const handleChange = jest.fn();
+    const { container } = render(<NativeSelect onChange={handleChange} />);
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "a" } });
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
 
   test("does not execute onClick handler when disabled", async () => {
-    const onClickSpy = jest.fn()
-    render(<NativeSelect onClick={onClickSpy} disabled />)
-    screen.getByRole("combobox").click()
-    expect(onClickSpy).not.toHaveBeenCalled()
-  })
+    const onClickSpy = jest.fn();
+    render(<NativeSelect onClick={onClickSpy} disabled />);
+    screen.getByRole("combobox").click();
+    expect(onClickSpy).not.toHaveBeenCalled();
+  });
 
   test("does not execute onChange handler when disabled", async () => {
-    const onChangeSpy = jest.fn()
-    render(<NativeSelect onChange={onChangeSpy} disabled />)
-    screen.getByRole("combobox").click()
-    expect(onChangeSpy).not.toHaveBeenCalled()
-  })
+    const onChangeSpy = jest.fn();
+    render(<NativeSelect onChange={onChangeSpy} disabled />);
+    screen.getByRole("combobox").click();
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
 
   test("renders a loading Select as passed", async () => {
-    render(<NativeSelect loading />)
-    expect(screen.getByRole("combobox")).toBeDisabled()
-    expect(screen.getByRole("progressbar")).toBeInTheDocument()
-  })
+    render(<NativeSelect loading />);
+    expect(screen.getByRole("combobox")).toBeDisabled();
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
 
   test("can not be clicked when loading", async () => {
-    const onClickSpy = jest.fn()
-    render(<NativeSelect loading onClick={onClickSpy} />)
-    screen.getByRole("combobox").click()
-    expect(onClickSpy).not.toHaveBeenCalled()
-  })
+    const onClickSpy = jest.fn();
+    render(<NativeSelect loading onClick={onClickSpy} />);
+    screen.getByRole("combobox").click();
+    expect(onClickSpy).not.toHaveBeenCalled();
+  });
+
+  test("renders a wrapperClassName to the outer wrapping element", async () => {
+    render(<NativeSelect wrapperClassName="my-wrapper-class" />);
+    expect(document.querySelector(".juno-select-wrapper")).toBeInTheDocument();
+    expect(document.querySelector(".juno-select-wrapper")).toHaveClass(
+      "my-wrapper-class"
+    );
+  });
 
   test("renders all props as passed", async () => {
-    render(<NativeSelect data-lolol="some-random-prop" />)
-    expect(screen.getByRole("combobox")).toBeInTheDocument()
+    render(<NativeSelect data-lolol="some-random-prop" />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
     expect(screen.getByRole("combobox")).toHaveAttribute(
       "data-lolol",
       "some-random-prop"
-    )
-  })
-})
+    );
+  });
+});

--- a/libs/juno-ui-components/src/components/Select/Select.component.js
+++ b/libs/juno-ui-components/src/components/Select/Select.component.js
@@ -9,25 +9,25 @@ import React, {
   useId,
   useMemo,
   useState,
-} from "react"
-import PropTypes from "prop-types"
-import { Listbox } from "@headlessui/react"
-import { Label } from "../Label/Label.component"
-import { Icon } from "../Icon/Icon.component"
-import { Spinner } from "../Spinner/Spinner.component"
-import { FormHint } from "../FormHint/FormHint.component"
-import { Float } from "@headlessui-float/react"
-import { flip, offset, shift, size } from "@floating-ui/react-dom"
-import { usePortalRef } from "../PortalProvider/index"
-import { createPortal } from "react-dom"
-import "./select.scss"
+} from "react";
+import PropTypes from "prop-types";
+import { Listbox } from "@headlessui/react";
+import { Label } from "../Label/Label.component";
+import { Icon } from "../Icon/Icon.component";
+import { Spinner } from "../Spinner/Spinner.component";
+import { FormHint } from "../FormHint/FormHint.component";
+import { Float } from "@headlessui-float/react";
+import { flip, offset, shift, size } from "@floating-ui/react-dom";
+import { usePortalRef } from "../PortalProvider/index";
+import { createPortal } from "react-dom";
+import "./select.scss";
 
 const labelStyles = `
   jn-no-wrap
   jn-pointer-events-none
   jn-top-2
   jn-left-4
-`
+`;
 
 const toggleStyles = `
   jn-appearance-none
@@ -41,16 +41,16 @@ const toggleStyles = `
   focus:jn-outline-none
   focus:jn-ring-2
   focus:jn-ring-theme-focus
-`
+`;
 const validToggleStyles = `
   jn-border
   jn-border-theme-success
-`
+`;
 
 const invalidToggleStyles = `
   jn-border
   jn-border-theme-error
-`
+`;
 
 const centeredIconStyles = `
   jn-absolute
@@ -58,14 +58,14 @@ const centeredIconStyles = `
   jn-left-1/2
   jn-translate-y-[-50%]
   jn-translate-x-[-0.75rem]
-`
+`;
 
 const menuStyles = `
   jn-rounded
   jn-bg-theme-background-lvl-1
   jn-w-full
   jn-overflow-y-auto
-`
+`;
 
 const truncateStyles = `
   jn-block
@@ -73,9 +73,9 @@ const truncateStyles = `
   jn-overflow-hidden
   jn-text-ellipsis
   jn-whitespace-nowrap
-`
+`;
 
-export const SelectContext = createContext()
+export const SelectContext = createContext();
 
 /** 
   A Select component that can be configured to allow selecting a single item or multiple items.
@@ -107,22 +107,23 @@ export const Select = ({
   valueLabel,
   variant,
   width,
+  wrapperClassName,
   ...props
 }) => {
   const isNotEmptyString = (str) => {
-    return !(typeof str === "string" && str.trim().length === 0)
-  }
+    return !(typeof str === "string" && str.trim().length === 0);
+  };
 
-  const uniqueId = () => "juno-select-" + useId()
+  const uniqueId = () => "juno-select-" + useId();
 
-  const theId = id || uniqueId()
-  const helptextId = "juno-select-helptext-" + useId()
+  const theId = id || uniqueId();
+  const helptextId = "juno-select-helptext-" + useId();
 
-  const [optionValuesAndLabels, setOptionValuesAndLabels] = useState(new Map())
-  const [hasError, setHasError] = useState(false)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
+  const [optionValuesAndLabels, setOptionValuesAndLabels] = useState(new Map());
+  const [hasError, setHasError] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [isValid, setIsValid] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   // This callback is for all SelectOptions to send us their value, label and children so we can save them in a map
   // We need this because the Select component wants to display the selected value, label or children in the toggle button
@@ -137,41 +138,41 @@ export const Select = ({
         children: children,
         displayName: children || label || value,
       })
-    )
-  }
+    );
+  };
 
   const invalidated = useMemo(
     () => invalid || (errortext && isNotEmptyString(errortext) ? true : false),
     [invalid, errortext]
-  )
+  );
   const validated = useMemo(
     () =>
       valid || (successtext && isNotEmptyString(successtext) ? true : false),
     [valid, successtext]
-  )
+  );
 
   useEffect(() => {
-    setHasError(error)
-  }, [error])
+    setHasError(error);
+  }, [error]);
 
   useEffect(() => {
-    setIsInvalid(invalidated)
-  }, [invalidated])
+    setIsInvalid(invalidated);
+  }, [invalidated]);
 
   useEffect(() => {
-    setIsValid(validated)
-  }, [validated])
+    setIsValid(validated);
+  }, [validated]);
 
   useEffect(() => {
-    setIsLoading(loading)
-  }, [loading])
+    setIsLoading(loading);
+  }, [loading]);
 
   const handleChange = (value) => {
-    onChange && onChange(value || "")
-    onValueChange && onValueChange(value || "")
-  }
+    onChange && onChange(value || "");
+    onValueChange && onValueChange(value || "");
+  };
 
-  const portalContainerRef = usePortalRef()
+  const portalContainerRef = usePortalRef();
 
   // Headless-UI-Float Middleware
   const middleware = [
@@ -185,25 +186,25 @@ export const Select = ({
           maxWidth: `${availableWidth}px`,
           maxHeight: `${availableHeight}px`,
           overflowY: "auto",
-        })
+        });
       },
     }),
-  ]
+  ];
 
   // This function is used to determine what to render for the selected options in the Select Toggle in multi-select case.
   // For each of the values, we get the respective element from the optionValuesAndLabels map, get the corresponding label or children, and filter these for empty elements to make sure we do not include any empty strings in the returned array.
   const getMultipleDisplayValues = (values) => {
     const getChildrenOrLabel = (key) => {
-      const element = optionValuesAndLabels.get(key)
+      const element = optionValuesAndLabels.get(key);
       if (element) {
-        return element.displayName?.length ? element.displayName : null
+        return element.displayName?.length ? element.displayName : null;
       }
-    }
+    };
     const valuesToDisplay = values
       .map((key) => getChildrenOrLabel(key))
-      .filter((value) => value && value.toString().trim().length > 0)
-    return valuesToDisplay.join(", ")
-  }
+      .filter((value) => value && value.toString().trim().length > 0);
+    return valuesToDisplay.join(", ");
+  };
 
   return (
     <SelectContext.Provider
@@ -218,6 +219,7 @@ export const Select = ({
           jn-relative
           ${width == "auto" ? "jn-inline-block" : "jn-block"}
           ${width == "auto" ? "jn-w-auto" : "jn-w-full"}
+          ${wrapperClassName}
         `}
       >
         <Listbox
@@ -374,27 +376,27 @@ export const Select = ({
         )}
       </div>
     </SelectContext.Provider>
-  )
-}
+  );
+};
 
 // Validator function to make sure the proptype of value is set accordingly when we use single or multi select
 const valuePropType = (props) => {
-  const { multiple, value } = props
+  const { multiple, value } = props;
 
   // only validate if value is not undefined to avoid throwing an error when not necessary:
   if (value) {
     if (multiple && !Array.isArray(value)) {
       return new Error(
         "Invalid prop value supplied to Select component: Pass an array when using as a multi-select."
-      )
+      );
     }
     if (!multiple && typeof value !== "string") {
       return new Error(
         "Invalid prop value supplied to Select component: Pass a string when using as single select."
-      )
+      );
     }
   }
-}
+};
 
 Select.propTypes = {
   /** Pass an aria-label to the Select toggle button */
@@ -448,7 +450,9 @@ Select.propTypes = {
   variant: PropTypes.oneOf(["default", "primary", "primary-danger", "subdued"]),
   /** Whether the Select toggle should consume the available width of its parent container (default), or render its "natural" width depending on the content and the currently selected value or state. */
   width: PropTypes.oneOf(["full", "auto"]),
-}
+  /** Pass a className to the outer wrapping element. */
+  wrapperClassName: PropTypes.string,
+};
 
 Select.defaultProps = {
   ariaLabel: "",
@@ -476,4 +480,5 @@ Select.defaultProps = {
   valueLabel: undefined,
   variant: "default",
   width: "full",
-}
+  wrapperClassName: "",
+};

--- a/libs/juno-ui-components/src/components/Select/Select.test.js
+++ b/libs/juno-ui-components/src/components/Select/Select.test.js
@@ -3,242 +3,250 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as React from "react"
-import { cleanup, render, screen, fireEvent } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import { act } from "react-dom/test-utils"
-import { Select } from "./index"
-import { SelectOption } from "../SelectOption/index"
+import * as React from "react";
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "react-dom/test-utils";
+import { Select } from "./index";
+import { SelectOption } from "../SelectOption/index";
 
-const mockOnChange = jest.fn()
-const mockOnValueChange = jest.fn()
+const mockOnChange = jest.fn();
+const mockOnValueChange = jest.fn();
 
 const ControlledSelectParent = ({ value, children, onChange, ...props }) => {
-  const [val, setVal] = React.useState(value)
+  const [val, setVal] = React.useState(value);
 
   const handleChange = (v) => {
-    setVal(v)
-    onChange()
-  }
+    setVal(v);
+    onChange();
+  };
 
   return (
     <Select {...props} value={val} onChange={handleChange}>
       {children}
     </Select>
-  )
-}
+  );
+};
 
 describe("Select", () => {
   afterEach(() => {
-    cleanup()
-    jest.clearAllMocks()
-  })
+    cleanup();
+    jest.clearAllMocks();
+  });
 
   test("renders a Select toggle", async () => {
-    render(<Select />)
-    expect(screen.getByRole("button")).toHaveAttribute("type", "button")
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveClass("juno-select-toggle")
-  })
+    render(<Select />);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveClass("juno-select-toggle");
+  });
 
   test("renders a default variant select toggle by defgault", async () => {
-    render(<Select />)
-    expect(screen.getByRole("button")).toHaveAttribute("type", "button")
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveClass("juno-select-toggle")
+    render(<Select />);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveClass("juno-select-toggle");
     expect(screen.getByRole("button")).not.toHaveClass(
       "juno-select-toggle-primary"
-    )
+    );
     expect(screen.getByRole("button")).not.toHaveClass(
       "juno-select-toggle-primary-danger"
-    )
+    );
     expect(screen.getByRole("button")).not.toHaveClass(
       "juno-select-toggle-primary-subdued"
-    )
-  })
+    );
+  });
 
   test("renders a primary variant select toggle as passed", async () => {
-    render(<Select variant="primary" />)
-    expect(screen.getByRole("button")).toHaveAttribute("type", "button")
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveClass("juno-select-toggle-primary")
-  })
+    render(<Select variant="primary" />);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveClass(
+      "juno-select-toggle-primary"
+    );
+  });
 
   test("renders a primary-danger variant select toggle as passed", async () => {
-    render(<Select variant="primary-danger" />)
-    expect(screen.getByRole("button")).toHaveAttribute("type", "button")
-    expect(screen.getByRole("button")).toBeInTheDocument()
+    render(<Select variant="primary-danger" />);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    expect(screen.getByRole("button")).toBeInTheDocument();
     expect(screen.getByRole("button")).toHaveClass(
       "juno-select-toggle-primary-danger"
-    )
-  })
+    );
+  });
 
   test("renders a subdued variant select toggle as passed", async () => {
-    render(<Select variant="subdued" />)
-    expect(screen.getByRole("button")).toHaveAttribute("type", "button")
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveClass("juno-select-toggle-subdued")
-  })
+    render(<Select variant="subdued" />);
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveClass(
+      "juno-select-toggle-subdued"
+    );
+  });
 
   test("renders a Select with a label as passed", async () => {
-    render(<Select label="My Label" />)
-    expect(document.querySelector(".juno-label")).toBeInTheDocument()
-    expect(document.querySelector(".juno-label")).toHaveTextContent("My Label")
-  })
+    render(<Select label="My Label" />);
+    expect(document.querySelector(".juno-label")).toBeInTheDocument();
+    expect(document.querySelector(".juno-label")).toHaveTextContent("My Label");
+  });
 
   test("renders a placeholder as passed", async () => {
-    render(<Select placeholder="my-placeholder" />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveTextContent("my-placeholder")
-  })
+    render(<Select placeholder="my-placeholder" />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveTextContent("my-placeholder");
+  });
 
   test("renders default placeholder if empty string or undefined were passed as value", async () => {
-    render(<Select value="" />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveTextContent("Select…")
-  })
+    render(<Select value="" />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveTextContent("Select…");
+  });
 
   test("renders a Select toggle with an id as passed", async () => {
-    render(<Select id="select-1" />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveAttribute("id", "select-1")
-  })
+    render(<Select id="select-1" />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveAttribute("id", "select-1");
+  });
 
   test("renders a Select toggle with a generated unique id if no id was passed", async () => {
-    render(<Select />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveAttribute("id")
+    render(<Select />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveAttribute("id");
     expect(screen.getByRole("button").getAttribute("id")).toMatch(
       "juno-select-"
-    )
-  })
+    );
+  });
 
   test("renders a Select toggle with an associated label with an id as passed", async () => {
-    render(<Select id="my-select" label="My Select" />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByLabelText("My Select")).toBeInTheDocument()
-    expect(screen.getByLabelText("My Select")).toHaveClass("juno-select-toggle")
-  })
+    render(<Select id="my-select" label="My Select" />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByLabelText("My Select")).toBeInTheDocument();
+    expect(screen.getByLabelText("My Select")).toHaveClass(
+      "juno-select-toggle"
+    );
+  });
 
   test("renders a Select toggle with a label associated by an auto-generated id if no id was passed ", async () => {
-    render(<Select label="This is a Select" />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByLabelText("This is a Select")).toBeInTheDocument()
+    render(<Select label="This is a Select" />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByLabelText("This is a Select")).toBeInTheDocument();
     expect(screen.getByLabelText("This is a Select")).toHaveClass(
       "juno-select-toggle"
-    )
-  })
+    );
+  });
 
   test("renders a required marker as passed", async () => {
-    render(<Select label="My Select" required={true} />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(document.querySelector(".juno-label")).toHaveTextContent("My Select")
-    expect(document.querySelector(".juno-required")).toBeInTheDocument()
-  })
+    render(<Select label="My Select" required={true} />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(document.querySelector(".juno-label")).toHaveTextContent(
+      "My Select"
+    );
+    expect(document.querySelector(".juno-required")).toBeInTheDocument();
+  });
 
   test("renders an aria-label as passed", async () => {
-    render(<Select ariaLabel="my-select" />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
+    render(<Select ariaLabel="my-select" />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
     expect(screen.getByRole("button")).toHaveAttribute(
       "aria-label",
       "my-select"
-    )
-  })
+    );
+  });
 
   test("renders a custom className to the Select toggle as passed", async () => {
-    render(<Select className="my-class" />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveClass("my-class")
-  })
+    render(<Select className="my-class" />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveClass("my-class");
+  });
 
   test("renders a disabled Select as passed", async () => {
-    render(<Select disabled />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toBeDisabled()
-  })
+    render(<Select disabled />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
 
   test("renders a valid Select as passed", async () => {
-    render(<Select valid />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveClass("juno-select-valid")
-    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-  })
+    render(<Select valid />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveClass("juno-select-valid");
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
 
   test("renders an invalid Select as passed", async () => {
-    render(<Select invalid />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveClass("juno-select-invalid")
-    expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-  })
+    render(<Select invalid />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveClass("juno-select-invalid");
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
 
   test("renders a successtext as passed and validates the Element", async () => {
-    render(<Select successtext="great success!" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
+    render(<Select successtext="great success!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
     expect(document.querySelector(".juno-form-hint")).toHaveClass(
       "juno-form-hint-success"
-    )
+    );
     expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
       "great success!"
-    )
-    expect(screen.getByRole("button")).toHaveClass("juno-select-valid")
-    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByRole("button")).toHaveClass("juno-select-valid");
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
 
   test("renders an errortext as passed and invalidates the Element", async () => {
-    render(<Select errortext="this is an error!" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
+    render(<Select errortext="this is an error!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
     expect(document.querySelector(".juno-form-hint")).toHaveClass(
       "juno-form-hint-error"
-    )
+    );
     expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
       "this is an error!"
-    )
-    expect(screen.getByRole("button")).toHaveClass("juno-select-invalid")
-    expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-  })
+    );
+    expect(screen.getByRole("button")).toHaveClass("juno-select-invalid");
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
 
   test("renders loading Select with a Spinner as passed", async () => {
-    render(<Select loading />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveClass("juno-select-loading")
-    expect(document.querySelector(".juno-spinner")).toBeInTheDocument()
-  })
+    render(<Select loading />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveClass("juno-select-loading");
+    expect(document.querySelector(".juno-spinner")).toBeInTheDocument();
+  });
 
   test("renders a Select in error state as passed", async () => {
-    render(<Select error />)
-    expect(screen.getByRole("button")).toBeInTheDocument()
-    expect(screen.getByRole("button")).toHaveClass("juno-select-error")
-  })
+    render(<Select error />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveClass("juno-select-error");
+  });
 
   test("renders non-truncated Select Options by default", async () => {
     render(
       <Select>
         <SelectOption value="1">Option 1</SelectOption>
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    await userEvent.click(toggle)
-    expect(screen.getByRole("option")).toBeInTheDocument()
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    await userEvent.click(toggle);
+    expect(screen.getByRole("option")).toBeInTheDocument();
     expect(screen.getByRole("option")).not.toHaveClass(
       "juno-select-option-truncate"
-    )
-  })
+    );
+  });
 
   test("renders truncated Select Options as passed", async () => {
     render(
       <Select truncateOptions>
         <SelectOption value="1">Option 1</SelectOption>
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    await userEvent.click(toggle)
-    expect(screen.getByRole("option")).toBeInTheDocument()
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    await userEvent.click(toggle);
+    expect(screen.getByRole("option")).toBeInTheDocument();
     expect(screen.getByRole("option")).toHaveClass(
       "juno-select-option-truncate"
-    )
-  })
+    );
+  });
 
   test("renders a Select with a selected value as passed", async () => {
     render(
@@ -247,18 +255,18 @@ describe("Select", () => {
         <SelectOption value="Option 2" />
         <SelectOption value="Option 3" />
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    expect(toggle).toHaveTextContent("Option 2")
-    await userEvent.click(toggle)
-    expect(screen.getByRole("listbox")).toBeInTheDocument()
-    expect(screen.getAllByRole("option")[1]).toHaveTextContent("Option 2")
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("Option 2");
+    await userEvent.click(toggle);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getAllByRole("option")[1]).toHaveTextContent("Option 2");
     expect(screen.getAllByRole("option")[1]).toHaveAttribute(
       "aria-selected",
       "true"
-    )
-  })
+    );
+  });
 
   test("renders the valueLabel in the toggle for selected items if passed", async () => {
     render(
@@ -267,11 +275,11 @@ describe("Select", () => {
         <SelectOption value="option-2" label="Option 1" />
         <SelectOption value="option-3" label="Option 1" />
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    expect(toggle).toHaveTextContent("Option 1")
-  })
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("Option 1");
+  });
 
   test("opens the Select menu with options as passed when the user clicks the Select toggle", async () => {
     render(
@@ -280,16 +288,16 @@ describe("Select", () => {
         <SelectOption value="Option 2" />
         <SelectOption value="Option 3" />
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    await userEvent.click(toggle)
-    expect(screen.getByRole("listbox")).toBeInTheDocument()
-    expect(screen.queryAllByRole("option")).toHaveLength(3)
-    expect(screen.getAllByRole("option")[0]).toHaveTextContent("Option 1")
-    expect(screen.getAllByRole("option")[1]).toHaveTextContent("Option 2")
-    expect(screen.getAllByRole("option")[2]).toHaveTextContent("Option 3")
-  })
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    await userEvent.click(toggle);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.queryAllByRole("option")).toHaveLength(3);
+    expect(screen.getAllByRole("option")[0]).toHaveTextContent("Option 1");
+    expect(screen.getAllByRole("option")[1]).toHaveTextContent("Option 2");
+    expect(screen.getAllByRole("option")[2]).toHaveTextContent("Option 3");
+  });
 
   test("changes the selected value as clicked by a user", async () => {
     render(
@@ -298,44 +306,44 @@ describe("Select", () => {
         <SelectOption value="Option 2" />
         <SelectOption value="Option 3" />
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    expect(toggle).toHaveTextContent("Select…")
-    await userEvent.click(toggle)
-    expect(screen.getByRole("listbox")).toBeInTheDocument()
-    const option2 = screen.getAllByRole("option")[1]
-    await userEvent.click(option2)
-    expect(toggle).toHaveTextContent("Option 2")
-  })
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("Select…");
+    await userEvent.click(toggle);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    const option2 = screen.getAllByRole("option")[1];
+    await userEvent.click(option2);
+    expect(toggle).toHaveTextContent("Option 2");
+  });
 
   test("executes an onChange handler when the selected value changes", async () => {
     render(
       <Select onChange={mockOnChange}>
         <SelectOption value="Option-1">Option 1</SelectOption>
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    await userEvent.click(toggle)
-    expect(screen.getByRole("listbox")).toBeInTheDocument()
-    await userEvent.click(screen.getByRole("option"))
-    expect(mockOnChange).toHaveBeenCalled()
-  })
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    await userEvent.click(toggle);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("option"));
+    expect(mockOnChange).toHaveBeenCalled();
+  });
 
   test("executes a legacy onValueChange handler when the Select value changes", async () => {
     render(
       <Select onValueChange={mockOnValueChange}>
         <SelectOption value="Option-1">Option 1</SelectOption>
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    await userEvent.click(toggle)
-    expect(screen.getByRole("listbox")).toBeInTheDocument()
-    await userEvent.click(screen.getByRole("option"))
-    expect(mockOnValueChange).toHaveBeenCalled()
-  })
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    await userEvent.click(toggle);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("option"));
+    expect(mockOnValueChange).toHaveBeenCalled();
+  });
 
   test("works as a controlled component", async () => {
     render(
@@ -344,16 +352,16 @@ describe("Select", () => {
         <SelectOption value="Option 2">Option 2</SelectOption>
         <SelectOption value="Option 3">Option 3</SelectOption>
       </ControlledSelectParent>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    expect(toggle).toHaveTextContent("Option 1")
-    await userEvent.click(toggle)
-    expect(screen.getByRole("listbox")).toBeInTheDocument()
-    const option2 = screen.getAllByRole("option")[1]
-    await userEvent.click(option2)
-    expect(toggle).toHaveTextContent("Option 2")
-  })
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("Option 1");
+    await userEvent.click(toggle);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    const option2 = screen.getAllByRole("option")[1];
+    await userEvent.click(option2);
+    expect(toggle).toHaveTextContent("Option 2");
+  });
 
   test("updates value as passed", async () => {
     const { rerender } = render(
@@ -362,20 +370,20 @@ describe("Select", () => {
         <SelectOption value="option-2" />
         <SelectOption value="option-3" />
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    expect(toggle).toHaveTextContent("option-2")
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("option-2");
     rerender(
       <Select value="option-3">
         <SelectOption value="option-1" />
         <SelectOption value="option-2" />
         <SelectOption value="option-3" />
       </Select>
-    )
-    expect(toggle).toBeInTheDocument()
-    expect(toggle).toHaveTextContent("option-3")
-  })
+    );
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("option-3");
+  });
 
   test("works as an uncontrolled component", async () => {
     render(
@@ -384,16 +392,16 @@ describe("Select", () => {
         <SelectOption value="Option 2">Option 2</SelectOption>
         <SelectOption value="Option 3">Option 3</SelectOption>
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    expect(toggle).toHaveTextContent("Option 2")
-    await userEvent.click(toggle)
-    expect(screen.getByRole("listbox")).toBeInTheDocument()
-    const option3 = screen.getAllByRole("option")[2]
-    await userEvent.click(option3)
-    expect(toggle).toHaveTextContent("Option 3")
-  })
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("Option 2");
+    await userEvent.click(toggle);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    const option3 = screen.getAllByRole("option")[2];
+    await userEvent.click(option3);
+    expect(toggle).toHaveTextContent("Option 3");
+  });
 
   test("works when options are not passed a value prop but only children", async () => {
     render(
@@ -404,18 +412,30 @@ describe("Select", () => {
         <SelectOption>Option 4</SelectOption>
         <SelectOption>Option 5</SelectOption>
       </Select>
-    )
-    const toggle = screen.getByRole("button")
-    expect(toggle).toBeInTheDocument()
-    expect(toggle).toHaveTextContent("Select…")
-    await userEvent.click(toggle)
-    expect(screen.getByRole("listbox")).toBeInTheDocument()
-    const option3 = screen.getAllByRole("option")[2]
-    await userEvent.click(option3)
-    expect(toggle).toHaveTextContent("Option 3")
-    await userEvent.click(toggle)
-    const option1 = screen.getAllByRole("option")[0]
-    await userEvent.click(option1)
-    expect(toggle).toHaveTextContent("Option 1")
-  })
-})
+    );
+    const toggle = screen.getByRole("button");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("Select…");
+    await userEvent.click(toggle);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    const option3 = screen.getAllByRole("option")[2];
+    await userEvent.click(option3);
+    expect(toggle).toHaveTextContent("Option 3");
+    await userEvent.click(toggle);
+    const option1 = screen.getAllByRole("option")[0];
+    await userEvent.click(option1);
+    expect(toggle).toHaveTextContent("Option 1");
+  });
+});
+
+test("renders a wrapperClassName to the outer wrapping element", async () => {
+  render(
+    <Select wrapperClassName="my-wrapper-class">
+      <SelectOption>Option 1</SelectOption>
+    </Select>
+  );
+  expect(document.querySelector(".juno-select-wrapper ")).toBeInTheDocument();
+  expect(document.querySelector(".juno-select-wrapper ")).toHaveClass(
+    "my-wrapper-class"
+  );
+});

--- a/libs/juno-ui-components/src/components/Switch/Switch.component.js
+++ b/libs/juno-ui-components/src/components/Switch/Switch.component.js
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useMemo, useId } from "react"
-import PropTypes from "prop-types"
-import { Label } from "../Label/index"
-import { Icon } from "../Icon/index"
-import { FormHint } from "../FormHint/FormHint.component"
+import React, { useState, useEffect, useMemo, useId } from "react";
+import PropTypes from "prop-types";
+import { Label } from "../Label/index";
+import { Icon } from "../Icon/index";
+import { FormHint } from "../FormHint/FormHint.component";
 
 const switchWrapperStyles = `
 	jn-flex
 	jn-flex-row
 	jn-items-center
-`
+`;
 
 const switchbasestyles = `
 	jn-rounded-full
@@ -27,17 +27,17 @@ const switchbasestyles = `
 	focus:jn-ring-theme-focus
 	disabled:jn-opacity-50
 	disabled:jn-cursor-not-allowed
-`
+`;
 const switchsizestyles = (size) => {
-	switch (size) {
-		case "small":
-		  	return 'jn-w-[1.75rem] jn-h-4'
-		case "large":
-			return 'jn-w-[3.125rem] jn-h-[1.6875rem]'
-		default:
-		  	return 'jn-w-switch-default jn-h-switch-default'
-	  }
-}
+  switch (size) {
+    case "small":
+      return "jn-w-[1.75rem] jn-h-4";
+    case "large":
+      return "jn-w-[3.125rem] jn-h-[1.6875rem]";
+    default:
+      return "jn-w-switch-default jn-h-switch-default";
+  }
+};
 
 const handlebasestyles = `
 	jn-inline-block
@@ -46,46 +46,44 @@ const handlebasestyles = `
 	jn-rounded-full
 	jn-bg-theme-switch-handle
 	jn-border-theme-default
-`
+`;
 const handlesizestyles = (size) => {
-	switch (size) {
-		case "small":
-			return 'jn-w-[0.75rem] jn-h-[0.75rem]'
-		case "large":
-			return 'jn-w-[1.4375rem] jn-h-[1.4375rem]'
-		default: 
-			return 'jn-w-switch-handle-default jn-h-switch-handle-default'
-	}
-	
-	
-}
+  switch (size) {
+    case "small":
+      return "jn-w-[0.75rem] jn-h-[0.75rem]";
+    case "large":
+      return "jn-w-[1.4375rem] jn-h-[1.4375rem]";
+    default:
+      return "jn-w-switch-handle-default jn-h-switch-handle-default";
+  }
+};
 
 const defaultborderstyles = `
 	jn-border-theme-switch-default
-`
+`;
 
 const invalidbasestyles = `
 	jn-border-theme-error
-`
+`;
 
 const validbasestyles = `
 	jn-border-theme-success
-`
+`;
 
 const handleonstyles = `
 	jn-right-[1px] 
 	jn-bg-theme-switch-handle-checked
-`
+`;
 const handleoffstyles = `
 	jn-left-[1px]
-`
+`;
 
 const switchLabelStyles = `
 	jn-text-theme-high
 	jn-ml-2
 	disabled:jn-opacity-50
 	disabled:jn-cursor-not-allowed
-`
+`;
 
 const requiredStyles = `
 		jn-inline-block
@@ -96,202 +94,221 @@ const requiredStyles = `
 		jn-ml-1
 		jn-mt-1
 		jn-bg-theme-required
-`
+`;
 
 const iconstyles = `
 	jn-inline-block 
 	jn-ml-1 
 	jn-leading-1
 	jn-mt-[-.2rem]
-`
+`;
 
 const hintStyles = `
 	jn-mt-0
-`
+`;
 
 /** A Switch/Toggle component */
 export const Switch = ({
-	name,
-	id,
-	label,
-	required,
-	size,
-	on,
-	disabled,
-	invalid,
-	valid,
-	helptext,
-	errortext,
-	successtext,
-	className,
-	onChange,
-	onClick,
-	...props
+  className,
+  disabled,
+  errortext,
+  helptext,
+  id,
+  invalid,
+  label,
+  name,
+  on,
+  onChange,
+  onClick,
+  required,
+  size,
+  successtext,
+  valid,
+  wrapperClassName,
+  ...props
 }) => {
-	
-	const isNotEmptyString = (str) => {
-		return !(typeof str === 'string' && str.trim().length === 0)
-	}
-	
-	const uniqueId = () => (
-		"juno-switch-" + useId()
-	)
-	
-	const [isOn, setIsOn] = useState(on)
-	const [isInvalid, setIsInvalid] = useState(false)
-	const [isValid, setIsValid] = useState(false)
-	
-	useEffect(() => {
-		setIsOn(on)
-	  }, [on])
-		
-	const invalidated = useMemo(
-		() => invalid || (errortext && isNotEmptyString(errortext) ? true : false),
-		[invalid, errortext]
-	)
-	const validated = useMemo(
-		() => valid || (successtext && isNotEmptyString(successtext) ? true : false),
-		[valid, successtext]
-	)
-		
-	useEffect(() => {
-		setIsInvalid(invalidated)
-	}, [invalidated])
-	
-	useEffect(() => {
-		setIsValid(validated)
-	}, [validated])
-	
-	const handleClick = (event) => {
-		setIsOn(!isOn)
-		onClick && onClick(event)
-		onChange && onChange(event)
-	}
-	
-	const theId = id || uniqueId()
-	
-	return (
-		<div>
-			<span className={`
+  const isNotEmptyString = (str) => {
+    return !(typeof str === "string" && str.trim().length === 0);
+  };
+
+  const uniqueId = () => "juno-switch-" + useId();
+
+  const [isOn, setIsOn] = useState(on);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [isValid, setIsValid] = useState(false);
+
+  useEffect(() => {
+    setIsOn(on);
+  }, [on]);
+
+  const invalidated = useMemo(
+    () => invalid || (errortext && isNotEmptyString(errortext) ? true : false),
+    [invalid, errortext]
+  );
+  const validated = useMemo(
+    () =>
+      valid || (successtext && isNotEmptyString(successtext) ? true : false),
+    [valid, successtext]
+  );
+
+  useEffect(() => {
+    setIsInvalid(invalidated);
+  }, [invalidated]);
+
+  useEffect(() => {
+    setIsValid(validated);
+  }, [validated]);
+
+  const handleClick = (event) => {
+    setIsOn(!isOn);
+    onClick && onClick(event);
+    onChange && onChange(event);
+  };
+
+  const theId = id || uniqueId();
+
+  return (
+    <div>
+      <span
+        className={`
 				juno-switch-wrapper 
 				${switchWrapperStyles}
+        ${wrapperClassName}
 				`}
-			>
-				<button 
-					type="button"
-					role="switch"
-					name={name}
-					id={theId}
-					aria-checked={isOn}
-					disabled={disabled}
-					onClick={handleClick}
-					className={`
+      >
+        <button
+          type="button"
+          role="switch"
+          name={name}
+          id={theId}
+          aria-checked={isOn}
+          disabled={disabled}
+          onClick={handleClick}
+          className={`
 						juno-switch 
 						juno-switch-${size} 
 						${switchbasestyles} 
 						${switchsizestyles(size)} 
-						${ isInvalid ? "juno-switch-invalid " + invalidbasestyles : "" } 
-						${ isValid ? "juno-switch-valid " + validbasestyles : "" } 
-						${ isValid || isInvalid ? "" : defaultborderstyles } 
+						${isInvalid ? "juno-switch-invalid " + invalidbasestyles : ""} 
+						${isValid ? "juno-switch-valid " + validbasestyles : ""} 
+						${isValid || isInvalid ? "" : defaultborderstyles} 
 						${className}`}
-					{...props}
-				>
-					<span className={`juno-switch-handle ${handlebasestyles} ${handlesizestyles(size)} ${ isOn ? handleonstyles : handleoffstyles}`} ></span>
-				</button>
-				
-				<Label 
-					text={label}
-					htmlFor={theId}
-					className="jn-ml-2"
-					disabled={disabled}
-					required={required}
-				/>
-				
-				{isInvalid ? (
-					<Icon
-						icon="dangerous"
-						color="jn-text-theme-error"
-						size="1.125rem"
-						className={`${iconstyles} ${ disabled ? "jn-opacity-50" : "" }`}
-					/>
-				) : ""}
-				
-				{isValid ? (
-					<Icon
-						icon="checkCircle"
-						color="jn-text-theme-success"
-						size="1.125rem"
-						className={`${iconstyles} ${ disabled ? "jn-opacity-50" : "" }`}
-					/>
-				) : ""}
-				
-			</span>
-			{ errortext && isNotEmptyString(errortext) ?
-					<FormHint text={errortext} variant="error" className={`${hintStyles}`} />
-				:
-					""
-			}
-			{ successtext && isNotEmptyString(successtext) ?
-					<FormHint text={successtext} variant="success" className={`${hintStyles}`} />
-				:
-					""
-			}
-			{ helptext && isNotEmptyString(helptext) ?
-					<FormHint text={helptext} className={`${hintStyles}`} />
-				:
-					""
-			 }
-		</div>
-	)
-}
+          {...props}
+        >
+          <span
+            className={`juno-switch-handle ${handlebasestyles} ${handlesizestyles(
+              size
+            )} ${isOn ? handleonstyles : handleoffstyles}`}
+          ></span>
+        </button>
 
-Switch.propTypes = { 
-	/** Name attribute */
-	name: PropTypes.string,
-	/** Id */
-	id: PropTypes.string,
-	/** Add a label to the Switch */
-	label: PropTypes.string,
-	/** Whether the Switch is required */
-	required: PropTypes.bool,
-	/** Leave empty for default size */
-	size: PropTypes.oneOf(["small", "default", "large"]),
-	/**  Pass checked state for initial rendering. */
-	on: PropTypes.bool,
-	/** Disabled switch */
-	disabled: PropTypes.bool,
-	/** Whether the Switch is invalid */
-	invalid: PropTypes.bool,
-	/** Whether the Switch is valid */
-	valid: PropTypes.bool,
-	/** A helptext to render to explain meaning and significance of the Switch */
-	helptext: PropTypes.node,
-	/** A text to render when the Switch was successfully validated */
-	errortext: PropTypes.node,
-	/** A text to render when the Switch has an error or could not be validated */
-	successtext: PropTypes.node,
-	/** Pass a className */
-	className: PropTypes.string,
-	/** Pass a change handler */
-	onChange: PropTypes.func,
-	/** Pass a click handler */
-	onClick: PropTypes.func,
-}
+        <Label
+          text={label}
+          htmlFor={theId}
+          className="jn-ml-2"
+          disabled={disabled}
+          required={required}
+        />
+
+        {isInvalid ? (
+          <Icon
+            icon="dangerous"
+            color="jn-text-theme-error"
+            size="1.125rem"
+            className={`${iconstyles} ${disabled ? "jn-opacity-50" : ""}`}
+          />
+        ) : (
+          ""
+        )}
+
+        {isValid ? (
+          <Icon
+            icon="checkCircle"
+            color="jn-text-theme-success"
+            size="1.125rem"
+            className={`${iconstyles} ${disabled ? "jn-opacity-50" : ""}`}
+          />
+        ) : (
+          ""
+        )}
+      </span>
+      {errortext && isNotEmptyString(errortext) ? (
+        <FormHint
+          text={errortext}
+          variant="error"
+          className={`${hintStyles}`}
+        />
+      ) : (
+        ""
+      )}
+      {successtext && isNotEmptyString(successtext) ? (
+        <FormHint
+          text={successtext}
+          variant="success"
+          className={`${hintStyles}`}
+        />
+      ) : (
+        ""
+      )}
+      {helptext && isNotEmptyString(helptext) ? (
+        <FormHint text={helptext} className={`${hintStyles}`} />
+      ) : (
+        ""
+      )}
+    </div>
+  );
+};
+
+Switch.propTypes = {
+  /** Pass a className */
+  className: PropTypes.string,
+  /** Disabled switch */
+  disabled: PropTypes.bool,
+  /** A text to render when the Switch was successfully validated */
+  errortext: PropTypes.node,
+  /** A helptext to render to explain meaning and significance of the Switch */
+  helptext: PropTypes.node,
+  /** Id */
+  id: PropTypes.string,
+  /** Whether the Switch is invalid */
+  invalid: PropTypes.bool,
+  /** Add a label to the Switch */
+  label: PropTypes.string,
+  /** Name attribute */
+  name: PropTypes.string,
+  /**  Pass checked state for initial rendering. */
+  on: PropTypes.bool,
+  /** Pass a change handler */
+  onChange: PropTypes.func,
+  /** Pass a click handler */
+  onClick: PropTypes.func,
+  /** Whether the Switch is required */
+  required: PropTypes.bool,
+  /** Leave empty for default size */
+  size: PropTypes.oneOf(["small", "default", "large"]),
+  /** A text to render when the Switch has an error or could not be validated */
+  successtext: PropTypes.node,
+  /** Whether the Switch is valid */
+  valid: PropTypes.bool,
+  /** Pass a className to the outermost wrapper element */
+  wrapperClassName: PropTypes.string,
+};
 
 Switch.defaultProps = {
-	name: "",
-	id: null,
-	label: undefined,
-	required: false,
-	size: "default",
-	on: false,
-	disabled: null,
-	invalid: false,
-	valid: false,
-	helptext: "",
-	errortext: "",
-	successtext: "",
-	className: "",
-	onChange: undefined,
-	onClick: undefined,
-}
+  className: "",
+  disabled: null,
+  errortext: "",
+  helptext: "",
+  id: null,
+  invalid: false,
+  label: undefined,
+  name: "",
+  on: false,
+  onChange: undefined,
+  onClick: undefined,
+  required: false,
+  size: "default",
+  successtext: "",
+  valid: false,
+  wrapperClassName: "",
+};

--- a/libs/juno-ui-components/src/components/Switch/Switch.test.js
+++ b/libs/juno-ui-components/src/components/Switch/Switch.test.js
@@ -3,179 +3,201 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
-import { act } from 'react-dom/test-utils'
-import { Switch } from "./index"
+import * as React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+import { Switch } from "./index";
 
 describe("Switch", () => {
-  
   test("renders a switch button", async () => {
-  	render(<Switch />)
-  	expect(screen.getByRole("switch")).toBeInTheDocument()
-  })
-  
+    render(<Switch />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+  });
+
   test("renders a switch with a name as passed", async () => {
-    render(<Switch name="My Switch" />)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveAttribute('name', "My Switch")
-  })
-  
+    render(<Switch name="My Switch" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveAttribute("name", "My Switch");
+  });
+
   test("renders a switch with an id as passed", async () => {
-    render(<Switch id="my-switch" />)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveAttribute('id', "my-switch")
-  })
-  
+    render(<Switch id="my-switch" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveAttribute("id", "my-switch");
+  });
+
   test("renders a switch with an auto-generated id if no id is passed", async () => {
-    render(<Switch /> )
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveAttribute("id")
-    expect(screen.getByRole("switch").getAttribute("id")).toMatch("juno-switch")
-  })
-  
+    render(<Switch />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveAttribute("id");
+    expect(screen.getByRole("switch").getAttribute("id")).toMatch(
+      "juno-switch"
+    );
+  });
+
   test("renders a Switch with an associated label with an id as passed", async () => {
-    render(<Switch id="my-switch" label="My Switch"/>)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByLabelText("My Switch")).toBeInTheDocument()
-    expect(document.querySelector(".juno-label")).toBeInTheDocument()
-    expect(document.querySelector(".juno-label")).toHaveTextContent("My Switch")
-  })
-  
+    render(<Switch id="my-switch" label="My Switch" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByLabelText("My Switch")).toBeInTheDocument();
+    expect(document.querySelector(".juno-label")).toBeInTheDocument();
+    expect(document.querySelector(".juno-label")).toHaveTextContent(
+      "My Switch"
+    );
+  });
+
   test("renders a Switch with a label associated by an auto-generated id if no id was passed ", async () => {
-    render(<Switch label="This is a Switch" />)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByLabelText("This is a Switch")).toBeInTheDocument()
-  })
-  
+    render(<Switch label="This is a Switch" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByLabelText("This is a Switch")).toBeInTheDocument();
+  });
+
   test("renders a disabled switch as passed", async () => {
     act(() => {
-      render(<Switch disabled />)
-    })
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toBeDisabled()
-  })
-  
+      render(<Switch disabled />);
+    });
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toBeDisabled();
+  });
+
   test("renders an invalid Switch as passed", async () => {
     act(() => {
-      render(<Switch invalid />)
-    })
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveClass("juno-switch-invalid")
-    expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-  })
-  
+      render(<Switch invalid />);
+    });
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveClass("juno-switch-invalid");
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
+
   test("renders a valid Switch as passed", async () => {
     act(() => {
-      render(<Switch valid />)
-    })
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveClass("juno-switch-valid")
-    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-  })
-  
+      render(<Switch valid />);
+    });
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveClass("juno-switch-valid");
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
+
   test("renders a default size switch by default", async () => {
-    render(<Switch />)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveClass("juno-switch-default")
-  })
-  
+    render(<Switch />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveClass("juno-switch-default");
+  });
+
   test("renders a small switch as passed", async () => {
-    render(<Switch size="small" />)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveClass("juno-switch-small")
-  })
-  
+    render(<Switch size="small" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveClass("juno-switch-small");
+  });
+
   test("renders a large switch as passed", async () => {
-    render(<Switch size="large" />)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveClass("juno-switch-large")
-  })
-  
+    render(<Switch size="large" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveClass("juno-switch-large");
+  });
+
   test("renders an aria-checked switch as passed", async () => {
     act(() => {
-      render(<Switch on />)
-    })
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveAttribute('aria-checked')
-  })
-  
+      render(<Switch on />);
+    });
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked");
+  });
+
   test("renders an aria-checked attribute set to false if off", async () => {
-    render(<Switch />)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveAttribute('aria-checked', "false")
-  })
-  
+    render(<Switch />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+  });
+
   test("renders a helptext as passed", async () => {
-    render(<Switch helptext="this is a helptext"/>)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
-    expect(document.querySelector(".juno-form-hint")).toHaveClass("juno-form-hint-help")
-    expect(document.querySelector(".juno-form-hint")).toHaveTextContent("this is a helptext")
-  })
-  
+    render(<Switch helptext="this is a helptext" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
+    expect(document.querySelector(".juno-form-hint")).toHaveClass(
+      "juno-form-hint-help"
+    );
+    expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
+      "this is a helptext"
+    );
+  });
+
   test("renders a successtext as passed and validates the Element", async () => {
-    render(<Switch successtext="great success!" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
-    expect(document.querySelector(".juno-form-hint")).toHaveClass("juno-form-hint-success")
-    expect(document.querySelector(".juno-form-hint")).toHaveTextContent("great success!")
-    expect(screen.getByRole("switch")).toHaveClass("juno-switch-valid")
-  })
-  
+    render(<Switch successtext="great success!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
+    expect(document.querySelector(".juno-form-hint")).toHaveClass(
+      "juno-form-hint-success"
+    );
+    expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
+      "great success!"
+    );
+    expect(screen.getByRole("switch")).toHaveClass("juno-switch-valid");
+  });
+
   test("renders an errortext as passed and invalidates the Element", async () => {
-    render(<Switch errortext="this is an error!" />)
-    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
-    expect(document.querySelector(".juno-form-hint")).toHaveClass("juno-form-hint-error")
-    expect(document.querySelector(".juno-form-hint")).toHaveTextContent("this is an error!")
-    expect(screen.getByRole("switch")).toHaveClass("juno-switch-invalid")
-  })
-  
+    render(<Switch errortext="this is an error!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
+    expect(document.querySelector(".juno-form-hint")).toHaveClass(
+      "juno-form-hint-error"
+    );
+    expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
+      "this is an error!"
+    );
+    expect(screen.getByRole("switch")).toHaveClass("juno-switch-invalid");
+  });
+
+  test("renders a wrapperClassName to the outer wrapper element", async () => {
+    render(<Switch wrapperClassName="my-wrapper-class" />);
+    expect(document.querySelector(".juno-switch-wrapper")).toBeInTheDocument();
+    expect(document.querySelector(".juno-switch-wrapper")).toHaveClass(
+      "my-wrapper-class"
+    );
+  });
+
   test("renders a custom className", async () => {
-    render(<Switch className="my-custom-class" />)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveClass('my-custom-class')
-  })
-  
+    render(<Switch className="my-custom-class" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveClass("my-custom-class");
+  });
+
   test("renders all props as passed", async () => {
-    render(<Switch id="switch-1" data-test="23" />)
-    expect(screen.getByRole("switch")).toBeInTheDocument()
-    expect(screen.getByRole("switch")).toHaveAttribute('id', "switch-1")
-    expect(screen.getByRole("switch")).toHaveAttribute('data-test', "23")
-  })
-  
-  test("executes custom handler on change as passed", async () => {	
+    render(<Switch id="switch-1" data-test="23" />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveAttribute("id", "switch-1");
+    expect(screen.getByRole("switch")).toHaveAttribute("data-test", "23");
+  });
+
+  test("executes custom handler on change as passed", async () => {
     const onChangeSpy = jest.fn();
     render(<Switch onChange={onChangeSpy} />);
     act(() => {
-      screen.getByRole('switch').click();
-    })
-    expect(onChangeSpy).toHaveBeenCalled();	
-  })
-  
-  test("executes handler on click as passed", async () => {	
+      screen.getByRole("switch").click();
+    });
+    expect(onChangeSpy).toHaveBeenCalled();
+  });
+
+  test("executes handler on click as passed", async () => {
     const onClickSpy = jest.fn();
     render(<Switch onClick={onClickSpy} />);
     act(() => {
-      screen.getByRole('switch').click();
-    })
-    expect(onClickSpy).toHaveBeenCalled();	
-  })
-  
-  test("does not execute handler on change when disabled", async () => {	
-      const onChangeSpy = jest.fn();
-      render(<Switch onChange={onChangeSpy} disabled/>);
-      act(() => {
-        screen.getByRole('switch').click();
-      })
-      expect(onChangeSpy).not.toHaveBeenCalled();	
-    })
-    
-  test("does not execute handler on click when disabled", async () => {	
-    const onClickSpy = jest.fn();
-    render(<Switch onClick={onClickSpy} disabled/>);
-    act(() => {
-      screen.getByRole('switch').click();
-    })
-    expect(onClickSpy).not.toHaveBeenCalled();	
-  })
+      screen.getByRole("switch").click();
+    });
+    expect(onClickSpy).toHaveBeenCalled();
+  });
 
-})
+  test("does not execute handler on change when disabled", async () => {
+    const onChangeSpy = jest.fn();
+    render(<Switch onChange={onChangeSpy} disabled />);
+    act(() => {
+      screen.getByRole("switch").click();
+    });
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not execute handler on click when disabled", async () => {
+    const onClickSpy = jest.fn();
+    render(<Switch onClick={onClickSpy} disabled />);
+    act(() => {
+      screen.getByRole("switch").click();
+    });
+    expect(onClickSpy).not.toHaveBeenCalled();
+  });
+});

--- a/libs/juno-ui-components/src/components/TabList/TabList.component.js
+++ b/libs/juno-ui-components/src/components/TabList/TabList.component.js
@@ -3,71 +3,75 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react"
-import { TabList as ReactTabList } from "react-tabs"
-import { useTabsContext } from "../Tabs/Tabs.component.js"
-import PropTypes from "prop-types"
+import React from "react";
+import { TabList as ReactTabList } from "react-tabs";
+import { useTabsContext } from "../Tabs/Tabs.component.js";
+import PropTypes from "prop-types";
 
 const tabListStyles = `
 	jn-flex
 	jn-h-[3.4375rem]
-`
+`;
 // focus-within:ring-1
 // focus-within:ring-theme-focus
 // focus-within:ring-inset
 
 const getVariantStyles = (variant) => {
-	switch (variant) {
-		case "main": 
-			return `jn-bg-theme-tab-navigation-top`
-		case "codeblocks":
-			return `
+  switch (variant) {
+    case "main":
+      return `jn-bg-theme-tab-navigation-top`;
+    case "codeblocks":
+      return `
 				jn-text-sm
 				jn-bg-theme-code-block
 				jn-border-b-[1px]
 				jn-border-theme-codeblock-bar 
-			`
-		default: 
-			return `
+			`;
+    default:
+      return `
 				jn-border-b-[1px] 
 				jn-border-theme-tab-navigation-content-bottom
-			`
-	}
-}
+			`;
+  }
+};
 
-/** A tabList component wraps all individual Tabs inside a parent Tabs component */
+/** A tabList component wraps all individual Tabs inside a parent Tabs component. Only functional and interactive in the context of a Tabs component. */
 
-const TabList = ({
-	variant,
-	children,
-	...props
-}) => {
-	
-	const tabsContext = useTabsContext() || {}
-	const tabsVariant = tabsContext.variant || variant
-	
-	return (
-		<ReactTabList 
-			className={`juno-tablist juno-tablist-${tabsVariant} ${tabListStyles} ${getVariantStyles(tabsVariant)}`}
-			{...props} >
-				{children}
-		</ReactTabList>
-	)
-}
+const TabList = ({ variant, children, className, ...props }) => {
+  const tabsContext = useTabsContext() || {};
+  const tabsVariant = tabsContext.variant || variant;
 
-TabList.tabsRole = 'TabList'
+  return (
+    <ReactTabList
+      className={`
+				juno-tablist 
+				juno-tablist-${tabsVariant} 
+				${tabListStyles} 
+				${getVariantStyles(tabsVariant)}
+				${className}
+			`}
+      {...props}
+    >
+      {children}
+    </ReactTabList>
+  );
+};
+
+TabList.tabsRole = "TabList";
 
 TabList.propTypes = {
-	/** Pick the TabList style */
-	variant: PropTypes.oneOf(["main", "content", "codeblocks"]),
-	/** The individual child Tabs to render */
-	children: PropTypes.node,
-}
+  /** Pick the TabList style */
+  variant: PropTypes.oneOf(["main", "content", "codeblocks"]),
+  /** The individual child Tabs to render */
+  children: PropTypes.node,
+  /** Pass a custom className */
+  className: PropTypes.string,
+};
 
 TabList.defaultProps = {
-	variant: "content",
-	children: null,
-}
+  variant: "content",
+  children: null,
+  className: "",
+};
 
-export { TabList }
-
+export { TabList };

--- a/libs/juno-ui-components/src/components/TextInput/TextInput.component.js
+++ b/libs/juno-ui-components/src/components/TextInput/TextInput.component.js
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useMemo, useId, useRef } from "react"
-import PropTypes from "prop-types"
-import { Label } from "../Label/index"
-import { Icon } from "../Icon/index"
-import { FormHint } from "../FormHint/FormHint.component"
-import "./textinput.scss"
+import React, { useState, useEffect, useMemo, useId, useRef } from "react";
+import PropTypes from "prop-types";
+import { Label } from "../Label/index";
+import { Icon } from "../Icon/index";
+import { FormHint } from "../FormHint/FormHint.component";
+import "./textinput.scss";
 
 const textinputstyles = `
 	jn-bg-theme-textinput
@@ -26,149 +26,148 @@ const textinputstyles = `
   autofill:jn-bg-theme-textinput-autofill
   autofill:jn-text-theme-textinput-autofill
   peer
-`
+`;
 
 const defaultborderstyles = `
 	jn-border-theme-textinput-default
-`
+`;
 
 const invalidstyles = `
 	jn-border-theme-error
-`
+`;
 
 const validstyles = `
 	jn-border-theme-success
-`
+`;
 
 const withLabelStyles = `
   jn-pt-[1.125rem] 
   jn-pb-1
-`
+`;
 
 const noLabelStyles = `
   jn-py-4
-`
+`;
 
 const wrapperStyles = `
   jn-inline-block
   jn-relative
-`
+`;
 
 const labelStyles = `
   peer-autofill:jn-text-theme-textinput-autofill-label
   jn-pointer-events-none
   jn-top-2
   jn-left-[0.9375rem]
-`
+`;
 
 const iconcontainerstyles = `
   jn-inline-flex
   jn-absolute
   jn-top-[.4rem]
   jn-right-3
-`
+`;
 
 const disablediconstyles = `
   jn-opacity-50
-`
+`;
 
 const iconstyles = `
   jn-inline-block 
   jn-ml-1 
   jn-leading-1
   jn-mt-[-.2rem]
-`
+`;
 
 const hintStyles = `
   jn-mt-0
-`
+`;
 
 /** 
 A controlled Text Input.
 Also covers email, telephone, password, url derivates. 
 */
 export const TextInput = ({
-  name,
-  value,
-  id,
-  type,
-  placeholder,
-  disabled,
-  readOnly,
-  required,
-  invalid,
-  valid,
+  autoComplete,
   autoFocus,
   className,
-  label,
-  helptext,
-  successtext,
+  disabled,
   errortext,
-  autoComplete,
-  width,
+  id,
+  invalid,
+  helptext,
+  label,
+  name,
   onChange,
   onFocus,
   onBlur,
+  placeholder,
+  readOnly,
+  required,
+  successtext,
+  type,
+  valid,
+  value,
+  width,
+  wrapperClassName,
   ...props
 }) => {
-  
   const isNotEmptyString = (str) => {
-    return !(typeof str === 'string' && str.trim().length === 0)
-  }
-  
-  const uniqueId = () => (
-    "juno-textinput-" + useId()
-  )
-  
-  const ref = useRef()
-  const [val, setValue] = useState("")
-  const [hasFocus, setFocus] = useState(false)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
-  
+    return !(typeof str === "string" && str.trim().length === 0);
+  };
+
+  const uniqueId = () => "juno-textinput-" + useId();
+
+  const ref = useRef();
+  const [val, setValue] = useState("");
+  const [hasFocus, setFocus] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [isValid, setIsValid] = useState(false);
+
   /* Set the focus state variable in case the input was focussed by passing autoFocus, or when the input was rendered and focussed by the user before React started listening to client side events, e.g. when rendering server-side: */
   useEffect(() => {
     if (document.hasFocus() && ref.current.contains(document.activeElement)) {
       setFocus(true);
     }
-  }, [])
-  
+  }, []);
+
   useEffect(() => {
-    setValue(value)
-  }, [value])
+    setValue(value);
+  }, [value]);
 
   const invalidated = useMemo(
     () => invalid || (errortext && isNotEmptyString(errortext) ? true : false),
     [invalid, errortext]
-  )
+  );
   const validated = useMemo(
-    () => valid || (successtext && isNotEmptyString(successtext) ? true : false),
+    () =>
+      valid || (successtext && isNotEmptyString(successtext) ? true : false),
     [valid, successtext]
-  )
-  
+  );
+
   useEffect(() => {
-    setIsInvalid(invalidated)
-  }, [invalidated])
-  
+    setIsInvalid(invalidated);
+  }, [invalidated]);
+
   useEffect(() => {
-    setIsValid(validated)
-  }, [validated])
+    setIsValid(validated);
+  }, [validated]);
 
   const handleValueChange = (event) => {
-    setValue(event.target.value)
-    onChange && onChange(event)
-  }
-  
+    setValue(event.target.value);
+    onChange && onChange(event);
+  };
+
   const handleFocus = (event) => {
-    setFocus(true)
-    onFocus && onFocus(event)
-  }
-  
+    setFocus(true);
+    onFocus && onFocus(event);
+  };
+
   const handleBlur = (event) => {
-    setFocus(false)
-    onBlur && onBlur(event)
-  }
-  
+    setFocus(false);
+    onBlur && onBlur(event);
+  };
+
   const Icons = ({ disabled }) => {
     if (isValid || isInvalid) {
       return (
@@ -184,24 +183,29 @@ export const TextInput = ({
             <Icon icon="checkCircle" color="jn-text-theme-success" />
           ) : null}
         </div>
-      )
+      );
     } else {
-      return ""
+      return "";
     }
-  }
-  
-  const theId = id || uniqueId()
-  
+  };
+
+  const theId = id || uniqueId();
+
   return (
-    <div>
-      <span 
+    <div
+      className={`
+      juno-textinput-wrapper-outer
+      ${wrapperClassName}
+    `}
+    >
+      <span
         className={`
           juno-textinput-wrapper 
           ${wrapperStyles}
-          ${ width == "auto" ? "jn-inline-block" : "jn-block" }
-          ${ width == "auto" ? "jn-w-auto" : "jn-w-full" }
-          `} 
-        >
+          ${width == "auto" ? "jn-inline-block" : "jn-block"}
+          ${width == "auto" ? "jn-w-auto" : "jn-w-full"}
+          `}
+      >
         <input
           type={type}
           name={name}
@@ -216,116 +220,129 @@ export const TextInput = ({
           onChange={handleValueChange}
           onFocus={handleFocus}
           onBlur={handleBlur}
-          className={
-            `juno-textinput 
-            ${ textinputstyles }
-            ${ label ? withLabelStyles : noLabelStyles }
-            ${ isInvalid ? "juno-textinput-invalid " + invalidstyles : "" } 
-            ${ isValid ? "juno-textinput-valid " + validstyles : "" }  
-            ${ isValid || isInvalid ? "" : defaultborderstyles } 
-            ${ width == "auto" ? "jn-w-auto" : "jn-w-full" }
-            ${ className }
+          className={`juno-textinput 
+            ${textinputstyles}
+            ${label ? withLabelStyles : noLabelStyles}
+            ${isInvalid ? "juno-textinput-invalid " + invalidstyles : ""} 
+            ${isValid ? "juno-textinput-valid " + validstyles : ""}  
+            ${isValid || isInvalid ? "" : defaultborderstyles} 
+            ${width == "auto" ? "jn-w-auto" : "jn-w-full"}
+            ${className}
           `}
           {...props}
         />
-        { label && label.length ?
-            <Label 
-              text={label}
-              htmlFor={theId}
-              className={`${labelStyles}`}
-              disabled={disabled}
-              required={required}
-              floating
-              minimized={ placeholder || hasFocus || val && val.length ? true : false}
-            />
-          :
-            ""
-        }
+        {label && label.length ? (
+          <Label
+            text={label}
+            htmlFor={theId}
+            className={`${labelStyles}`}
+            disabled={disabled}
+            required={required}
+            floating
+            minimized={
+              placeholder || hasFocus || (val && val.length) ? true : false
+            }
+          />
+        ) : (
+          ""
+        )}
         <Icons disabled={disabled} />
       </span>
-      { errortext && isNotEmptyString(errortext) ?
-          <FormHint text={errortext} variant="error" className={`${hintStyles}`} />
-        :
-          ""
-      }
-      { successtext && isNotEmptyString(successtext) ?
-          <FormHint text={successtext} variant="success" className={`${hintStyles}`} />
-        :
-          ""
-      }
-      { helptext && isNotEmptyString(helptext) ?
-          <FormHint text={helptext} className={`${hintStyles}`} />
-        :
-          ""
-       }
+      {errortext && isNotEmptyString(errortext) ? (
+        <FormHint
+          text={errortext}
+          variant="error"
+          className={`${hintStyles}`}
+        />
+      ) : (
+        ""
+      )}
+      {successtext && isNotEmptyString(successtext) ? (
+        <FormHint
+          text={successtext}
+          variant="success"
+          className={`${hintStyles}`}
+        />
+      ) : (
+        ""
+      )}
+      {helptext && isNotEmptyString(helptext) ? (
+        <FormHint text={helptext} className={`${hintStyles}`} />
+      ) : (
+        ""
+      )}
     </div>
-  )
-}
+  );
+};
 
 TextInput.propTypes = {
-  /** Pass a name attribute */
-  name: PropTypes.string,
-  /** Pass a value */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Pass an id */
-  id: PropTypes.string,
-  /** Pass a placeholder */
-  placeholder: PropTypes.string,
-  /** Render a disabled input */
-  disabled: PropTypes.bool,
-  /** Render a readonly input */
-  readOnly: PropTypes.bool,
-  /** Whether the field is required */
-  required: PropTypes.bool,
-  /** Whether the field is invalid */
-  invalid: PropTypes.bool,
-  /** Whether the field is valid */
-  valid: PropTypes.bool,
-  /** Whether the field receives autofocus */
-  autoFocus: PropTypes.bool,
-  /** Pass a classname */
-  className: PropTypes.string,
   /** Pass a valid autocomplete value. We do not police validity. */
   autoComplete: PropTypes.string,
+  /** Whether the field receives autofocus */
+  autoFocus: PropTypes.bool,
+  /** Pass a classname to the input element */
+  className: PropTypes.string,
+  /** Render a disabled input */
+  disabled: PropTypes.bool,
+  /** A text to render when the TextInput has an error or could not be validated */
+  errortext: PropTypes.node,
+  /** A helptext to render to explain meaning and significance of the TextInput */
+  helptext: PropTypes.node,
+  /** Pass an id to the input element */
+  id: PropTypes.string,
+  /** Whether the field is invalid */
+  invalid: PropTypes.bool,
+  /** The label of the input */
+  label: PropTypes.string,
+  /** Pass a name attribute for the input element */
+  name: PropTypes.string,
+  /** Pass a blur handler */
+  onBlur: PropTypes.func,
   /** Pass a change handler */
   onChange: PropTypes.func,
   /** Pass a focus handler */
   onFocus: PropTypes.func,
-  /** Pass a blur handler */
-  onBlur: PropTypes.func,
-  /** Specify the type attribute. Defaults to an input with no type attribute, which in turn will be treateas as type="text" by browsers. */
-  type: PropTypes.oneOf(["text", "email", "password", "tel", "url", "number"]),
-  /** The label of the input */
-  label: PropTypes.string,
-  /** A helptext to render to explain meaning and significance of the TextInput */
-  helptext: PropTypes.node,
+  /** Pass a placeholder */
+  placeholder: PropTypes.string,
+  /** Render a readonly input */
+  readOnly: PropTypes.bool,
+  /** Whether the field is required */
+  required: PropTypes.bool,
   /** A text to render when the TextInput was successfully validated */
   successtext: PropTypes.node,
-  /** A text to render when the TextInput has an error or could not be validated */
-  errortext: PropTypes.node,
+  /** Specify the type attribute. Defaults to an input with no type attribute, which in turn will be treateas as type="text" by browsers. */
+  type: PropTypes.oneOf(["text", "email", "password", "tel", "url", "number"]),
+  /** Whether the field is valid */
+  valid: PropTypes.bool,
+  /** Pass a value */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** The width of the text input. Either 'full' (default) or 'auto'. */
   width: PropTypes.oneOf(["full", "auto"]),
-}
+  /** Pass a className to the outer wrapper <div> element. */
+  wrapperClassName: PropTypes.string,
+};
 
 TextInput.defaultProps = {
-  value: "",
-  id: "",
-  placeholder: "",
-  disabled: false,
-  readOnly: false,
-  required: false,
-  invalid: false,
-  valid: false,
+  autoComplete: "off",
   autoFocus: false,
   className: "",
-  autoComplete: "off",
-  helptext: "",
-  successtext: "",
+  disabled: false,
   errortext: "",
+  helptext: "",
+  id: "",
+  invalid: false,
+  label: undefined,
+  name: undefined,
+  onBlur: undefined,
   onChange: undefined,
   onFocus: undefined,
-  onBlur: undefined,
+  placeholder: "",
+  readOnly: false,
+  required: false,
+  successtext: "",
   type: null,
-  label: undefined,
+  valid: false,
+  value: "",
   width: "full",
-}
+  wrapperClassName: "",
+};

--- a/libs/juno-ui-components/src/components/TextInput/TextInput.stories.js
+++ b/libs/juno-ui-components/src/components/TextInput/TextInput.stories.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { TextInput } from './index.js';
+import React from "react";
+import { TextInput } from "./index.js";
 
 export default {
-  title: 'Forms/TextInput',
+  title: "Forms/TextInput",
   component: TextInput,
   argTypes: {
     errortext: {
@@ -28,13 +28,13 @@ export const Default = {
 
 export const WithLabel = {
   args: {
-    label: 'Text Input',
+    label: "Text Input",
   },
 };
 
 export const RequiredWithLabel = {
   args: {
-    label: 'Required Text Input',
+    label: "Required Text Input",
     required: true,
   },
 };
@@ -66,42 +66,43 @@ export const Disabled = {
 export const ReadOnly = {
   args: {
     readOnly: true,
+    value: "Readonly, can not be edited.",
   },
 };
 
 export const Email = {
   args: {
-    type: 'email',
+    type: "email",
   },
 };
 
 export const Tel = {
   args: {
-    type: 'tel',
+    type: "tel",
   },
 };
 
 export const Url = {
   args: {
-    type: 'url',
+    type: "url",
   },
 };
 
 export const Number = {
   args: {
-    type: 'number',
+    type: "number",
   },
 };
 
 export const Password = {
   args: {
-    type: 'password',
+    type: "password",
   },
 };
 
 export const WithHelpText = {
   args: {
-    helptext: 'This is an explanatory text referring to the input',
+    helptext: "This is an explanatory text referring to the input",
   },
 };
 
@@ -117,12 +118,12 @@ export const WithHelpTextAsNode = {
 
 export const WithSuccessText = {
   args: {
-    successtext: 'This field is a great success!',
+    successtext: "This field is a great success!",
   },
 };
 
 export const WithErrorText = {
   args: {
-    errortext: 'This field has an error',
+    errortext: "This field has an error",
   },
 };

--- a/libs/juno-ui-components/src/components/TextInput/TextInput.test.js
+++ b/libs/juno-ui-components/src/components/TextInput/TextInput.test.js
@@ -3,185 +3,212 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
-import { TextInput } from "./index"
-
+import * as React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TextInput } from "./index";
 
 describe("TextInput", () => {
-	
-	test("renders a html default text input with no type attribute", async () => {
-		render(<TextInput />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).not.toHaveAttribute('type')
-	})
-	
-	test("renders a text input with a name as passed", async () => {
-		render(<TextInput name="My TextInput" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('name', "My TextInput")
-	})
-	
-	test("renders a text input with a value as passed", async () => {
-		render(<TextInput value="Some kind of value" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('value', "Some kind of value")
-	})
-	
-	test("renders a label as passed", async () => {
-		render(<TextInput label="The Label" id="my-textinput"/>)
-		expect(document.querySelector(".juno-label")).toBeInTheDocument()
-		expect(document.querySelector(".juno-label")).toHaveTextContent("The Label")
-	})
-	
-	test("renders a text input with an id as passed", async () => {
-		render(<TextInput id="my-textinput" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('id', "my-textinput")
-	})
-	
-	test("renders a text input with an auto-generated id if no id is passed", async () => {
-		render(<TextInput />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute("id")
-		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("juno-textinput")
-	})
-	
-	test("renders a text input with a label associated by an id as passed", async () => {
-		render(<TextInput label="TextInput goes here" id="ti-1"/>)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute("id")
-		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("ti-1")
-		expect(screen.getByLabelText("TextInput goes here")).toBeInTheDocument()
-	})
-	
-	test("renders a text input with a label associated by an auto-generated id if no id was passed ", async () => {
-		render(<TextInput label="This is a TextInput" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByLabelText("This is a TextInput")).toBeInTheDocument()
-	})
-	
-	test("renders a placeholder as passed", async () => {
-		render(<TextInput placeholder="my placeholder" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('placeholder', "my placeholder")
-	})
-	
-	// resort to using a testId since <input type=""password" has no accessible wai-aria role:
-	test("renders a password input as passed", async () => {
-		render(<TextInput type="password" data-testid="pw"/>)
-		expect(screen.getByTestId("pw")).toBeInTheDocument()
-		expect(screen.getByTestId("pw")).toHaveAttribute('type', "password")
-	})
-	
-	test("renders an email input as passed", async () => {
-		render(<TextInput type="email" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('type', "email")
-	})
-	
-	test("renders a telephone number input as passed", async () => {
-		render(<TextInput type="tel" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('type', "tel")
-	})
-	
-	test("renders an url input as passed", async () => {
-		render(<TextInput type="url" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('type', "url")
-	})
-	
-	test("renders a number input as passed", async () => {
-		render(<TextInput type="number" />)
-		expect(screen.getByRole("spinbutton")).toBeInTheDocument()
-		expect(screen.getByRole("spinbutton")).toHaveAttribute('type', "number")
-	})
-	
-	test("renders a disabled input as passed", async () => {
-		render(<TextInput disabled />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toBeDisabled()
-	})
-	
-	test("renders a readonly input as passed", async () => {
-		render(<TextInput readOnly />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('readonly')
-	})
-	
-	test("renders a focussed input as passed", async () => {
-		render(<TextInput autoFocus />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveFocus()
-	})
-	
-	test("renders an invalid input as passed", async () => {
-		render(<TextInput invalid />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveClass("juno-textinput-invalid")
-		expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-	})
-	
-	test("renders a valid input as passed", async () => {
-		render(<TextInput valid />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveClass("juno-textinput-valid")
-		expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-	})
-	
-	test("renders a helptext as passed", async () => {
-		render(<TextInput helptext="this is a helptext"/>)
-		expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
-		expect(document.querySelector(".juno-form-hint")).toHaveClass("juno-form-hint-help")
-		expect(document.querySelector(".juno-form-hint")).toHaveTextContent("this is a helptext")
-	})
-	
-	test("renders a successtext as passed and validates the Element", async () => {
-		render(<TextInput successtext="great success!" />)
-		expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
-		expect(document.querySelector(".juno-form-hint")).toHaveClass("juno-form-hint-success")
-		expect(document.querySelector(".juno-form-hint")).toHaveTextContent("great success!")
-		expect(screen.getByRole("textbox")).toHaveClass("juno-textinput-valid")
-	})
-	
-	test("renders an errortext as passed and invalidates the Element", async () => {
-		render(<TextInput errortext="this is an error!" />)
-		expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
-		expect(document.querySelector(".juno-form-hint")).toHaveClass("juno-form-hint-error")
-		expect(document.querySelector(".juno-form-hint")).toHaveTextContent("this is an error!")
-		expect(screen.getByRole("textbox")).toHaveClass("juno-textinput-invalid")
-	})
+  test("renders a html default text input with no type attribute", async () => {
+    render(<TextInput />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).not.toHaveAttribute("type");
+  });
 
-	test("fires onChange handler as passed", async () => {
-		const handleChange = jest.fn()
-		const { container } = render(
-			<TextInput onChange={handleChange} data-testid="my-input"/>
-		)
-		const textinput = screen.getByRole("textbox")
-		fireEvent.change(textinput, { target: { value: 'a' } })
-		expect(handleChange).toHaveBeenCalledTimes(1)
-	})
-	
-	test("does not fire onChange handler when disabled", async () => {
-		const onChangeSpy = jest.fn();
-		const { container } = render(
-				<TextInput onChange={onChangeSpy} disabled />
-			)
-		screen.getByRole('textbox').click();
-		expect(onChangeSpy).not.toHaveBeenCalled();	
-	})
-	
-	test("renders a className as passed", async () => {
-		render(<TextInput className="my-custom-class" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveClass("my-custom-class")
-	})
-	
-	test("renders other props as passed", async () => {
-		render(<TextInput data-lolol="527" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('data-lolol', "527")
-	})
-	
-})
+  test("renders a text input with a name as passed", async () => {
+    render(<TextInput name="My TextInput" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("name", "My TextInput");
+  });
+
+  test("renders a text input with a value as passed", async () => {
+    render(<TextInput value="Some kind of value" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "value",
+      "Some kind of value"
+    );
+  });
+
+  test("renders a label as passed", async () => {
+    render(<TextInput label="The Label" id="my-textinput" />);
+    expect(document.querySelector(".juno-label")).toBeInTheDocument();
+    expect(document.querySelector(".juno-label")).toHaveTextContent(
+      "The Label"
+    );
+  });
+
+  test("renders a text input with an id as passed", async () => {
+    render(<TextInput id="my-textinput" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("id", "my-textinput");
+  });
+
+  test("renders a text input with an auto-generated id if no id is passed", async () => {
+    render(<TextInput />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("id");
+    expect(screen.getByRole("textbox").getAttribute("id")).toMatch(
+      "juno-textinput"
+    );
+  });
+
+  test("renders a text input with a label associated by an id as passed", async () => {
+    render(<TextInput label="TextInput goes here" id="ti-1" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("id");
+    expect(screen.getByRole("textbox").getAttribute("id")).toMatch("ti-1");
+    expect(screen.getByLabelText("TextInput goes here")).toBeInTheDocument();
+  });
+
+  test("renders a text input with a label associated by an auto-generated id if no id was passed ", async () => {
+    render(<TextInput label="This is a TextInput" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByLabelText("This is a TextInput")).toBeInTheDocument();
+  });
+
+  test("renders a placeholder as passed", async () => {
+    render(<TextInput placeholder="my placeholder" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "placeholder",
+      "my placeholder"
+    );
+  });
+
+  // resort to using a testId since <input type=""password" has no accessible wai-aria role:
+  test("renders a password input as passed", async () => {
+    render(<TextInput type="password" data-testid="pw" />);
+    expect(screen.getByTestId("pw")).toBeInTheDocument();
+    expect(screen.getByTestId("pw")).toHaveAttribute("type", "password");
+  });
+
+  test("renders an email input as passed", async () => {
+    render(<TextInput type="email" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("type", "email");
+  });
+
+  test("renders a telephone number input as passed", async () => {
+    render(<TextInput type="tel" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("type", "tel");
+  });
+
+  test("renders an url input as passed", async () => {
+    render(<TextInput type="url" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("type", "url");
+  });
+
+  test("renders a number input as passed", async () => {
+    render(<TextInput type="number" />);
+    expect(screen.getByRole("spinbutton")).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton")).toHaveAttribute("type", "number");
+  });
+
+  test("renders a disabled input as passed", async () => {
+    render(<TextInput disabled />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+
+  test("renders a readonly input as passed", async () => {
+    render(<TextInput readOnly />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("readonly");
+  });
+
+  test("renders a focussed input as passed", async () => {
+    render(<TextInput autoFocus />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveFocus();
+  });
+
+  test("renders an invalid input as passed", async () => {
+    render(<TextInput invalid />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveClass("juno-textinput-invalid");
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
+
+  test("renders a valid input as passed", async () => {
+    render(<TextInput valid />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveClass("juno-textinput-valid");
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
+
+  test("renders a helptext as passed", async () => {
+    render(<TextInput helptext="this is a helptext" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
+    expect(document.querySelector(".juno-form-hint")).toHaveClass(
+      "juno-form-hint-help"
+    );
+    expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
+      "this is a helptext"
+    );
+  });
+
+  test("renders a successtext as passed and validates the Element", async () => {
+    render(<TextInput successtext="great success!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
+    expect(document.querySelector(".juno-form-hint")).toHaveClass(
+      "juno-form-hint-success"
+    );
+    expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
+      "great success!"
+    );
+    expect(screen.getByRole("textbox")).toHaveClass("juno-textinput-valid");
+  });
+
+  test("renders an errortext as passed and invalidates the Element", async () => {
+    render(<TextInput errortext="this is an error!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
+    expect(document.querySelector(".juno-form-hint")).toHaveClass(
+      "juno-form-hint-error"
+    );
+    expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
+      "this is an error!"
+    );
+    expect(screen.getByRole("textbox")).toHaveClass("juno-textinput-invalid");
+  });
+
+  test("fires onChange handler as passed", async () => {
+    const handleChange = jest.fn();
+    const { container } = render(
+      <TextInput onChange={handleChange} data-testid="my-input" />
+    );
+    const textinput = screen.getByRole("textbox");
+    fireEvent.change(textinput, { target: { value: "a" } });
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fire onChange handler when disabled", async () => {
+    const onChangeSpy = jest.fn();
+    const { container } = render(<TextInput onChange={onChangeSpy} disabled />);
+    screen.getByRole("textbox").click();
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  test("renders a className as passed", async () => {
+    render(<TextInput className="my-custom-class" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveClass("my-custom-class");
+  });
+
+  test("renders a wrapperClassName to the outer wrapper element", async () => {
+    render(<TextInput wrapperClassName="my-wrapper-class" />);
+    expect(
+      document.querySelector(".juno-textinput-wrapper-outer")
+    ).toBeInTheDocument();
+    expect(document.querySelector(".juno-textinput-wrapper-outer")).toHaveClass(
+      "my-wrapper-class"
+    );
+  });
+
+  test("renders other props as passed", async () => {
+    render(<TextInput data-lolol="527" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("data-lolol", "527");
+  });
+});

--- a/libs/juno-ui-components/src/components/Textarea/Textarea.component.js
+++ b/libs/juno-ui-components/src/components/Textarea/Textarea.component.js
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useMemo, useId, useRef } from "react"
-import PropTypes from "prop-types"
-import { Label } from "../Label/index"
-import { Icon } from "../Icon/index"
-import { FormHint } from "../FormHint/FormHint.component"
+import React, { useState, useEffect, useMemo, useId, useRef } from "react";
+import PropTypes from "prop-types";
+import { Label } from "../Label/index";
+import { Icon } from "../Icon/index";
+import { FormHint } from "../FormHint/FormHint.component";
 
 const wrapperStyles = `
   jn-inline-block
   jn-relative
-`
+`;
 
 const textareastyles = `
   jn-bg-theme-textinput
@@ -27,28 +27,28 @@ const textareastyles = `
   focus:jn-ring-theme-focus
   disabled:jn-opacity-50
   disabled:jn-cursor-not-allowed
-`
+`;
 
 const defaultborderstyles = `
   jn-border-theme-textinput-default
-`
+`;
 
 const invalidstyles = `
   jn-border-theme-error
-`
+`;
 
 const validstyles = `
   jn-border-theme-success
-`
+`;
 
 const withLabelStyles = `
   jn-pt-[1.125rem] 
   jn-pb-1
-`
+`;
 
 const noLabelStyles = `
   jn-py-4
-`
+`;
 
 const labelStyles = `
   jn-pointer-events-none
@@ -56,115 +56,114 @@ const labelStyles = `
   jn-left-[0.9375rem]
   jn-pr-4
   jn-bg-theme-textinput
-`
+`;
 
 const iconcontainerstyles = `
   jn-inline-flex
   jn-absolute
   jn-top-[.4rem]
   jn-right-3
-`
+`;
 
 const disablediconstyles = `
   jn-opacity-50
-`
+`;
 
 const iconstyles = `
   jn-inline-block 
   jn-ml-1 
   jn-leading-1
   jn-mt-[-.2rem]
-`
+`;
 const hintStyles = `
   jn-mt-0
-`
+`;
 
 /** 
 A controlled Text Input.
 Also covers email, telephone, password, url derivates. 
 */
 export const Textarea = ({
-  name,
-  value,
-  id,
-  type,
-  placeholder,
-  disabled,
-  readOnly,
-  required,
-  invalid,
-  valid,
+  autoComplete,
   autoFocus,
   className,
-  label,
-  helptext,
-  successtext,
+  disabled,
   errortext,
-  autoComplete,
-  width,
+  helptext,
+  id,
+  invalid,
+  label,
+  name,
+  onBlur,
   onChange,
   onFocus,
-  onBlur,
+  placeholder,
+  readOnly,
+  required,
+  successtext,
+  type,
+  valid,
+  value,
+  width,
+  wrapperClassName,
   ...props
 }) => {
-  
   const isNotEmptyString = (str) => {
-    return !(typeof str === 'string' && str.trim().length === 0)
-  }
-  
-  const uniqueId = () => (
-    "juno-textarea-" + useId()
-  )
-  
-  const ref = useRef()
-  const [val, setValue] = useState("")
-  const [hasFocus, setFocus] = useState(false)
-  const [isInvalid, setIsInvalid] = useState(false)
-  const [isValid, setIsValid] = useState(false)
-  
+    return !(typeof str === "string" && str.trim().length === 0);
+  };
+
+  const uniqueId = () => "juno-textarea-" + useId();
+
+  const ref = useRef();
+  const [val, setValue] = useState("");
+  const [hasFocus, setFocus] = useState(false);
+  const [isInvalid, setIsInvalid] = useState(false);
+  const [isValid, setIsValid] = useState(false);
+
   /* Set the focus state variable in case the input was focussed by passing autoFocus, or when the input was rendered and focussed by the user before React started listening to client side events, e.g. when rendering server-side: */
   useEffect(() => {
     if (document.hasFocus() && ref.current.contains(document.activeElement)) {
       setFocus(true);
     }
-  }, [])
-  
+  }, []);
+
   useEffect(() => {
-    setValue(value)
-  }, [value])
-  
+    setValue(value);
+  }, [value]);
+
   const invalidated = useMemo(
     () => invalid || (errortext && isNotEmptyString(errortext) ? true : false),
     [invalid, errortext]
-  )
+  );
   const validated = useMemo(
-    () => valid || (successtext && isNotEmptyString(successtext) ? true : false),
+    () =>
+      valid || (successtext && isNotEmptyString(successtext) ? true : false),
     [valid, successtext]
-  )
+  );
 
   useEffect(() => {
-    setIsInvalid(invalidated)
-  }, [invalidated])
+    setIsInvalid(invalidated);
+  }, [invalidated]);
 
   useEffect(() => {
-    setIsValid(validated)
-  }, [validated])
+    setIsValid(validated);
+  }, [validated]);
 
   const handleValueChange = (event) => {
-    setValue(event.target.value)
-    onChange && onChange(event)
-  }
-  
+    setValue(event.target.value);
+    onChange && onChange(event);
+  };
+
   const handleFocus = (event) => {
-    setFocus(true)
-    onFocus && onFocus(event)
-  }
-  
+    setFocus(true);
+    onFocus && onFocus(event);
+  };
+
   const handleBlur = (event) => {
-    setFocus(false)
-    onBlur && onBlur(event)
-  }
-  
+    setFocus(false);
+    onBlur && onBlur(event);
+  };
+
   const Icons = ({ disabled }) => {
     if (isValid || isInvalid) {
       return (
@@ -180,37 +179,44 @@ export const Textarea = ({
             <Icon icon="checkCircle" color="jn-text-theme-success" />
           ) : null}
         </div>
-      )
+      );
     } else {
-      return ""
+      return "";
     }
-  }
-  
-  const theId = id || uniqueId()
-  
+  };
+
+  const theId = id || uniqueId();
+
   return (
-    <div>
-      <span 
+    <div
+      className={`
+        juno-textarea-wrapper-outer 
+        ${wrapperClassName}
+      `}
+    >
+      <span
         className={`
           juno-textarea-wrapper 
           ${wrapperStyles}
-          ${ width == "auto" ? "jn-inline-block" : "jn-block" }
-          ${ width == "auto" ? "jn-w-auto" : "jn-w-full" }
-        `} 
-        >
-        { label && label.length ?
-            <Label 
-              text={label}
-              htmlFor={theId}
-              className={`${labelStyles}`}
-              disabled={disabled}
-              required={required}
-              floating
-              minimized={ placeholder || hasFocus || val && val.length  ? true : false}
-            />
-          :
-            ""
-        }
+          ${width == "auto" ? "jn-inline-block" : "jn-block"}
+          ${width == "auto" ? "jn-w-auto" : "jn-w-full"}
+        `}
+      >
+        {label && label.length ? (
+          <Label
+            text={label}
+            htmlFor={theId}
+            className={`${labelStyles}`}
+            disabled={disabled}
+            required={required}
+            floating
+            minimized={
+              placeholder || hasFocus || (val && val.length) ? true : false
+            }
+          />
+        ) : (
+          ""
+        )}
         <textarea
           name={name}
           autoComplete={autoComplete}
@@ -224,103 +230,114 @@ export const Textarea = ({
           onChange={handleValueChange}
           onFocus={handleFocus}
           onBlur={handleBlur}
-          className={
-            `juno-textarea 
-            ${ textareastyles }
-            ${ label ? withLabelStyles : noLabelStyles }
-            ${ isInvalid ? "juno-textarea-invalid " + invalidstyles : "" } 
-            ${ isValid ? "juno-textarea-valid " + validstyles : "" }  
-            ${ isValid || isInvalid ? "" : defaultborderstyles } 
-            ${ width == "auto" ? "jn-w-auto" : "jn-w-full" }
-            ${ className }
+          className={`juno-textarea 
+            ${textareastyles}
+            ${label ? withLabelStyles : noLabelStyles}
+            ${isInvalid ? "juno-textarea-invalid " + invalidstyles : ""} 
+            ${isValid ? "juno-textarea-valid " + validstyles : ""}  
+            ${isValid || isInvalid ? "" : defaultborderstyles} 
+            ${width == "auto" ? "jn-w-auto" : "jn-w-full"}
+            ${className}
           `}
           {...props}
         />
         <Icons disabled={disabled} />
       </span>
-      { errortext && isNotEmptyString(errortext) ?
-          <FormHint text={errortext} variant="error" className={`${hintStyles}`} />
-        :
-          ""
-      }
-      { successtext && isNotEmptyString(successtext) ?
-          <FormHint text={successtext} variant="success" className={`${hintStyles}`} />
-        :
-          ""
-      }
-      { helptext && isNotEmptyString(helptext) ?
-          <FormHint text={helptext} className={`${hintStyles}`} />
-        :
-          ""
-       }
+      {errortext && isNotEmptyString(errortext) ? (
+        <FormHint
+          text={errortext}
+          variant="error"
+          className={`${hintStyles}`}
+        />
+      ) : (
+        ""
+      )}
+      {successtext && isNotEmptyString(successtext) ? (
+        <FormHint
+          text={successtext}
+          variant="success"
+          className={`${hintStyles}`}
+        />
+      ) : (
+        ""
+      )}
+      {helptext && isNotEmptyString(helptext) ? (
+        <FormHint text={helptext} className={`${hintStyles}`} />
+      ) : (
+        ""
+      )}
     </div>
-  )
-}
+  );
+};
 
 Textarea.propTypes = {
-  /** Pass a name attribute */
-  name: PropTypes.string,
-  /** The label of the textarea */
-  label: PropTypes.string,
-  /** Pass a value */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Pass an id */
-  id: PropTypes.string,
-  /** Pass a placeholder */
-  placeholder: PropTypes.string,
-  /** Render a disabled input */
-  disabled: PropTypes.bool,
-  /** Render a readonly input */
-  readOnly: PropTypes.bool,
-  /** Whether the field is required */
-  required: PropTypes.bool,
-  /** Whether the field is invalid */
-  invalid: PropTypes.bool,
-  /** Whether the field is valid */
-  valid: PropTypes.bool,
-  /** Whether the field receives autofocus */
-  autoFocus: PropTypes.bool,
-  /** Pass a classname */
-  className: PropTypes.string,
   /** Pass a valid autocomplete value. We do not police validity. */
   autoComplete: PropTypes.string,
+  /** Whether the field receives autofocus */
+  autoFocus: PropTypes.bool,
+  /** Pass a classname to the textarea element */
+  className: PropTypes.string,
+  /** Render a disabled input */
+  disabled: PropTypes.bool,
+  /** A text to render when the Textarea has an error or could not be validated */
+  errortext: PropTypes.node,
+  /** A helptext to render to explain meaning and significance of the Textarea */
+  helptext: PropTypes.node,
+  /** Pass an id */
+  id: PropTypes.string,
+  /** Whether the field is invalid */
+  invalid: PropTypes.bool,
+  /** The label of the textarea */
+  label: PropTypes.string,
+  /** Pass a name attribute */
+  name: PropTypes.string,
+  /** Pass a blur handler */
+  onBlur: PropTypes.func,
   /** Pass a change handler */
   onChange: PropTypes.func,
   /** Pass a focus handler */
   onFocus: PropTypes.func,
-  /** Pass a blur handler */
-  onBlur: PropTypes.func,
-  /** Specify the type attribute. Defaults to an input with no type attribute, which in turn will be treateas as type="text" by browsers. */
-  type: PropTypes.oneOf(["text", "email", "password", "tel", "url", "number"]),
-  /** A helptext to render to explain meaning and significance of the Textarea */
-  helptext: PropTypes.node,
+  /** Pass a placeholder */
+  placeholder: PropTypes.string,
+  /** Render a readonly input */
+  readOnly: PropTypes.bool,
+  /** Whether the field is required */
+  required: PropTypes.bool,
   /** A text to render when the Textarea was successfully validated */
   successtext: PropTypes.node,
-  /** A text to render when the Textarea has an error or could not be validated */
-  errortext: PropTypes.node,
+  /** Specify the type attribute. Defaults to an input with no type attribute, which in turn will be treateas as type="text" by browsers. */
+  type: PropTypes.oneOf(["text", "email", "password", "tel", "url", "number"]),
+  /** Whether the field is valid */
+  valid: PropTypes.bool,
+  /** Pass a value */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** The width of the textarea. Either 'full' (default) or 'auto'. */
   width: PropTypes.oneOf(["full", "auto"]),
-}
+  /** Pass a className to the outer wrapping <div> element */
+  wrapperClassName: PropTypes.string,
+};
 
 Textarea.defaultProps = {
-  value: "",
-  id: "",
-  placeholder: "",
-  disabled: false,
-  readOnly: false,
-  required: false,
-  invalid: false,
-  valid: false,
+  autoComplete: "off",
   autoFocus: false,
   className: "",
-  autoComplete: "off",
-  helptext: "",
-  successtext: "",
+  disabled: false,
   errortext: "",
+  helptext: "",
+  id: "",
+  invalid: false,
+  label: undefined,
+  name: undefined,
+  onBlur: undefined,
   onChange: undefined,
   onFocus: undefined,
-  onBlur: undefined,
+  placeholder: "",
+  readOnly: false,
+  required: false,
+  successtext: "",
   type: null,
-  label: undefined,
+  valid: false,
+  value: "",
   width: "full",
-}
+  wrapperClassName: "",
+};

--- a/libs/juno-ui-components/src/components/Textarea/Textarea.stories.js
+++ b/libs/juno-ui-components/src/components/Textarea/Textarea.stories.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
-import { Textarea } from './index.js';
+import React from "react";
+import { Textarea } from "./index.js";
 
 export default {
-  title: 'Forms/Textarea',
+  title: "Forms/Textarea",
   component: Textarea,
   argTypes: {
     errortext: {
@@ -24,19 +24,19 @@ export default {
 
 export const Default = {
   args: {
-    placeholder: 'Some text here',
+    placeholder: "Some text here",
   },
 };
 
 export const WithLabel = {
   args: {
-    label: 'Textarea',
+    label: "Textarea",
   },
 };
 
 export const RequiredWithLabel = {
   args: {
-    label: 'Required Textarea',
+    label: "Required Textarea",
     required: true,
   },
 };
@@ -44,34 +44,41 @@ export const RequiredWithLabel = {
 export const Invalid = {
   args: {
     invalid: true,
-    placeholder: 'Some invalid text here',
+    placeholder: "Some invalid text here",
   },
 };
 
 export const Valid = {
   args: {
     valid: true,
-    placeholder: 'Some valid text here',
+    placeholder: "Some valid text here",
   },
 };
 
 export const Disabled = {
   args: {
     disabled: true,
-    placeholder: 'A disabled textarea',
+    placeholder: "A disabled textarea",
+  },
+};
+
+export const Readonly = {
+  args: {
+    readOnly: true,
+    value: "Text is readonly.",
   },
 };
 
 export const Autofocus = {
   args: {
-    placeholder: 'An autofocussing textarea',
+    placeholder: "An autofocussing textarea",
     autoFocus: true,
   },
 };
 
 export const WithHelpText = {
   args: {
-    helptext: 'This is an explanatory text referring to the input',
+    helptext: "This is an explanatory text referring to the input",
   },
 };
 
@@ -87,12 +94,12 @@ export const WithHelpTextAsNode = {
 
 export const WithSuccessText = {
   args: {
-    successtext: 'This field is a great success!',
+    successtext: "This field is a great success!",
   },
 };
 
 export const WithErrorText = {
   args: {
-    errortext: 'This field has an error',
+    errortext: "This field has an error",
   },
 };

--- a/libs/juno-ui-components/src/components/Textarea/Textarea.test.js
+++ b/libs/juno-ui-components/src/components/Textarea/Textarea.test.js
@@ -3,156 +3,181 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
-import { Textarea } from "./index"
-
+import * as React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Textarea } from "./index";
 
 describe("Textarea", () => {
-	
-	test("renders a native html textarea", async () => {
-		render(<Textarea />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-	})
-	
-	test("renders a name as passed", async () => {
-		render(<Textarea name="my-textarea"/>)
-		expect(screen.getByRole("textbox")).toHaveAttribute('name', "my-textarea")
-	})
-	
-	test("renders text content as passed", async () => {
-		render(<Textarea value="Test some text" />)
-		expect(screen.getByRole("textbox")).toHaveTextContent("Test some text")
-	})
-	
-	test("renders a label as passed", async () => {
-		render(<Textarea label="The Label" id="my-textarea"/>)
-		// implicitly test whether the textarea element can be selected via the labels text:
-		expect(screen.getByLabelText("The Label")).toBeInTheDocument()
-		expect(document.querySelector(".juno-label")).toBeInTheDocument()
-		expect(document.querySelector(".juno-label")).toHaveTextContent("The Label")
-	})
-	
-	test("renders a Textarea with an id as passed", async () => {
-		render(<Textarea id="my-textarea" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute('id', "my-textarea")
-	})
-	
-	test("renders a Textarea with an auto-generated id if no id is passed", async () => {
-		render(<Textarea /> )
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute("id")
-		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("juno-textarea")
-	})
-	
-	test("renders a Textarea with a label associated by an id as passed", async () => {
-		render(< Textarea label="My Textarea" id="ta-1"/>)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveAttribute("id")
-		expect(screen.getByRole("textbox").getAttribute("id")).toMatch("ta-1")
-		expect(screen.getByLabelText("My Textarea")).toBeInTheDocument()
-	})
-	
-	test("renders a Textarea with a label associated by an auto-generated id if no id was passed ", async () => {
-		render(<Textarea label="This is a Textarea" />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByLabelText("This is a Textarea")).toBeInTheDocument()
-	})
-	
-	test("renders an invalid textarea as passed", async () => {
-		render(<Textarea invalid />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveClass("juno-textarea-invalid")
-		expect(screen.getByTitle("Dangerous")).toBeInTheDocument()
-	})
-	
-	test("renders a valid textarea as passed", async () => {
-		render(<Textarea valid />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toHaveClass("juno-textarea-valid")
-		expect(screen.getByTitle("CheckCircle")).toBeInTheDocument()
-	})
-	
-	test("renders a placeholder as passed", async () => {
-		render(<Textarea placeholder="My placeholder" />)
-		expect(screen.getByRole("textbox")).toHaveAttribute('placeholder', "My placeholder")
-	})
-	
-	test("renders a disabled textarea as passed", async () => {
-		render(<Textarea disabled />)
-		expect(screen.getByRole("textbox")).toBeInTheDocument()
-		expect(screen.getByRole("textbox")).toBeDisabled()
-	})
-	
-	test("renders a placeholder as passed", async () => {
-		render(<Textarea placeholder="my placeholder"/>)
-		expect(screen.getByRole("textbox")).toHaveAttribute('placeholder', "my placeholder")
-	})
-	
-	test("renders autocomplete on as passed", async () => {
-		render(<Textarea autoComplete="on"/>)
-		expect(screen.getByRole("textbox")).toHaveAttribute('autocomplete', "on")
-	})
-	
-	test("renders autofocus as passed", async () => {
-		render(<Textarea autoFocus />)
-		expect(screen.getByRole("textbox")).toHaveFocus()
-	})
-	
-	test("renders a helptext as passed", async () => {
-		render(<Textarea helptext="this is a helptext"/>)
-		expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
-		expect(document.querySelector(".juno-form-hint")).toHaveClass("juno-form-hint-help")
-		expect(document.querySelector(".juno-form-hint")).toHaveTextContent("this is a helptext")
-	})
-	
-	test("renders a successtext as passed and validates the Element", async () => {
-		render(<Textarea successtext="great success!" />)
-		expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
-		expect(document.querySelector(".juno-form-hint")).toHaveClass("juno-form-hint-success")
-		expect(document.querySelector(".juno-form-hint")).toHaveTextContent("great success!")
-		expect(screen.getByRole("textbox")).toHaveClass("juno-textarea-valid")
-	})
-	
-	test("renders an errortext as passed and invalidates the Element", async () => {
-		render(<Textarea errortext="this is an error!" />)
-		expect(document.querySelector(".juno-form-hint")).toBeInTheDocument()
-		expect(document.querySelector(".juno-form-hint")).toHaveClass("juno-form-hint-error")
-		expect(document.querySelector(".juno-form-hint")).toHaveTextContent("this is an error!")
-		expect(screen.getByRole("textbox")).toHaveClass("juno-textarea-invalid")
-	})
-	
-	test("fires onChange handler as passed", async () => {
-		const handleChange = jest.fn()
-		const { container } = render(
-			<Textarea onChange={handleChange} />
-		)
-		const textarea = screen.getByRole("textbox")
-		fireEvent.change(textarea, { target: { value: 'a' } })
-		expect(handleChange).toHaveBeenCalledTimes(1)
-	})
-	
-	test("does not fire onChange handler when disabled", async () => {
-		const onChangeSpy = jest.fn();
-		const { container } = render(
-				<Textarea onChange={onChangeSpy} disabled />
-			)
-		screen.getByRole('textbox').click();
-		expect(onChangeSpy).not.toHaveBeenCalled();	
-	})
-	
-	test("renders a className as passed", async () => {
-		render(<Textarea className="my-custom-class" />)
-		expect(screen.getByRole("textbox")).toHaveClass("my-custom-class")
-	})
-	
-	test("renders other props as passed", async () => {
-		render(<Textarea cols="100" rows="25" minLength="0" maxLength="100"/>)
-		expect(screen.getByRole("textbox")).toHaveAttribute('cols', "100")
-		expect(screen.getByRole("textbox")).toHaveAttribute('rows', "25")
-		expect(screen.getByRole("textbox")).toHaveAttribute('minlength', "0")
-		expect(screen.getByRole("textbox")).toHaveAttribute('maxlength', "100")
-	})
+  test("renders a native html textarea", async () => {
+    render(<Textarea />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
 
-})
+  test("renders a name as passed", async () => {
+    render(<Textarea name="my-textarea" />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("name", "my-textarea");
+  });
+
+  test("renders text content as passed", async () => {
+    render(<Textarea value="Test some text" />);
+    expect(screen.getByRole("textbox")).toHaveTextContent("Test some text");
+  });
+
+  test("renders a label as passed", async () => {
+    render(<Textarea label="The Label" id="my-textarea" />);
+    // implicitly test whether the textarea element can be selected via the labels text:
+    expect(screen.getByLabelText("The Label")).toBeInTheDocument();
+    expect(document.querySelector(".juno-label")).toBeInTheDocument();
+    expect(document.querySelector(".juno-label")).toHaveTextContent(
+      "The Label"
+    );
+  });
+
+  test("renders a Textarea with an id as passed", async () => {
+    render(<Textarea id="my-textarea" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("id", "my-textarea");
+  });
+
+  test("renders a Textarea with an auto-generated id if no id is passed", async () => {
+    render(<Textarea />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("id");
+    expect(screen.getByRole("textbox").getAttribute("id")).toMatch(
+      "juno-textarea"
+    );
+  });
+
+  test("renders a Textarea with a label associated by an id as passed", async () => {
+    render(<Textarea label="My Textarea" id="ta-1" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveAttribute("id");
+    expect(screen.getByRole("textbox").getAttribute("id")).toMatch("ta-1");
+    expect(screen.getByLabelText("My Textarea")).toBeInTheDocument();
+  });
+
+  test("renders a Textarea with a label associated by an auto-generated id if no id was passed ", async () => {
+    render(<Textarea label="This is a Textarea" />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByLabelText("This is a Textarea")).toBeInTheDocument();
+  });
+
+  test("renders an invalid textarea as passed", async () => {
+    render(<Textarea invalid />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveClass("juno-textarea-invalid");
+    expect(screen.getByTitle("Dangerous")).toBeInTheDocument();
+  });
+
+  test("renders a valid textarea as passed", async () => {
+    render(<Textarea valid />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveClass("juno-textarea-valid");
+    expect(screen.getByTitle("CheckCircle")).toBeInTheDocument();
+  });
+
+  test("renders a placeholder as passed", async () => {
+    render(<Textarea placeholder="My placeholder" />);
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "placeholder",
+      "My placeholder"
+    );
+  });
+
+  test("renders a disabled textarea as passed", async () => {
+    render(<Textarea disabled />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+
+  test("renders a placeholder as passed", async () => {
+    render(<Textarea placeholder="my placeholder" />);
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "placeholder",
+      "my placeholder"
+    );
+  });
+
+  test("renders autocomplete on as passed", async () => {
+    render(<Textarea autoComplete="on" />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("autocomplete", "on");
+  });
+
+  test("renders autofocus as passed", async () => {
+    render(<Textarea autoFocus />);
+    expect(screen.getByRole("textbox")).toHaveFocus();
+  });
+
+  test("renders a helptext as passed", async () => {
+    render(<Textarea helptext="this is a helptext" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
+    expect(document.querySelector(".juno-form-hint")).toHaveClass(
+      "juno-form-hint-help"
+    );
+    expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
+      "this is a helptext"
+    );
+  });
+
+  test("renders a successtext as passed and validates the Element", async () => {
+    render(<Textarea successtext="great success!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
+    expect(document.querySelector(".juno-form-hint")).toHaveClass(
+      "juno-form-hint-success"
+    );
+    expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
+      "great success!"
+    );
+    expect(screen.getByRole("textbox")).toHaveClass("juno-textarea-valid");
+  });
+
+  test("renders an errortext as passed and invalidates the Element", async () => {
+    render(<Textarea errortext="this is an error!" />);
+    expect(document.querySelector(".juno-form-hint")).toBeInTheDocument();
+    expect(document.querySelector(".juno-form-hint")).toHaveClass(
+      "juno-form-hint-error"
+    );
+    expect(document.querySelector(".juno-form-hint")).toHaveTextContent(
+      "this is an error!"
+    );
+    expect(screen.getByRole("textbox")).toHaveClass("juno-textarea-invalid");
+  });
+
+  test("fires onChange handler as passed", async () => {
+    const handleChange = jest.fn();
+    const { container } = render(<Textarea onChange={handleChange} />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "a" } });
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fire onChange handler when disabled", async () => {
+    const onChangeSpy = jest.fn();
+    const { container } = render(<Textarea onChange={onChangeSpy} disabled />);
+    screen.getByRole("textbox").click();
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  test("renders a className as passed", async () => {
+    render(<Textarea className="my-custom-class" />);
+    expect(screen.getByRole("textbox")).toHaveClass("my-custom-class");
+  });
+
+  test("renders a wrapperClassName to the outer wrapping <div> element", async () => {
+    render(<Textarea wrapperClassName="my-wrapper-class" />);
+    expect(
+      document.querySelector(".juno-textarea-wrapper-outer")
+    ).toBeInTheDocument();
+    expect(document.querySelector(".juno-textarea-wrapper-outer")).toHaveClass(
+      "my-wrapper-class"
+    );
+  });
+
+  test("renders other props as passed", async () => {
+    render(<Textarea cols="100" rows="25" minLength="0" maxLength="100" />);
+    expect(screen.getByRole("textbox")).toHaveAttribute("cols", "100");
+    expect(screen.getByRole("textbox")).toHaveAttribute("rows", "25");
+    expect(screen.getByRole("textbox")).toHaveAttribute("minlength", "0");
+    expect(screen.getByRole("textbox")).toHaveAttribute("maxlength", "100");
+  });
+});


### PR DESCRIPTION
* add `wrapperClassName` prop to the following components:
    * ComboBox
    * DateTimePicker
    * NativeSelect
    * NavigationItem
    * Select
    * Switch
    * TabList
    * Textarea
    * TextInput
* cleanup and format
* put props in alphabetic order
* add tests for wrapperClassName
* improve readonly-story