### PR TITLE
ThemeToggle

### DIFF
--- a/packages/ui-components/src/components/Icon/Icon.component.js
+++ b/packages/ui-components/src/components/Icon/Icon.component.js
@@ -43,6 +43,7 @@ import Comment from "@material-design-icons/svg/filled/comment.svg"
 import ManageAccounts from "@material-design-icons/svg/filled/manage_accounts.svg"
 import MonitorHeart from "@material-design-icons/svg/outlined/monitor_heart.svg"
 import MoreVert from "@material-design-icons/svg/outlined/more_vert.svg"
+import NightsStay from "@material-design-icons/svg/outlined/nights_stay.svg"
 import NotificationsOff from "@material-design-icons/svg/outlined/notifications_off.svg"
 import OpenInBrowser from "@material-design-icons/svg/outlined/open_in_browser.svg"
 import OpenInNew from "@material-design-icons/svg/outlined/open_in_new.svg"
@@ -54,6 +55,7 @@ import SeverityMedium from "./icons/juno_severity_medium.svg"
 import SeverityHigh from "./icons/juno_severity_high.svg"
 import SeverityCritical from "./icons/juno_severity_critical.svg"
 import Warning from "@material-design-icons/svg/filled/warning.svg"
+import WBSunny from "@material-design-icons/svg/outlined/wb_sunny.svg"
 import Widgets from "@material-design-icons/svg/filled/widgets.svg"
 
 /**
@@ -125,6 +127,7 @@ export const knownIcons = [
   "manageAccounts",
   "monitorHeart",
   "moreVert",
+  "nightsStay",
   "notificationsOff",
   "openInBrowser",
   "openInNew",
@@ -136,6 +139,7 @@ export const knownIcons = [
   "severityCritical",
   "success",
   "warning",
+  "wbSunny",
   "widgets",
 ]
 
@@ -570,6 +574,18 @@ const getColoredSizedIcon = ({
           {...iconProps}
         />
       )
+      case "nightsStay":
+      return (
+        <NightsStay
+          width={size}
+          height={size}
+          className={iconClass}
+          alt="nights stay"
+          title={title ? title : "Nights stay"}
+          role="img"
+          {...iconProps}
+        />
+      )
     case "notificationsOff":
       return (
         <NotificationsOff
@@ -710,6 +726,18 @@ const getColoredSizedIcon = ({
           className={iconClass}
           alt="warning"
           title={title ? title : "Warning"}
+          role="img"
+          {...iconProps}
+        />
+      )
+      case "wbSunny":
+      return (
+        <WBSunny
+          width={size}
+          height={size}
+          className={iconClass}
+          alt="wb sunny"
+          title={title ? title : "WBSunny"}
           role="img"
           {...iconProps}
         />

--- a/packages/ui-components/src/components/Icon/Icon.stories.js
+++ b/packages/ui-components/src/components/Icon/Icon.stories.js
@@ -318,6 +318,13 @@ export const More_Vert = {
   },
 };
 
+export const Nights_Stay = {
+  args: {
+    ...Default.args,
+    icon: 'nightsStay',
+  },
+};
+
 export const Notifications_Off = {
   args: {
     ...Default.args,
@@ -392,6 +399,13 @@ export const Warning = {
   args: {
     ...Default.args,
     icon: 'warning',
+  },
+};
+
+export const WBSunny = {
+  args: {
+    ...Default.args,
+    icon: 'wbSunny',
   },
 };
 

--- a/packages/ui-components/src/components/StyleProvider/StyleProvider.component.js
+++ b/packages/ui-components/src/components/StyleProvider/StyleProvider.component.js
@@ -26,8 +26,8 @@ const APP_BODY_CSS_CLASS_NAME = "juno-app-body"
 const DEFAULT_THEME_NAME = "theme-dark"
 
 /**
- * Component wich inserts the ui styles and manages theming. 
- * It also creates a shadow dom element with styes inside  if 'stylesWrapper' is equal to "shadowRoot".
+ * Component that inserts the ui styles and manages theming and styles. 
+ * Also creates a shadow DOM element with styes inside  if 'stylesWrapper' is equal to "shadowRoot".
  * Accepted values for 'stylesWrapper' are 'head', 'inline' and 'shadowRoot'.
  * Both this component and ShadowRoot can be used independently. 
  * The stylesWrapper parameter is set to "inline" by default.
@@ -149,13 +149,13 @@ StyleProvider.propTypes = {
   shadowRootMode: PropTypes.oneOf(["open", "closed"]),
 }
 
-// define default values
+// Define default values
 StyleProvider.defaultProps = {
   children: null,
   stylesWrapper: "inline",
   theme: undefined,
 }
 
-// export a helper hook to use styles in nested components
-// returns {styles, theme, currentTheme, setThemeClass, addCssClass, removeCssClass}
+// Export a helper hook to use styles in nested components
+// Returns {styles, theme, currentTheme, setThemeClass, addCssClass, removeCssClass}
 StyleProvider.useStyles = () => React.useContext(StylesContext)

--- a/packages/ui-components/src/components/StyleProvider/StyleProvider.component.js
+++ b/packages/ui-components/src/components/StyleProvider/StyleProvider.component.js
@@ -50,12 +50,10 @@ export const StyleProvider = ({
   children,
   shadowRootMode,
 }) => {
-  // Create a unique Id string to add to the key in local storage. Otherwise, in case there are multiple StyleProvider instances, these would all write to and read from the same key causing havoc.
-  const themeUId = useId()
   // Determine the default value to init the storedTheme by using the prop if passed, or default:
   const themeClass = themeProp || DEFAULT_THEME_NAME
-  // Init the currently stored theme using either the theme passed as a prop or default:
-  const [storedTheme, setStoredTheme] = useLocalStorage("juno-theme" + "-" + themeUId, themeClass)
+  // Init the currently stored theme using either the theme found in local storage, a theme passed as a prop, or default:
+  const [storedTheme, setStoredTheme] = useLocalStorage("juno-theme", themeClass)
   
   // Store a reference to the current theme. This is needed to remove the old theme class when the theme is updated:
   // (Idea: this could potentially be omitted if we do not remove and add the theme class to update, but just re-generate the whole set of classes, so we do not care about the old theme class anymore.)

--- a/packages/ui-components/src/components/StyleProvider/StyleProvider.stories.js
+++ b/packages/ui-components/src/components/StyleProvider/StyleProvider.stories.js
@@ -50,7 +50,7 @@ export const AddStylesToShadowRoot = {
   },
 };
 
-export const WithTheme = {
+export const WithLightTheme = {
   render: Template,
 
   args: {

--- a/packages/ui-components/src/components/StyleProvider/StyleProvider.test.js
+++ b/packages/ui-components/src/components/StyleProvider/StyleProvider.test.js
@@ -4,10 +4,18 @@
  */
 
 import * as React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import '@testing-library/jest-dom/extend-expect'
 import { StyleProvider } from "./index"
 
+jest.mock('../../hooks/useLocalStorage', () => ({
+  __esModule: true,
+  default: jest.fn((key, initialValue) => [initialValue, jest.fn()]),
+}));
+
+
 describe("StyleProvider", () => {
+  
   test("renders a StyleProvider wrapper div with 'theme-dark' theme class by default", async () => {
     const { container } = render(<StyleProvider></StyleProvider>)
     expect(container.querySelector("div.juno-app-body")).toHaveClass(
@@ -21,4 +29,105 @@ describe("StyleProvider", () => {
     )
     expect(container.querySelector("div.juno-app-body")).toHaveClass("my-theme")
   })
+  
+  test("allows a child component to set the theme correctly via the function provided", async () => {
+    const TestToggleComponent = () => {
+        const { setThemeClass } = StyleProvider.useStyles()
+        return (
+          <button onClick={() => setThemeClass('theme-dark')}>Toggle Theme</button>
+        );
+    };
+    const { container } = render(
+      <StyleProvider theme="theme-light">
+        <TestToggleComponent />
+      </StyleProvider>
+    );
+    // Verify initial theme class
+    const appBody = container.querySelector('.juno-app-body');
+    expect(appBody).toHaveClass('theme-light');
+    
+    // Simulate theme toggle
+    fireEvent.click(screen.getByText('Toggle Theme'));
+    expect(appBody).toHaveClass('theme-dark');
+  })
+
+
+  test("allows a child component to set a css class on the container via the function provided", async () => {
+    const TestAddClassComponent = () => {
+      const { addCssClass } = StyleProvider.useStyles()
+      return (<button onClick={() => addCssClass("added-css-class")}>Set a Class</button>)
+    }
+    const { container} = render(
+      <StyleProvider theme="theme-dark">
+        <TestAddClassComponent />
+      </StyleProvider>
+    )
+    // Verify initial theme class
+    const appBody = container.querySelector('.juno-app-body');
+    expect(appBody).toHaveClass('theme-dark');
+    // Simulate adding a class
+    fireEvent.click(screen.getByText('Set a Class'));
+    expect(appBody).toHaveClass('added-css-class');
+    // double-check existing classes are still there:
+    expect(appBody).toHaveClass('theme-dark');
+  })
+  
+  test("allows a child component to remove a css class on the container via the function provided", async () => {
+    const TestRemoveClassComponent = () => {
+      const { removeCssClass } = StyleProvider.useStyles()
+      return(<button onClick={() => removeCssClass("theme-dark")}>Remove a Class</button>) 
+    }
+    const { container} = render(
+      <StyleProvider theme="theme-dark">
+        <TestRemoveClassComponent />
+      </StyleProvider>
+    )
+
+    // Verify initial theme class
+    const appBody = container.querySelector('.juno-app-body');
+    expect(appBody).toHaveClass('theme-dark');
+    // Simulate removing a class
+    fireEvent.click(screen.getByText('Remove a Class'));
+    expect(appBody).not.toHaveClass('theme-dark');
+  })
+  
+  test("allows child components to consume the current theme name via the context it provides", async () => {
+    const TestChildComponent = () => {
+      const {currentTheme} = StyleProvider.useStyles()
+      return(<button>{currentTheme}</button>)
+    }
+    const { container } = render(
+      <StyleProvider theme="theme-test">
+        <TestChildComponent />
+      </StyleProvider>
+    )
+    const appBody = container.querySelector('.juno-app-body');
+    expect(appBody).toHaveClass('theme-test');
+    expect(screen.getByRole("button")).toHaveTextContent("theme-test")
+  })
+  
+  test.skip("updates the current theme name provided when the theme is changed", async () => {
+    const TestChildComponent = () => {
+      const {currentTheme, setThemeClass} = StyleProvider.useStyles()
+      const [childTheme, setChildTheme] = React.useState("")
+      React.useEffect(() => {
+        setChildTheme(currentTheme)
+      }, [currentTheme])
+      return(<button onClick={() => setThemeClass("theme-light")}>{childTheme}</button>)
+    }
+    const { container } = render(
+      <StyleProvider theme="theme-test">
+        <TestChildComponent />
+      </StyleProvider>
+    )
+    const appBody = container.querySelector('.juno-app-body');
+    expect(appBody).toHaveClass('theme-test');
+    expect(screen.getByRole("button")).toHaveTextContent("theme-test")
+    // simulate updating the current theme 
+    fireEvent.click(screen.getByText('theme-test'));
+    expect(appBody).not.toHaveClass('theme-test');
+    expect(appBody).toHaveClass('theme-light');
+    await waitFor( () => {expect(screen.getByRole("button")).toHaveTextContent("theme-light")})
+  })
+  
 })

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
@@ -3,9 +3,6 @@ import PropTypes from "prop-types";
 import { Button } from "../Button/"
 import { StyleProvider} from "../StyleProvider/index"
 
-
-// TODO: description, stories, tests, warn if no context.
-
 /** 
 A Toggle button to toggle Light and Dark UI Themes.
 Requires a StyleProvider context, which is automatically provided by the Juno AppShell.
@@ -25,7 +22,7 @@ export const ThemeToggle = ({
   
   // Warn if no context is found
   if (!ThemeContext) {
-    console.warn("ThemeToggle requires a StyleProvider context in order to work. Use ThemeToggle in a Juno AppShell or include StyleProvider manually.")
+    console.warn("Juno ThemeToggle requires a StyleProvider context in order to work. Use ThemeToggle in a Juno AppShell or include StyleProvider manually.")
   }
   
   // Destructure the context, fallback

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
@@ -2,6 +2,7 @@ import React, { useContext, useState, useEffect} from "react"
 import PropTypes from "prop-types";
 import { Button } from "../Button/"
 import { StyleProvider} from "../StyleProvider/index"
+import { Icon } from "../Icon/"
 
 /** 
 A Toggle button to toggle Light and Dark UI Themes.
@@ -47,7 +48,7 @@ export const ThemeToggle = ({
       onClick={toggleTheme}
       {...props}
     >
-     {currentTheme === "theme-light" ? "Switch to Dark Theme" : "Switch to Light Theme"}
+     {currentTheme === "theme-light" ? <Icon icon="nightsStay" alt="Toggle theme" title="Toggle theme"/> : <Icon icon="wbSunny" alt="Toggle theme" title="Toggle theme" />}
     </Button>
   )
 }

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import { Button } from "../Button/"
 import { StyleProvider} from "../StyleProvider/index"
 
+
+// TODO: description, propTypes, stories, tests.
 export const ThemeToggle = ({
   className,
   disabled, 

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
@@ -1,0 +1,57 @@
+import React, { useContext, useState, useEffect} from "react"
+import PropTypes from "prop-types";
+import { Button } from "../Button/"
+import { StyleProvider} from "../StyleProvider/StyleProvider.component"
+
+export const ThemeToggle = ({
+  className,
+  disabled, 
+  id,
+  name,
+  onToggleTheme,
+  ...props
+}) => {
+  
+  const ThemeContext = StyleProvider.useStyles()
+  
+  const {
+    currentTheme: currentTheme,
+    setThemeClass: setThemeClass
+  } = ThemeContext || {}
+  
+  
+  const toggleTheme = () => {
+    const newTheme = currentTheme === "theme-dark" ? "theme-light" : "theme-dark"
+    setThemeClass(newTheme)
+    onToggleTheme && onToggleTheme(newTheme)
+  }
+  
+  return (
+    <Button 
+      className={`juno-theme-toggle ${className}`} 
+      disabled={disabled}
+      id={id}
+      name={name}
+      onClick={toggleTheme}
+      {...props}
+    >
+     {currentTheme === "theme-light" ? "Switch to Dark Theme" : "Switch to Light Theme"}
+    </Button>
+  )
+}
+
+ThemeToggle.propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  id: PropTypes.string,
+  name: PropTypes.string,
+  onToggleTheme: PropTypes.func,
+}
+
+ThemeToggle.defaultProps = {
+  className: "",
+  disabled: false,
+  id: undefined,
+  name: undefined,
+  onToggleTheme: undefined,
+}

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
@@ -4,7 +4,13 @@ import { Button } from "../Button/"
 import { StyleProvider} from "../StyleProvider/index"
 
 
-// TODO: description, propTypes, stories, tests.
+// TODO: description, stories, tests, warn if no context.
+
+/** 
+A Toggle button to toggle Light and Dark UI Themes.
+Requires a StyleProvider context, which is automatically provided by the Juno AppShell.
+If you are not using AppShell, include  a StyleProvider manually.
+ */
 export const ThemeToggle = ({
   className,
   disabled, 
@@ -14,8 +20,15 @@ export const ThemeToggle = ({
   ...props
 }) => {
   
+  // Consume the theme context 
   const ThemeContext = StyleProvider.useStyles()
   
+  // Warn if no context is found
+  if (!ThemeContext) {
+    console.warn("ThemeToggle requires a StyleProvider context in order to work. Use ThemeToggle in a Juno AppShell or include StyleProvider manually.")
+  }
+  
+  // Destructure the context, fallback
   const {
     currentTheme: currentTheme,
     setThemeClass: setThemeClass
@@ -24,7 +37,7 @@ export const ThemeToggle = ({
   
   const toggleTheme = () => {
     const newTheme = currentTheme === "theme-dark" ? "theme-light" : "theme-dark"
-    setThemeClass(newTheme)
+    setThemeClass && setThemeClass(newTheme)
     onToggleTheme && onToggleTheme(newTheme)
   }
   
@@ -43,10 +56,15 @@ export const ThemeToggle = ({
 }
 
 ThemeToggle.propTypes = {
+  /** Pass a custom className */
   className: PropTypes.string,
+  /** Whether the ThemeToggle is disabled */
   disabled: PropTypes.bool,
+  /** Optional of the ThemeToggle */
   id: PropTypes.string,
+  /** Optional name attribute of the ThemeToggle */
   name: PropTypes.string,
+  /** Handler to execute when the theme is toggled */
   onToggleTheme: PropTypes.func,
 }
 

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.component.js
@@ -1,7 +1,7 @@
 import React, { useContext, useState, useEffect} from "react"
 import PropTypes from "prop-types";
 import { Button } from "../Button/"
-import { StyleProvider} from "../StyleProvider/StyleProvider.component"
+import { StyleProvider} from "../StyleProvider/index"
 
 export const ThemeToggle = ({
   className,

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
@@ -7,13 +7,7 @@ import { StyleProvider } from "../StyleProvider/index";
 export default {
   title: "Components/ThemeToggle",
   component: ThemeToggle,
-  parameters: {
-    docs: {
-      description: {
-        component: "A toggle to switch between Dark and Light Theme.",
-      },
-    },
-  },
+  
   argTypes: {},
   decorators: [
     (Story) => (

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { ThemeToggle } from "./index";
+import { StyleProvider } from "../StyleProvider/";
+
+export default {
+  title: "Components/ThemeToggle",
+  component: ThemeToggle,
+  parameters: {
+    docs: {
+      description: {
+        component: "A toggle to switch between Dark and Light Theme.",
+      },
+    },
+  },
+  argTypes: {},
+  decorators: [
+    (Story) => (
+      <StyleProvider theme="theme-light">
+        <div className="jn-p-12" style={{ minHeight: "250px" }}>
+          <Story />
+          <p> Some content. </p>
+        </div>
+      </StyleProvider>
+    ),
+  ],
+};
+
+const Template = (args) => <ThemeToggle {...args} />;
+
+export const Default = {
+  parameters: {},
+  args: {},
+};
+
+export const Disabled = {
+  args: {
+    disabled: true,
+  },
+};

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
@@ -8,19 +8,19 @@ export default {
   component: ThemeToggle,
   
   argTypes: {},
-  decorators: [
-    (Story, context) => {
-      const theme = context.args.theme
-      return (
-        <StyleProvider theme={theme}>
-          <div className="jn-p-12" style={{ minHeight: "250px" }}>
-            <Story />
-            <p> Some content. </p>
-          </div>
-        </StyleProvider>
-      )
-    },
-  ],
+  // decorators: [
+  //   (Story, context) => {
+  //     const theme = context.args.theme
+  //     return (
+  //       <StyleProvider theme={theme}>
+  //         <div className="jn-p-12" style={{ minHeight: "250px" }}>
+  //           <Story />
+  //           <p> Some content. </p>
+  //         </div>
+  //       </StyleProvider>
+  //     )
+  //   },
+  // ],
 };
 
 const Template = (args) => <ThemeToggle {...args} />;

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
@@ -2,6 +2,8 @@ import React from "react";
 import { ThemeToggle } from "./index";
 import { StyleProvider } from "../StyleProvider/index";
 
+// TODO: update decorator to accept a theme
+
 export default {
   title: "Components/ThemeToggle",
   component: ThemeToggle,

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
@@ -10,14 +10,17 @@ export default {
   
   argTypes: {},
   decorators: [
-    (Story) => (
-      <StyleProvider theme="theme-light">
-        <div className="jn-p-12" style={{ minHeight: "250px" }}>
-          <Story />
-          <p> Some content. </p>
-        </div>
-      </StyleProvider>
-    ),
+    (Story, context) => {
+      const theme = context.args.theme
+      return (
+        <StyleProvider theme={theme}>
+          <div className="jn-p-12" style={{ minHeight: "250px" }}>
+            <Story />
+            <p> Some content. </p>
+          </div>
+        </StyleProvider>
+      )
+    },
   ],
 };
 
@@ -27,6 +30,12 @@ export const Default = {
   parameters: {},
   args: {},
 };
+
+export const LightTheme = {
+  args: {
+    theme: "theme-light"
+  }
+}
 
 export const Disabled = {
   args: {

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
@@ -2,7 +2,6 @@ import React from "react";
 import { ThemeToggle } from "./index";
 import { StyleProvider } from "../StyleProvider/index";
 
-// TODO: update decorator to accept a theme
 
 export default {
   title: "Components/ThemeToggle",

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { ThemeToggle } from "./index";
-import { StyleProvider } from "../StyleProvider/";
+import { StyleProvider } from "../StyleProvider/index";
 
 export default {
   title: "Components/ThemeToggle",

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.test.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.test.js
@@ -1,0 +1,27 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { ThemeToggle } from "./index"
+
+
+describe("Toast", () => {
+  test("render a ThemeToggle", async () => {
+    render(<ThemeToggle />)
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveClass("juno-theme-toggle")
+  })
+
+  test("renders a custom classNames as passed", async () => {
+    render(<ThemeToggle className="my-custom-class" />)
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveClass("my-custom-class")
+  })
+
+  test("renders arbitrary props as passed", async () => {
+    render(<ThemeToggle data-lolol="My theme toggle" />)
+    expect(screen.getByRole("button")).toHaveAttribute(
+      "data-lolol",
+      "My theme toggle"
+    )
+  })
+})

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.test.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.test.js
@@ -1,14 +1,64 @@
 import * as React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { ThemeToggle } from "./index"
+import { StyleProvider} from "../StyleProvider/index"
 
+const mockOnToggleTheme = jest.fn()
 
-describe("Toast", () => {
+describe("ThemeToggle", () => {
+  let consoleWarnSpy;
+  
+  
+  // Set up console.warn spy
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  })
+  
+  // Restore console.warn after each test
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+  
   test("render a ThemeToggle", async () => {
     render(<ThemeToggle />)
     expect(screen.getByRole("button")).toBeInTheDocument()
     expect(screen.getByRole("button")).toHaveClass("juno-theme-toggle")
+  })
+  
+  test("renders a disabled ThemeToggle as passed", async () => {
+    render(<ThemeToggle disabled/>)
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toBeDisabled()
+  })
+  
+  test("renders an id as passed", async () => {
+    render(<ThemeToggle id="my-theme-toggle"/>)
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveAttribute("id", "my-theme-toggle")
+  })
+  
+  test("renders a name as passed", async () => {
+    render(<ThemeToggle name="my-theme-toggle"/>)
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveAttribute("name", "my-theme-toggle")
+  }) 
+  
+  test("logs a console warning when no theme context is provided", async () => {
+    render(<ThemeToggle name="my-theme-toggle"/>)
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+     "ThemeToggle requires a StyleProvider context in order to work. Use ThemeToggle in a Juno AppShell or include StyleProvider manually."
+    )
+  })
+  
+  test("executes an onToggle handler when the user toggles the theme", async () => {
+    render(<ThemeToggle onToggleTheme={mockOnToggleTheme} />)
+    const user = userEvent.setup()
+    const toggleButton = screen.getByRole("button")
+    user.click(toggleButton)
+    await waitFor(() => {
+      expect(mockOnToggleTheme).toHaveBeenCalled()
+    })
   })
 
   test("renders a custom classNames as passed", async () => {

--- a/packages/ui-components/src/components/ThemeToggle/ThemeToggle.test.js
+++ b/packages/ui-components/src/components/ThemeToggle/ThemeToggle.test.js
@@ -47,7 +47,7 @@ describe("ThemeToggle", () => {
   test("logs a console warning when no theme context is provided", async () => {
     render(<ThemeToggle name="my-theme-toggle"/>)
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-     "ThemeToggle requires a StyleProvider context in order to work. Use ThemeToggle in a Juno AppShell or include StyleProvider manually."
+     "Juno ThemeToggle requires a StyleProvider context in order to work. Use ThemeToggle in a Juno AppShell or include StyleProvider manually."
     )
   })
   

--- a/packages/ui-components/src/components/ThemeToggle/index.js
+++ b/packages/ui-components/src/components/ThemeToggle/index.js
@@ -1,0 +1,1 @@
+export { ThemeToggle } from "./ThemeToggle.component.js";

--- a/packages/ui-components/src/hooks/useLocalStorage.js
+++ b/packages/ui-components/src/hooks/useLocalStorage.js
@@ -1,0 +1,40 @@
+import { useState, useEffect } from "react";
+
+/** 
+A hook to handle local storage. 
+
+Local storage can be used like a state variable. To initialize, pass the key and a default value:
+
+const [val, setVal] = useLocalStorage("my-val", "default value");
+
+*/
+function useLocalStorage(key, initialValue) {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.log("Juno Error: useLocalStorage error: ", error);
+      return initialValue;
+    }
+  });
+
+  const setValue = (value) => {
+    try {
+      // Optionally allow value to be a function, so it can be used just as useState:
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // save to our state:
+      setStoredValue(valueToStore);
+      // persist to local storage:
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (error) {
+      console.log("Juno Error: useLocalStorage error: ", error);
+      return initialValue;
+    }
+  };
+
+  return [storedValue, setValue];
+}
+
+export default useLocalStorage;


### PR DESCRIPTION
# ThemeToggle

Adds a ThemeToggle component to allow users manually toggling between Light and Dark UI themes, and persist their choice in localStorage.

# Changes Made

- add a `ThemeToggle` component
- add a `useLocalStorage` hook
- update `StyleProvider` component to
   - use `localStorage` hook to read and write the current user preference from localStorage
   - expose the current theme name in the StyleProvider context 


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. Step 1
2. Step 2
3. Step 3

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.


Closes #66 