### PR TITLE
Fix select menu position issue 67

### DIFF
--- a/.changeset/fix-select-menu-bottom-placment.md
+++ b/.changeset/fix-select-menu-bottom-placment.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+Fix select menu position issue 67 by switching from `flip()` to `autoPlacment()` placement strategy in headless ui middleware.

--- a/packages/ui-components/src/components/Select/Select.component.js
+++ b/packages/ui-components/src/components/Select/Select.component.js
@@ -11,7 +11,7 @@ import { Icon } from "../Icon/Icon.component"
 import { Spinner } from "../Spinner/Spinner.component"
 import { FormHint } from "../FormHint/FormHint.component"
 import { Float } from "@headlessui-float/react"
-import { flip, offset, shift, size } from "@floating-ui/react-dom"
+import { autoPlacement, flip, offset, shift, size } from "@floating-ui/react-dom"
 import { usePortalRef } from "../PortalProvider/index"
 import { createPortal } from "react-dom"
 import "./select.scss"
@@ -169,8 +169,16 @@ export const Select = ({
   // Headless-UI-Float Middleware
   const middleware = [
     offset(4),
-    shift(),
-    flip(),
+    //flip(),
+    autoPlacement(
+      (state) => (
+        console.log(state),
+        {
+          crossAxis: true,
+          allowedPlacements: ["bottom", "top"],
+        }
+      )
+    ),
     size({
       boundary: "viewport",
       apply({ availableWidth, availableHeight, elements }) {
@@ -181,6 +189,7 @@ export const Select = ({
         })
       },
     }),
+    shift(),
   ]
 
   // This function is used to determine what to render for the selected options in the Select Toggle in multi-select case.

--- a/packages/ui-components/src/components/Select/Select.component.js
+++ b/packages/ui-components/src/components/Select/Select.component.js
@@ -169,15 +169,13 @@ export const Select = ({
   // Headless-UI-Float Middleware
   const middleware = [
     offset(4),
-    //flip(),
-    autoPlacement(
-      (state) => (
-        console.log(state),
-        {
-          crossAxis: true,
-          allowedPlacements: ["bottom", "top"],
-        }
-      )
+    autoPlacement((state) =>
+      // Uncomment to examine Headless-UI-Floating middleware:
+      // console.log(state),
+      ({
+        crossAxis: true,
+        allowedPlacements: ["bottom", "top"],
+      })
     ),
     size({
       boundary: "viewport",

--- a/packages/ui-components/src/components/Select/Select.stories.js
+++ b/packages/ui-components/src/components/Select/Select.stories.js
@@ -84,8 +84,26 @@ ControlledTemplate.propTypes = {
   children: PropTypes.node,
 }
 
+const PageBottomTemplate = ({ children, ...args }) => (
+  <div style={{ position: "absolute", bottom: "0" }}>
+    Page Bottom Select
+    <Select {...args}>{children}</Select>
+  </div>
+)
+
 export const Default = {
   render: Template,
+  args: {
+    children: [
+      <SelectOption key="1" value="Option 1" />,
+      <SelectOption key="2" value="Option 2" />,
+      <SelectOption key="3" value="Option 3" />,
+    ],
+  },
+}
+
+export const PageBottom = {
+  render: PageBottomTemplate,
   args: {
     children: [
       <SelectOption key="1" value="Option 1" />,

--- a/packages/ui-components/src/components/Select/Select.stories.js
+++ b/packages/ui-components/src/components/Select/Select.stories.js
@@ -84,8 +84,8 @@ ControlledTemplate.propTypes = {
   children: PropTypes.node,
 }
 
-const PageBottomTemplate = ({ children, ...args }) => (
-  <div style={{ position: "absolute", bottom: "0" }}>
+const PageBottomTemplate = ({ parentStyles, children, ...args }) => (
+  <div style={parentStyles}>
     Page Bottom Select
     <Select {...args}>{children}</Select>
   </div>
@@ -105,10 +105,15 @@ export const Default = {
 export const PageBottom = {
   render: PageBottomTemplate,
   args: {
+    parentStyles: {
+      position: "absolute",
+      bottom: "0",
+    },
     children: [
       <SelectOption key="1" value="Option 1" />,
       <SelectOption key="2" value="Option 2" />,
       <SelectOption key="3" value="Option 3" />,
+      <SelectOption key="4" value="Option 4" />,
     ],
   },
 }

--- a/packages/ui-components/src/components/Select/Select.stories.js
+++ b/packages/ui-components/src/components/Select/Select.stories.js
@@ -84,9 +84,9 @@ ControlledTemplate.propTypes = {
   children: PropTypes.node,
 }
 
-const PageBottomTemplate = ({ parentStyles, children, ...args }) => (
+const BottomPositionTemplate = ({ parentStyles, children, ...args }) => (
   <div style={parentStyles}>
-    Page Bottom Select
+    Bottom Positioned Select
     <Select {...args}>{children}</Select>
   </div>
 )
@@ -98,22 +98,6 @@ export const Default = {
       <SelectOption key="1" value="Option 1" />,
       <SelectOption key="2" value="Option 2" />,
       <SelectOption key="3" value="Option 3" />,
-    ],
-  },
-}
-
-export const PageBottom = {
-  render: PageBottomTemplate,
-  args: {
-    parentStyles: {
-      position: "absolute",
-      bottom: "0",
-    },
-    children: [
-      <SelectOption key="1" value="Option 1" />,
-      <SelectOption key="2" value="Option 2" />,
-      <SelectOption key="3" value="Option 3" />,
-      <SelectOption key="4" value="Option 4" />,
     ],
   },
 }
@@ -555,6 +539,22 @@ export const MultiSelectWithOptionValuesAndLabels = {
       <SelectOption key="1" value="opt-1" label="Option 1" />,
       <SelectOption key="2" value="opt-2" label="Option 2" />,
       <SelectOption key="3" value="opt-3" label="Option 3" />,
+    ],
+  },
+}
+
+export const BottomPositionedSelect = {
+  render: BottomPositionTemplate,
+  args: {
+    parentStyles: {
+      position: "absolute",
+      bottom: "0",
+    },
+    children: [
+      <SelectOption key="1" value="Option 1" />,
+      <SelectOption key="2" value="Option 2" />,
+      <SelectOption key="3" value="Option 3" />,
+      <SelectOption key="4" value="Option 4" />,
     ],
   },
 }


### PR DESCRIPTION
# Summary

This PR makes sure the Select menu is always visible and usable, regardless where on a page or view the Select is located.

So far, a Select placed at the bottom of a page or view opened its menu downwards, outside of the viewport, while it *should* open upwards in order the be fully visible and usable. 

**Background:** 
Our Select internally uses Headless UI Select with Headless UI Float middleware to handle positioning of the menu.

Headless UI Float has two different placement strategies, `flip()` and `autoPlacement()`. 

`Flip()`, which we have used so far, should do smart auto-detection and place an element such as a menu in the desired direction, until it runs out of available space. For some reason we could not figure out in a timely manner, this does not always seem to work as expected. (https://floating-ui.com/docs/flip)

`autoPlacement()` however simply shows an element in the direction where the most net available space is, and appears to be working fine and robustly in all situations we have tried. (https://floating-ui.com/docs/autoplacement)

At a later point we may inspect the issue with usiing `flip()` further, but in order to have a robust solution now we have switched to `autoPlacement()`.

# Changes Made

* replace positioning strategy in headless ui float's middleware with `autoPlacement()`
* add a story to check for placment behaviour
* keep a commented out way to easily log the state of headless ui middleware for future usage

# Related Issues

closes #67 