### PR TITLE
fix(build): fix package output directory issues

### DIFF
--- a/.changeset/fresh-poems-wash.md
+++ b/.changeset/fresh-poems-wash.md
@@ -1,0 +1,7 @@
+---
+"@cloudoperators/juno-communicator": patch
+"@cloudoperators/juno-k8s-client": patch
+"@cloudoperators/juno-oauth": patch
+---
+
+Fix package output directory issue by adding --outDir option to Vite CLI.

--- a/packages/communicator/package.json
+++ b/packages/communicator/package.json
@@ -8,6 +8,7 @@
   ],
   "type": "module",
   "main": "build/index.js",
+  "module": "build/index.js",
   "types": "build/types/index.d.ts",
   "files": [
     "build/**",
@@ -16,7 +17,6 @@
   "repository": "https://github.com/cloudoperators/juno/tree/main/packages/communicator",
   "license": "Apache-2.0",
   "source": "src/index.js",
-  "module": "build/index.js",
   "engines": {
     "node": ">=20.0.0 <21.0.0",
     "npm": ">=10.0.0 <11.0.0"
@@ -26,7 +26,7 @@
     "test:watch": "vitest --watch",
     "lint": "eslint ",
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build --outDir build",
     "serve": "vite preview",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf build && rm -rf node_modules && rm -rf .turbo"

--- a/packages/k8s-client/package.json
+++ b/packages/k8s-client/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build --outDir build",
     "serve": "vite preview",
     "clean": "rm -rf build && rm -rf node_modules && rm -rf .turbo"
   },

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build --outDir build",
     "serve": "vite preview",
     "clean": "rm -rf build && rm -rf node_modules && rm -rf .turbo"
   }


### PR DESCRIPTION
# Summary

The recent changes to the main and module entries in the package.json files for communicator, k8sClient, and oauth broke these packages. Since the build is done with Vite and the default output folder is dist, there was a discrepancy between the settings and the actual output folders.

This was fixed by adding the --outDir option to the Vite CLI.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Add `--outDir` option to vite CLI in
  - oauth
  - communicator
  - k8sclient

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
