### PR TITLE
chore(ci): switch back to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,5 +39,5 @@ jobs:
           title: "publish(npm): automate Package Versioning and Publishing with Changesets"
           commit: "chore(version): update versions with Changesets"
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Summary

This PR updates the key in the release workflow from CHANGESET_GITHUB_TOKEN to GITHUB_TOKEN. We had previously used CHANGESET_GITHUB_TOKEN, a personal access token (PAT), in an attempt to make the checks work for release PRs. Unfortunately, this approach was unsuccessful, so we are reverting back to GITHUB_TOKEN to ensure that the author of automated release PRs is correctly set to the GitHub bot again.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
