### PR TITLE
fix(workflow) unify two steps in one when checking 3rd party license and check all libs and apps again.

### DIFF
--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -117,6 +117,6 @@ jobs:
         run: |
           echo type: $change_type, asset: $change_asset
           cd "$change_type/$change_asset"
-          npm ci
+          npm install --omit=optional
           npm install -g license-checker-rseidelsohn
           license-checker-rseidelsohn -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD;Python-2.0;BSD*;Unlicense"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -117,6 +117,6 @@ jobs:
         run: |
           echo type: $change_type, asset: $change_asset
           cd "$change_type/$change_asset"
-          NODE_ENV=production npm ci
-          npm install -g license-checker
-          license-checker -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD"
+          npm ci
+          npm install -g license-checker-rseidelsohn
+          license-checker-rseidelsohn -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD;Python-2.0;BSD*"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -149,17 +149,3 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-
-      - name: Extract change attributes and save to env
-        id: extract-attributes
-        run: |
-          change_type=$( echo '${{ toJson(matrix.change) }}' | jq -r '.type' )
-          change_asset=$( echo '${{ toJson(matrix.change) }}' | jq -r '.asset' )
-          echo "change_type=$change_type" >> $GITHUB_ENV
-          echo "change_asset=$change_asset" >> $GITHUB_ENV
-
-      - name: Run tests
-        run: |
-          cd "$change_type/$change_asset"
-          npm i
-          npm run test

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -117,17 +117,20 @@ jobs:
         run: |
           echo type: $change_type, asset: $change_asset
           cd "$change_type/$change_asset"
-          jq '(.devDependencies // {} | with_entries(select(.value | contains("https://assets.juno.global.cloud.sap") | not))) as $devDeps |
-              .devDependencies = $devDeps' package.json > temp.json && mv temp.json package.json
-          jq -r '.devDependencies | keys | .[]' package.json
+          jq '(.dependencies // {} | with_entries(select(.value | contains("https://assets.juno.global.cloud.sap") | not))) as $deps |
+              (.devDependencies // {} | with_entries(select(.value | contains("https://assets.juno.global.cloud.sap") | not))) as $devDeps |
+              (.peerDependencies // {} | with_entries(select(.value | contains("https://assets.juno.global.cloud.sap") | not))) as $peerDeps |
+              .dependencies = $deps |
+              .devDependencies = $devDeps |
+              .peerDependencies = $peerDeps' package.json > temp.json && mv temp.json package.json
 
       - name: Install npm dependencies and check 3rd party licenses
         run: |
           echo type: $change_type, asset: $change_asset
           cd "$change_type/$change_asset"
-          echo "========"
+          echo "====package.json===="
           cat package.json
           echo "========"
-          npm ci --omit=optional
+          npm i
           npm install -g license-checker-rseidelsohn
           license-checker-rseidelsohn -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD;Python-2.0;BSD*;Unlicense"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -134,3 +134,20 @@ jobs:
           npm i
           npm install -g license-checker-rseidelsohn
           license-checker-rseidelsohn -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD;Python-2.0;BSD*;Unlicense"
+
+  test-assets:
+    needs: check-3rd-party-licenses
+    runs-on: [default]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+      - name: Run tests
+        run: |
+          cd "$change_type/$change_asset"
+          npm i
+          npm run test

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -113,10 +113,18 @@ jobs:
           echo "change_type=$change_type" >> $GITHUB_ENV
           echo "change_asset=$change_asset" >> $GITHUB_ENV
 
-      - name: Install npm dependencies and check 3rd party licenses
+      - name: Remove all dependencies to our self hosted registry (temporary do tue not access from the internet)
         run: |
           echo type: $change_type, asset: $change_asset
           cd "$change_type/$change_asset"
-          npm install --omit=optional
+          jq '(.devDependencies // {} | with_entries(select(.value | contains("https://assets.juno.global.cloud.sap") | not))) as $deps |              
+          .dependencies = $deps package.json > temp.json && mv temp.json package.json
+          jq -r '.devDependencies | keys | .[]' package.json
+
+      - name: Install npm dependencies and check 3rd party licenses
+        run: |
+          echo type: $change_type, asset: $change_asset
+          echo Actual path is: $(pwd)
+          npm ci --omit=optional
           npm install -g license-checker-rseidelsohn
           license-checker-rseidelsohn -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD;Python-2.0;BSD*;Unlicense"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -113,15 +113,10 @@ jobs:
           echo "change_type=$change_type" >> $GITHUB_ENV
           echo "change_asset=$change_asset" >> $GITHUB_ENV
 
-      - name: Install npm dependencies
+      - name: Install npm dependencies and check 3rd party licenses
         run: |
           echo type: $change_type, asset: $change_asset
           cd "$change_type/$change_asset"
           NODE_ENV=production npm ci
-
-      - name: check license
-        run: |
-          echo type: $change_type, asset: $change_asset
-          npm install -g license-checker          
-          cd "$change_type/$change_asset"
-          license-checker -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;Unlicense;UNLICENSED;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD"
+          npm install -g license-checker
+          license-checker -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -124,7 +124,7 @@ jobs:
       - name: Install npm dependencies and check 3rd party licenses
         run: |
           echo type: $change_type, asset: $change_asset
-          echo Actual path is: $(pwd)
+          cd "$change_type/$change_asset"
           npm ci --omit=optional
           npm install -g license-checker-rseidelsohn
           license-checker-rseidelsohn -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD;Python-2.0;BSD*;Unlicense"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -119,4 +119,4 @@ jobs:
           cd "$change_type/$change_asset"
           npm ci
           npm install -g license-checker-rseidelsohn
-          license-checker-rseidelsohn -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD;Python-2.0;BSD*"
+          license-checker-rseidelsohn -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD;Python-2.0;BSD*;Unlicense"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -125,6 +125,9 @@ jobs:
         run: |
           echo type: $change_type, asset: $change_asset
           cd "$change_type/$change_asset"
+          echo "========"
+          cat package.json
+          echo "========"
           npm ci --omit=optional
           npm install -g license-checker-rseidelsohn
           license-checker-rseidelsohn -onlyAllow "MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;BSD-4-Clause;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD;Python-2.0;BSD*;Unlicense"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -138,6 +138,9 @@ jobs:
   test-assets:
     needs: check-3rd-party-licenses
     runs-on: [default]
+    strategy:
+      matrix:
+        change: ${{fromJson(needs.check-3rd-party-licenses.outputs.changes)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -146,6 +149,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
+
+      - name: Extract change attributes and save to env
+        id: extract-attributes
+        run: |
+          change_type=$( echo '${{ toJson(matrix.change) }}' | jq -r '.type' )
+          change_asset=$( echo '${{ toJson(matrix.change) }}' | jq -r '.asset' )
+          echo "change_type=$change_type" >> $GITHUB_ENV
+          echo "change_asset=$change_asset" >> $GITHUB_ENV
+
       - name: Run tests
         run: |
           cd "$change_type/$change_asset"

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -117,8 +117,8 @@ jobs:
         run: |
           echo type: $change_type, asset: $change_asset
           cd "$change_type/$change_asset"
-          jq '(.devDependencies // {} | with_entries(select(.value | contains("https://assets.juno.global.cloud.sap") | not))) as $deps |              
-          .dependencies = $deps package.json > temp.json && mv temp.json package.json
+          jq '(.devDependencies // {} | with_entries(select(.value | contains("https://assets.juno.global.cloud.sap") | not))) as $devDeps |
+              .devDependencies = $devDeps' package.json > temp.json && mv temp.json package.json
           jq -r '.devDependencies | keys | .[]' package.json
 
       - name: Install npm dependencies and check 3rd party licenses

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   reuse-compliance-check:
-    runs-on: [ubuntu-latest]
+    runs-on: [default]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
 
   detect-changes:
     needs: reuse-compliance-check
-    runs-on: [ubuntu-latest]
+    runs-on: [default]
     outputs:
       changes: ${{ steps.create-changes.outputs.changes}}
     steps:
@@ -92,7 +92,7 @@ jobs:
 
   check-3rd-party-licenses:
     needs: detect-changes
-    runs-on: [ubuntu-latest]
+    runs-on: [default]
     strategy:
       matrix:
         change: ${{fromJson(needs.detect-changes.outputs.changes)}}

--- a/apps/exampleapp/README.md
+++ b/apps/exampleapp/README.md
@@ -1,5 +1,7 @@
 # Example App
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 The example app serves as a demonstration application where we thoroughly test and implement interactions between multiple components following our best practices. Additionally, it functions as a prime illustration of how Juno components can be effectively utilized.
 
 # Usage

--- a/apps/exampleapp/package-lock.json
+++ b/apps/exampleapp/package-lock.json
@@ -46,8 +46,8 @@
         "zustand": "4.5.2"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       },
       "peerDependencies": {
         "@tanstack/react-query": "4.28.0",

--- a/apps/exampleapp/package-lock.json
+++ b/apps/exampleapp/package-lock.json
@@ -27,7 +27,10 @@
         "esbuild": "^0.17.19",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
+        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
         "luxon": "^2.3.0",
+        "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
+        "oauth": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
         "postcss": "^8.4.21",
         "postcss-url": "^10.1.3",
         "prop-types": "^15.8.1",
@@ -37,19 +40,14 @@
         "sass": "^1.60.0",
         "shadow-dom-testing-library": "^1.7.1",
         "tailwindcss": "^3.3.1",
+        "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
         "util": "^0.12.4",
+        "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
         "zustand": "4.5.2"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
         "npm": ">=10.0.0 <11.0.0"
-      },
-      "optionalDependencies": {
-        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
-        "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
-        "oauth": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
-        "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
-        "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz"
       },
       "peerDependencies": {
         "@tanstack/react-query": "4.28.0",
@@ -3797,13 +3795,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4850,7 +4848,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/cuint": {
       "version": "0.2.2",
@@ -8213,7 +8211,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -8307,7 +8305,7 @@
       "version": "2.14.1",
       "resolved": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
       "integrity": "sha512-O8h4E1/AylfMKla8pXAi0UdJRZp/iev40HJZyjvAds7q5pwF4UkB1PmLNbwwwzXKenXti2CyojIIQCKX8JpETA==",
-      "optional": true,
+      "dev": true,
       "peerDependencies": {
         "prop-types": "15.8.1",
         "react": "18.2.0",
@@ -8318,7 +8316,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/juri/-/juri-1.0.3.tgz",
       "integrity": "sha512-ARxzFFY6FnmMtTejPKLfcHSVV+AN11xquK4aNaWBA/5adTAiSKxs5lIYhft2vxHH6M1HGXTY17PA462sX0zN7g==",
-      "optional": true
+      "dev": true
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -8381,7 +8379,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -8480,7 +8478,7 @@
       "version": "0.1.12",
       "resolved": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
       "integrity": "sha512-8XVowXV8wxBJ10FBEAO2AGMpdaf6C6UKQCAjJELJnJHYwPDBYOnMa4nOwHCwzurH6rh0QTmbAeFz4HpD8Yglrw==",
-      "optional": true,
+      "dev": true,
       "peerDependencies": {
         "juno-ui-components": "*",
         "react": "18.2.0",
@@ -8665,13 +8663,13 @@
       "version": "1.2.1",
       "resolved": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
       "integrity": "sha512-UekxB4dCX+TdKA+/EUAVRfWyQWSY2MVbKZri/tQSfmhHHFJHFUKoBDKCv+1mIMNhtQKYFxKqDSIQ0m8sYS/Flw==",
-      "optional": true
+      "dev": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9227,7 +9225,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9238,7 +9236,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -9331,7 +9329,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9343,7 +9341,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -9648,7 +9646,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -10363,7 +10361,7 @@
       "version": "1.3.2",
       "resolved": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
       "integrity": "sha512-+6ID9hl4YIFiRd4EWy7oZlvFmevBNsIXa8KTZ0+HCj/f48s4NNZKXWooSakXeCmeFCzkcnP/Wv4jYD3RyWFAjg==",
-      "optional": true,
+      "dev": true,
       "dependencies": {
         "juri": "^1.0.3"
       }
@@ -10400,7 +10398,7 @@
       "version": "1.1.6",
       "resolved": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
       "integrity": "sha512-EJY8lT7jRzwlOmHA4YLKdSA8caLVoR4m8giN0+A6wQ2tUFYkBKRbF+pC6On5557tZyi4M2/IHanY0gpwydH3MA==",
-      "optional": true,
+      "dev": true,
       "peerDependencies": {
         "react": "^18.2.0"
       }
@@ -10798,7 +10796,7 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.2.tgz",
       "integrity": "sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },
@@ -10826,7 +10824,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "devOptional": true,
+      "dev": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/apps/exampleapp/package-lock.json
+++ b/apps/exampleapp/package-lock.json
@@ -27,10 +27,7 @@
         "esbuild": "^0.17.19",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
-        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
         "luxon": "^2.3.0",
-        "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
-        "oauth": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
         "postcss": "^8.4.21",
         "postcss-url": "^10.1.3",
         "prop-types": "^15.8.1",
@@ -40,14 +37,19 @@
         "sass": "^1.60.0",
         "shadow-dom-testing-library": "^1.7.1",
         "tailwindcss": "^3.3.1",
-        "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
         "util": "^0.12.4",
-        "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
         "zustand": "4.5.2"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
         "npm": ">=10.0.0 <11.0.0"
+      },
+      "optionalDependencies": {
+        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
+        "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
+        "oauth": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
+        "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
+        "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz"
       },
       "peerDependencies": {
         "@tanstack/react-query": "4.28.0",
@@ -3795,13 +3797,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4848,7 +4850,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/cuint": {
       "version": "0.2.2",
@@ -8211,7 +8213,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -8305,7 +8307,7 @@
       "version": "2.14.1",
       "resolved": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
       "integrity": "sha512-O8h4E1/AylfMKla8pXAi0UdJRZp/iev40HJZyjvAds7q5pwF4UkB1PmLNbwwwzXKenXti2CyojIIQCKX8JpETA==",
-      "dev": true,
+      "optional": true,
       "peerDependencies": {
         "prop-types": "15.8.1",
         "react": "18.2.0",
@@ -8316,7 +8318,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/juri/-/juri-1.0.3.tgz",
       "integrity": "sha512-ARxzFFY6FnmMtTejPKLfcHSVV+AN11xquK4aNaWBA/5adTAiSKxs5lIYhft2vxHH6M1HGXTY17PA462sX0zN7g==",
-      "dev": true
+      "optional": true
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -8379,7 +8381,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -8478,7 +8480,7 @@
       "version": "0.1.12",
       "resolved": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
       "integrity": "sha512-8XVowXV8wxBJ10FBEAO2AGMpdaf6C6UKQCAjJELJnJHYwPDBYOnMa4nOwHCwzurH6rh0QTmbAeFz4HpD8Yglrw==",
-      "dev": true,
+      "optional": true,
       "peerDependencies": {
         "juno-ui-components": "*",
         "react": "18.2.0",
@@ -8663,13 +8665,13 @@
       "version": "1.2.1",
       "resolved": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
       "integrity": "sha512-UekxB4dCX+TdKA+/EUAVRfWyQWSY2MVbKZri/tQSfmhHHFJHFUKoBDKCv+1mIMNhtQKYFxKqDSIQ0m8sYS/Flw==",
-      "dev": true
+      "optional": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9225,7 +9227,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9236,7 +9238,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -9329,7 +9331,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9341,7 +9343,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -9646,7 +9648,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -10361,7 +10363,7 @@
       "version": "1.3.2",
       "resolved": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
       "integrity": "sha512-+6ID9hl4YIFiRd4EWy7oZlvFmevBNsIXa8KTZ0+HCj/f48s4NNZKXWooSakXeCmeFCzkcnP/Wv4jYD3RyWFAjg==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "juri": "^1.0.3"
       }
@@ -10398,7 +10400,7 @@
       "version": "1.1.6",
       "resolved": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
       "integrity": "sha512-EJY8lT7jRzwlOmHA4YLKdSA8caLVoR4m8giN0+A6wQ2tUFYkBKRbF+pC6On5557tZyi4M2/IHanY0gpwydH3MA==",
-      "dev": true,
+      "optional": true,
       "peerDependencies": {
         "react": "^18.2.0"
       }
@@ -10796,7 +10798,7 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.2.tgz",
       "integrity": "sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },
@@ -10824,7 +10826,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/apps/exampleapp/package.json
+++ b/apps/exampleapp/package.json
@@ -33,7 +33,10 @@
     "esbuild": "^0.17.19",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
+    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
     "luxon": "^2.3.0",
+    "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
+    "oauth": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
     "postcss": "^8.4.21",
     "postcss-url": "^10.1.3",
     "prop-types": "^15.8.1",
@@ -43,15 +46,10 @@
     "sass": "^1.60.0",
     "shadow-dom-testing-library": "^1.7.1",
     "tailwindcss": "^3.3.1",
-    "util": "^0.12.4",
-    "zustand": "4.5.2"
-  },
-  "optionalDependencies": {
-    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
-    "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
-    "oauth": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
     "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
-    "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz"
+    "util": "^0.12.4",
+    "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
+    "zustand": "4.5.2"
   },
   "scripts": {
     "test": "jest",

--- a/apps/exampleapp/package.json
+++ b/apps/exampleapp/package.json
@@ -51,6 +51,13 @@
     "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
     "zustand": "4.5.2"
   },
+  "optionalDependencies": {
+    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
+    "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
+    "oauth": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
+    "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
+    "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz"
+  },
   "scripts": {
     "test": "jest",
     "start": "NODE_ENV=development node esbuild.config.js --serve --watch",

--- a/apps/exampleapp/package.json
+++ b/apps/exampleapp/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "module": "build/index.js",
   "source": "src/index.js",
-  "private": true,
+  "private": false,
   "engines": {
     "node": ">=20.0.0 <21.0.0",
     "npm": ">=10.0.0 <11.0.0"

--- a/apps/exampleapp/package.json
+++ b/apps/exampleapp/package.json
@@ -11,8 +11,8 @@
   "source": "src/index.js",
   "private": true,
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",

--- a/apps/exampleapp/package.json
+++ b/apps/exampleapp/package.json
@@ -33,10 +33,7 @@
     "esbuild": "^0.17.19",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",
     "luxon": "^2.3.0",
-    "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
-    "oauth": "https://assets.juno.global.cloud.sap/libs/oauth@1.2.1/package.tgz",
     "postcss": "^8.4.21",
     "postcss-url": "^10.1.3",
     "prop-types": "^15.8.1",
@@ -46,9 +43,7 @@
     "sass": "^1.60.0",
     "shadow-dom-testing-library": "^1.7.1",
     "tailwindcss": "^3.3.1",
-    "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
     "util": "^0.12.4",
-    "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
     "zustand": "4.5.2"
   },
   "optionalDependencies": {

--- a/apps/exampleapp/package.json
+++ b/apps/exampleapp/package.json
@@ -11,7 +11,7 @@
   "source": "src/index.js",
   "private": true,
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "devDependencies": {

--- a/apps/template/README.md
+++ b/apps/template/README.md
@@ -1,5 +1,7 @@
 # Template App
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 This is the standard app template for microfrontends. Use this as a basis for new juno microfrontend apps.
 
 ## Instructions

--- a/apps/template/package-lock.json
+++ b/apps/template/package-lock.json
@@ -43,8 +43,8 @@
         "zustand": "4.5.2"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       },
       "peerDependencies": {
         "@tanstack/react-query": "4.28.0",

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -12,7 +12,7 @@
   "module": "build/index.js",
   "private": true,
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "devDependencies": {

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "source": "src/index.js",
   "module": "build/index.js",
-  "private": true,
+  "private": false,
   "engines": {
     "node": ">=20.0.0 <21.0.0",
     "npm": ">=10.0.0 <11.0.0"

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -12,8 +12,8 @@
   "module": "build/index.js",
   "private": true,
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",

--- a/libs/communicator/README.md
+++ b/libs/communicator/README.md
@@ -1,5 +1,7 @@
 # Communicator
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 The **Communicator** library facilitates seamless message exchange across various contexts, including multiple tabs on the same origin, by utilizing events. It offers a versatile range of communication options, including broadcast events for widespread interaction and one-to-one messaging capabilities.
 
 ## Overview

--- a/libs/communicator/package-lock.json
+++ b/libs/communicator/package-lock.json
@@ -16,8 +16,8 @@
         "jest-environment-jsdom": "^29.7.0"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/libs/communicator/package.json
+++ b/libs/communicator/package.json
@@ -12,7 +12,7 @@
   "main": "build/index.js",
   "module": "build/index.js",
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "scripts": {

--- a/libs/communicator/package.json
+++ b/libs/communicator/package.json
@@ -12,8 +12,8 @@
   "main": "build/index.js",
   "module": "build/index.js",
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "scripts": {
     "dev": "NODE_ENV=development node ./esbuild.config.js --watch",

--- a/libs/juno-ui-components/README.md
+++ b/libs/juno-ui-components/README.md
@@ -1,5 +1,7 @@
 # Juno UI Components Library
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 ## Installation
 
 To include Juno UI components as a dev dependency in your app install with npm:

--- a/libs/juno-ui-components/package-lock.json
+++ b/libs/juno-ui-components/package-lock.json
@@ -70,8 +70,8 @@
         "tailwindcss": "^3.3.1"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       },
       "peerDependencies": {
         "prop-types": "15.8.1",

--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -18,7 +18,7 @@
   "repository": "https://github.com/cloudoperators/juno/tree/main/libs/juno-ui-components",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "devDependencies": {

--- a/libs/juno-ui-components/package.json
+++ b/libs/juno-ui-components/package.json
@@ -18,8 +18,8 @@
   "repository": "https://github.com/cloudoperators/juno/tree/main/libs/juno-ui-components",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-parameters": "^7.22.5",

--- a/libs/messages-provider/README.md
+++ b/libs/messages-provider/README.md
@@ -1,5 +1,7 @@
 # Messages Provider
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 Manage and display messages in your application easily and with the [Juno message component](https://github.com/cloudoperators/juno/blob/main/libs/juno-ui-components/README.md).
 
 A message holds generally important information to help understand the contents, purpose, or state of a whole page or view.

--- a/libs/messages-provider/package-lock.json
+++ b/libs/messages-provider/package-lock.json
@@ -32,8 +32,8 @@
         "zustand": "4.5.2"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       },
       "peerDependencies": {
         "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",

--- a/libs/messages-provider/package.json
+++ b/libs/messages-provider/package.json
@@ -12,8 +12,8 @@
   "module": "build/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "peerDependencies": {
     "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.14.1/package.tgz",

--- a/libs/messages-provider/package.json
+++ b/libs/messages-provider/package.json
@@ -12,7 +12,7 @@
   "module": "build/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "peerDependencies": {

--- a/libs/oauth/README.md
+++ b/libs/oauth/README.md
@@ -1,5 +1,7 @@
 # OpenID Connect Lib (oauth)
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 The principle of this lib is as follows. Immediately after loading this lib, it evaluates the URL. It looks for state param in the hash or search. If state is found, then the value of this parameter is used as a key to find the corresponding stored state properties in sessionStorage. If the saved state exists, then it is the answer (oidc response) from the ID provider to the previously made request (oidc request), and the lib tries to evaluate the result.
 
 ## Evaluation of the response

--- a/libs/oauth/package-lock.json
+++ b/libs/oauth/package-lock.json
@@ -19,8 +19,8 @@
         "jest-environment-jsdom": "^29.7.0"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/libs/oauth/package.json
+++ b/libs/oauth/package.json
@@ -12,7 +12,7 @@
   "module": "build/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "devDependencies": {

--- a/libs/oauth/package.json
+++ b/libs/oauth/package.json
@@ -12,8 +12,8 @@
   "module": "build/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",

--- a/libs/policy-engine/README.md
+++ b/libs/policy-engine/README.md
@@ -1,6 +1,8 @@
 # Policy Engine
 
-Ploicy Engine compiles a JSON file with rules and returns a policy, which in turn implements the check function. The syntax of the rules corresponds to the policy syntax used in Openstack Services. However, some features have been added to allow more flexibility.
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+Policy Engine compiles a JSON file with rules and returns a policy, which in turn implements the check function. The syntax of the rules corresponds to the policy syntax used in Openstack Services. However, some features have been added to allow more flexibility.
 
 ## Architecture
 

--- a/libs/policy-engine/package-lock.json
+++ b/libs/policy-engine/package-lock.json
@@ -19,8 +19,8 @@
         "rollup-plugin-delete": "^2.0.0"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/libs/policy-engine/package.json
+++ b/libs/policy-engine/package.json
@@ -11,7 +11,7 @@
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "devDependencies": {

--- a/libs/policy-engine/package.json
+++ b/libs/policy-engine/package.json
@@ -11,8 +11,8 @@
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.5",

--- a/libs/template-lib/README.md
+++ b/libs/template-lib/README.md
@@ -12,22 +12,10 @@
 
 add template to dependencies in package.json
 
-in juno monorepo
-
 ```json
 
   "dependencies": {
-    "template": "*"
-  },
-
-```
-
-outside juno
-
-```json
-
-  "dependencies": {
-    "template": "https://assets.juno.global.cloud.sap/libs/template@latest/package.tgz"
+    "template": "https://assets.juno.global.cloud.sap/libs/template@<version>/package.tgz"
   },
 
 ```

--- a/libs/template-lib/package-lock.json
+++ b/libs/template-lib/package-lock.json
@@ -16,8 +16,8 @@
         "jest-environment-jsdom": "^29.7.0"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/libs/template-lib/package.json
+++ b/libs/template-lib/package.json
@@ -12,7 +12,7 @@
   "module": "build/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "devDependencies": {

--- a/libs/template-lib/package.json
+++ b/libs/template-lib/package.json
@@ -12,8 +12,8 @@
   "module": "build/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",

--- a/libs/url-state-provider/README.md
+++ b/libs/url-state-provider/README.md
@@ -1,5 +1,7 @@
 # URL State Provider: Streamlining State Management in the URL
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 URL State Provider is your solution for simplifying the intricate task of managing multiple application states within the URL. Originally conceived for Micro Frontends (MFEs), this module empowers you to effortlessly navigate between diverse views while preserving the art of deep linking.
 
 ## Key Features

--- a/libs/url-state-provider/package-lock.json
+++ b/libs/url-state-provider/package-lock.json
@@ -30,8 +30,8 @@
         "rollup-plugin-delete": "^2.0.0"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/libs/url-state-provider/package.json
+++ b/libs/url-state-provider/package.json
@@ -12,8 +12,8 @@
   "module": "build/esm/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "scripts": {
     "build": "rollup -c",

--- a/libs/url-state-provider/package.json
+++ b/libs/url-state-provider/package.json
@@ -12,7 +12,7 @@
   "module": "build/esm/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "scripts": {

--- a/libs/url-state-router/README.md
+++ b/libs/url-state-router/README.md
@@ -1,6 +1,6 @@
 # URL State Router
 
-React ONLY!!!
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 If you already know the [React-Router](https://reactrouter.com) and you are wondering how you can use something similar in **micro frontends**, then you have come to the right place!
 

--- a/libs/url-state-router/package-lock.json
+++ b/libs/url-state-router/package-lock.json
@@ -34,8 +34,8 @@
         "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz"
       },
       "engines": {
-        "node": "˜20.0.0",
-        "npm": "˜10.0.0"
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       },
       "peerDependencies": {
         "prop-types": "^15.8.1",

--- a/libs/url-state-router/package.json
+++ b/libs/url-state-router/package.json
@@ -12,7 +12,7 @@
   "module": "build/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜20.0.0",
+    "node": "˜v20.0.0",
     "npm": "˜10.0.0"
   },
   "peerDependencies": {

--- a/libs/url-state-router/package.json
+++ b/libs/url-state-router/package.json
@@ -12,8 +12,8 @@
   "module": "build/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "peerDependencies": {
     "react": "18.2.0",

--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -14,22 +14,10 @@
 
 Add utils to dependencies in package.json:
 
-Within juno monorepo
-
 ```json
 
   "dependencies": {
     "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz"
-  },
-
-```
-
-Outside juno
-
-```json
-
-  "dependencies": {
-    "utils": "https://assets.juno.global.cloud.sap/libs/utils@latest/package.tgz"
   },
 
 ```

--- a/libs/utils/package-lock.json
+++ b/libs/utils/package-lock.json
@@ -20,6 +20,10 @@
         "react-dom": "18.2.0",
         "whatwg-fetch": "^3.6.19"
       },
+      "engines": {
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
+      },
       "peerDependencies": {
         "react": "18.2.0"
       }

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -12,6 +12,10 @@
   "main": "build/index.js",
   "module": "build/index.js",
   "license": "Apache-2.0",
+  "engines": {
+    "node": "˜v20.0.0",
+    "npm": "˜10.0.0"
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -13,8 +13,8 @@
   "module": "build/index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "˜v20.0.0",
-    "npm": "˜10.0.0"
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <11.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",


### PR DESCRIPTION
- Added a step to remove all entries from our internal registry in the `package.json` before installing the dependencies.
- Changed `npm ci` to `npm i` because if dependencies in the `package-lock.json` do not match those in `package.json`, `npm ci` will exit with an error instead of updating the `package-lock.json`.
- Removed `UNLICENSED` from the `onlyAllow` attribute since it came up because the apps were set to private. Setting the apps to public retrieves the license correctly with Apache.
- Removed `Unlicense` from the `onlyAllow` attribute since it wasn't clear if it is allowed.
- Added license badges to all `README` files in apps and libs.