### PR TITLE
fix(supernova): bind disabled TextInput directly to authName

### DIFF
--- a/.changeset/green-paws-warn.md
+++ b/.changeset/green-paws-warn.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-supernova": patch
+---
+
+Prevent editable TextInputs if name was given by auth.

--- a/apps/supernova/src/components/silences/RecreateSilence.jsx
+++ b/apps/supernova/src/components/silences/RecreateSilence.jsx
@@ -17,7 +17,7 @@ import {
   Pill,
   Stack,
 } from "@cloudoperators/juno-ui-components"
-import { useAuthData, useGlobalsApiEndpoint, useSilencesActions, useAuthUserEditable } from "../../hooks/useAppStore"
+import { useAuthData, useGlobalsApiEndpoint, useSilencesActions } from "../../hooks/useAppStore"
 import { debounce } from "../../helpers"
 import { post } from "../../api/client"
 import { DateTime } from "luxon"
@@ -58,7 +58,6 @@ const RecreateSilence = (props) => {
   const fingerprint = props.fingerprint ? props.fingerprint : null
   const authData = useAuthData()
   const apiEndpoint = useGlobalsApiEndpoint()
-  const isNameEditable = useAuthUserEditable()
 
   const { addLocalItem } = useSilencesActions()
 
@@ -211,7 +210,7 @@ const RecreateSilence = (props) => {
                     required
                     label="Silenced by"
                     value={formState.createdBy}
-                    disabled={!isNameEditable}
+                    disabled={!!authData?.parsed?.fullName}
                     onChange={(e) => onInputChanged({ key: "createdBy", value: e.target.value })}
                     errortext={showValidation["createdBy"] && errorHelpText(showValidation["createdBy"])}
                   />

--- a/apps/supernova/src/components/silences/SilenceNew.jsx
+++ b/apps/supernova/src/components/silences/SilenceNew.jsx
@@ -22,7 +22,6 @@ import {
   useGlobalsApiEndpoint,
   useSilencesActions,
   useAlertEnrichedLabels,
-  useAuthUserEditable,
 } from "../../hooks/useAppStore"
 import { post } from "../../api/client"
 import AlertDescription from "../alerts/shared/AlertDescription"
@@ -67,7 +66,6 @@ const SilenceNew = ({ alert, size, variant }) => {
   const excludedLabels = useSilencesExcludedLabels()
   const { addLocalItem, getMappingSilences } = useSilencesActions()
   const enrichedLabels = useAlertEnrichedLabels()
-  const isNameEditable = useAuthUserEditable()
 
   const [displayNewSilence, setDisplayNewSilence] = useState(false)
   const [formState, setFormState] = useState(DEFAULT_FORM_VALUES)
@@ -226,7 +224,7 @@ const SilenceNew = ({ alert, size, variant }) => {
                     value={formState.createdBy}
                     onChange={(e) => onInputChanged({ key: "createdBy", value: e.target.value })}
                     errortext={showValidation["createdBy"] && errorHelpText(showValidation["createdBy"])}
-                    disabled={!isNameEditable}
+                    disabled={!!authData?.parsed?.fullName}
                   />
                 </FormRow>
                 <FormRow>

--- a/apps/supernova/src/components/silences/SilenceScheduled.jsx
+++ b/apps/supernova/src/components/silences/SilenceScheduled.jsx
@@ -22,13 +22,7 @@ import {
   FormSection,
   DateTimePicker,
 } from "@cloudoperators/juno-ui-components"
-import {
-  useAuthData,
-  useSilenceTemplates,
-  useGlobalsApiEndpoint,
-  useSilencesActions,
-  useAuthUserEditable,
-} from "../../hooks/useAppStore"
+import { useAuthData, useSilenceTemplates, useGlobalsApiEndpoint, useSilencesActions } from "../../hooks/useAppStore"
 import { post } from "../../api/client"
 import { parseError } from "../../helpers"
 
@@ -39,7 +33,6 @@ const SilenceScheduled = (props) => {
   const { addMessage, resetMessages } = useActions()
   const silenceTemplates = useSilenceTemplates()
   const apiEndpoint = useGlobalsApiEndpoint()
-  const isNameEditable = useAuthUserEditable()
   const { addLocalItem } = useSilencesActions()
 
   // set sucess of sending the silence
@@ -255,7 +248,7 @@ const SilenceScheduled = (props) => {
                     value={formState?.createdBy?.value}
                     errortext={formState?.createdBy?.error}
                     onChange={(e) => onInputChanged({ key: "createdBy", value: e.target.value })}
-                    disabled={!isNameEditable}
+                    disabled={!!authData?.parsed?.fullName}
                   />
                 </FormRow>
                 <FormRow>

--- a/apps/supernova/src/lib/createAuthDataSlice.js
+++ b/apps/supernova/src/lib/createAuthDataSlice.js
@@ -12,7 +12,6 @@ const createAuthDataSlice = (set, get) => ({
   auth: {
     data: null,
     loggedIn: false,
-    userEditable: true,
 
     actions: {
       setData: (data) => {
@@ -26,7 +25,6 @@ const createAuthDataSlice = (set, get) => ({
               ...state.auth,
               loggedIn: data?.loggedIn,
               data: data?.auth,
-              userEditable: !!data.auth?.parsed?.fullName,
             },
           }),
           false,


### PR DESCRIPTION
# Summary

Bind disabled TextInput directly to authName to ensure correctness. To ensure the field is disabled if there is a name.

