### PR TITLE
feat(url-state-router): upgrade after migration

### DIFF
--- a/libs/url-state-router/package.json
+++ b/libs/url-state-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-state-router",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Router",
   "author": "UI-Team",
   "contributors": [


### PR DESCRIPTION
Engines introduce: "node": ">=20.0.0 <21.0.0", "npm": ">=10.0.0 <11.0.0"
Upgrade @rollup/plugin-node-resolve to ^15.1.3
Added missing lib: @rollup/plugin-commonjs
Fixed version for react-dom