### PR TITLE
fix(supernova): fixes the issue where the support group filter was re-added when the active filters became empty

### DIFF
--- a/.changeset/gentle-rabbits-add.md
+++ b/.changeset/gentle-rabbits-add.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-supernova": patch
+---
+
+fixes the issue where the support group filter was re-added when the active filters became empty

--- a/apps/supernova/public/index.html
+++ b/apps/supernova/public/index.html
@@ -6,8 +6,8 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8"/>
-    <link rel="icon" href="favicon.ico" sizes="any"/>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="favicon.ico" sizes="any" />
     <title>Supernova Dev</title>
     <style>
       html {
@@ -35,8 +35,8 @@
     <script type="module">
       // appProps are generated in development env and added to the build
       import allProps from "./build/appProps.js"
-      import ("./build/index.js").then((app) => {
-        app.mount(document.getElementById("root"), {props: allProps.appProps})
+      import("./build/index.js").then((app) => {
+        app.mount(document.getElementById("root"), { props: allProps.appProps })
       })
     </script>
     <div id="root"></div>

--- a/apps/supernova/public/index.html
+++ b/apps/supernova/public/index.html
@@ -6,8 +6,8 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="favicon.ico" sizes="any" />
+    <meta charset="UTF-8"/>
+    <link rel="icon" href="favicon.ico" sizes="any"/>
     <title>Supernova Dev</title>
     <style>
       html {
@@ -35,8 +35,8 @@
     <script type="module">
       // appProps are generated in development env and added to the build
       import allProps from "./build/appProps.js"
-      import("./build/index.js").then((app) => {
-        app.mount(document.getElementById("root"), { props: allProps.appProps })
+      import ("./build/index.js").then((app) => {
+        app.mount(document.getElementById("root"), {props: allProps.appProps})
       })
     </script>
     <div id="root"></div>

--- a/apps/supernova/src/hooks/useCommunication.js
+++ b/apps/supernova/src/hooks/useCommunication.js
@@ -3,50 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useCallback } from "react"
+import { useEffect } from "react"
 import { get, watch } from "@cloudoperators/juno-communicator"
-import {
-  useUserActivityActions,
-  useAuthActions,
-  useActiveFilters,
-  useFilterActions,
-  useFilterLabels,
-  useGlobalsIsURLRead,
-} from "./useAppStore"
+import { useUserActivityActions, useAuthActions, useGlobalsIsURLRead } from "./useAppStore"
 
 const useCommunication = () => {
-  console.debug("[supernova] useCommunication setup")
   const isURLRead = useGlobalsIsURLRead()
   const { setIsActive } = useUserActivityActions()
-  const { setData: authSetData } = useAuthActions()
-  const activeFilters = useActiveFilters()
-  const { setActiveFilters } = useFilterActions()
-  const filterLabels = useFilterLabels()
-
-  const setAuthData = useCallback(
-    (data) => {
-      if (!data) return
-
-      // set the auth data
-      authSetData(data)
-
-      // The following code exists of historical reasons and should be refactored
-      // We preset the support group filter based on auth data. This should be done
-      // with predefined filters prop
-
-      // check if activeFilters are set and skip if they are
-      // activeFilters example: {support_group: Array(1)}
-      if (
-        activeFilters &&
-        Object.keys(activeFilters).length === 0 &&
-        data?.auth?.parsed?.supportGroups &&
-        filterLabels?.includes("support_group")
-      ) {
-        setActiveFilters({ support_group: data.auth.parsed.supportGroups })
-      }
-    },
-    [authSetData, filterLabels, activeFilters]
-  )
+  const { setData: authSetData, setSupportGroup } = useAuthActions()
 
   useEffect(() => {
     // watch for user activity updates messages
@@ -62,16 +26,23 @@ const useCommunication = () => {
     return unwatch
   }, [setIsActive])
 
+  // WATCH for auth data updates
+  // GET the auth data initially
   useEffect(() => {
-    if (!isURLRead || !setAuthData) return
-
-    get("AUTH_GET_DATA", setAuthData)
-    const unwatchUpdate = watch("AUTH_UPDATE_DATA", setAuthData)
-
+    if (!isURLRead) return
+    get("AUTH_GET_DATA", (data) => {
+      authSetData(data)
+      setSupportGroup(data?.auth?.parsed?.supportGroups)
+    })
+    const unwatchUpdate = watch("AUTH_UPDATE_DATA", (data) => {
+      authSetData(data)
+      // TODO: if the user gets reauthenticated we would reset all active filters with the support group. This would be fixed once the initial filters with the support group is set
+      setSupportGroup(data?.auth?.parsed?.supportGroups)
+    })
     return () => {
       if (unwatchUpdate) unwatchUpdate()
     }
-  }, [setAuthData, isURLRead])
+  }, [isURLRead])
 }
 
 export default useCommunication

--- a/apps/supernova/src/lib/createAuthDataSlice.js
+++ b/apps/supernova/src/lib/createAuthDataSlice.js
@@ -15,6 +15,16 @@ const createAuthDataSlice = (set, get) => ({
     userEditable: true,
 
     actions: {
+      // The following method is a temporary fix and should be refactored
+      // We preset the support group filter based on auth data. This should be done
+      // with predefined filters prop
+      setSupportGroup: (supportGroup) => {
+        if (!supportGroup) return
+        const activeFilters = get().filters.activeFilters
+        if (Object.keys(activeFilters).length === 0 && get().filters.labels?.includes("support_group")) {
+          get().filters.actions.setActiveFilters({ support_group: supportGroup })
+        }
+      },
       setData: (data) => {
         if (!data) return
         // check if data has changed before updating the state


### PR DESCRIPTION
# Summary

Fixes an issue where the support group filter was re-added when the active filters were cleared. The logic has been temporarily moved to the store to prevent unnecessary re-renders.

### Changes Made:
- Added a new method to the Auth slice (to be removed once initial filter setup is implemented)
- Refactored the `useCommunication` hook for better performance and clarity.


# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 1: [link to issue]

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
