### PR TITLE
fix: use team instead of individual contributors for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 
-* @edda @andypf @artieReus @hgw77 @hodanoori @tilmanhaupt
-/packages/ui-components/ @edda @andypf @artieReus @hgw77 @hodanoori @tilmanhaupt @franzheidl
+* @cloudoperators/greenhouse-frontend
+/packages/ui-components/ @cloudoperators/greenhouse-frontend @franzheidl


### PR DESCRIPTION
# Summary

Change CODEOWNERS entries such that we use the frontend team as much as possible rather than individual contributors to make future maintenance easier.

# Changes Made

- replace individual contributors with team

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 1: #38 


# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
