### PR TITLE
fix(ci): fixes posting slack messages with JSON content from the step before

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,8 +49,37 @@ jobs:
         with:
           payload: |
             {
-              "text": "🎉 JUNO Packages Released Successfully! 🚀 - ${{ steps.changesets.outputs.publishedPackages }}",
-              "icon_url": "https://raw.githubusercontent.com/cloudoperators/juno/main/packages/ui-components/src/img/ccloud_shape.svg"
+              "blocks": [
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "image",
+                      "image_url": "https://avatars.githubusercontent.com/u/160245993?s=48&v=4",
+                      "alt_text": "cloudoperators/juno"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "JUNO Packages Released Successfully! 🚀"
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "text",
+                          "text": ${{ toJson(steps.changesets.outputs.publishedPackages) }}
+                        }
+                      ],
+                      "border": 0
+                    }
+                  ]
+                }
+              ]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Summary

This PR addresses an issue with sending Slack notifications where JSON content was not being posted correctly. The notification failed due to improper integration of JSON content as a substring in the value of the payload.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Fixes Posting Slack Messages with JSON Content
- Resolved Slack Notification Failure

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 1: [link to issue]

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
