### PR TITLE
feat(url-state-provider): upgrade after migration

### DIFF
--- a/libs/url-state-provider/package.json
+++ b/libs/url-state-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-state-provider",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Save several paths in the url. This makes it possible to manage the status of several apps such as micro frontends with the help of URL.",
   "author": "UI-Team",
   "contributors": [


### PR DESCRIPTION
Engines introduce: "node": ">=20.0.0 <21.0.0", "npm": ">=10.0.0 <11.0.0"
Added missing libs: @rollup/plugin-commonjs": "^24.0.0, @rollup/plugin-node-resolve, @rollup/plugin-terser