### PR TITLE
fix(heureka): fixes details panel deep link handling

### DIFF
--- a/apps/heureka/src/components/CustomAppShell.jsx
+++ b/apps/heureka/src/components/CustomAppShell.jsx
@@ -5,7 +5,7 @@
 
 import React from "react"
 import { AppShell, PageHeader, TopNavigation, TopNavigationItem } from "@cloudoperators/juno-ui-components"
-import { useGlobalsActions, useGlobalsActiveNavEntry } from "../hooks/useAppStore"
+import { useGlobalsActions, useGlobalsActiveView } from "../hooks/useAppStore"
 import ServicesView from "./services/ServicesView"
 import IssueMatchesView from "./issueMatches/IssueMatchesView"
 import ComponentsView from "./components/ComponentsView"
@@ -20,7 +20,7 @@ const VIEW_CONFIG = {
 
 const CustomAppShell = ({ children }) => {
   const { setActiveView, setShowPanel } = useGlobalsActions()
-  const activeView = useGlobalsActiveNavEntry()
+  const activeView = useGlobalsActiveView()
 
   const handleNavItemChange = (item) => {
     setActiveView(item)

--- a/apps/heureka/src/components/issueMatches/IssueMatchesDetails.jsx
+++ b/apps/heureka/src/components/issueMatches/IssueMatchesDetails.jsx
@@ -17,7 +17,7 @@ const IssueMatchesDetails = () => {
 
   const issueElem = useQuery({
     queryKey: ["IssueMatchesMain", { filter: { id: [showIssueDetail] } }],
-    enabled: !!queryClientFnReady,
+    enabled: !!queryClientFnReady && !!showIssueDetail,
   })
   const issue = useMemo(() => {
     if (!issueElem) return null

--- a/apps/heureka/src/components/services/ServicesDetails.jsx
+++ b/apps/heureka/src/components/services/ServicesDetails.jsx
@@ -33,7 +33,7 @@ const ServicesDetail = () => {
 
   const serviceElem = useQuery({
     queryKey: ["ServicesMain", { filter: { serviceName: [showServiceDetail] } }],
-    enabled: !!queryClientFnReady,
+    enabled: !!queryClientFnReady && !!showServiceDetail,
   })
 
   const users = useQuery({

--- a/apps/heureka/src/components/shared/ListController.jsx
+++ b/apps/heureka/src/components/shared/ListController.jsx
@@ -9,14 +9,14 @@ import { useGlobalsQueryClientFnReady, useGlobalsQueryOptions, useGlobalsActions
 import { Pagination, Container, Stack } from "@cloudoperators/juno-ui-components"
 import { useActions as messageActions } from "@cloudoperators/juno-messages-provider"
 import { parseError } from "../../helpers"
-import { useGlobalsActiveNavEntry } from "../../hooks/useAppStore"
+import { useGlobalsActiveView } from "../../hooks/useAppStore"
 
 const ListController = ({ queryKey, entityName, ListComponent, activeFilters, searchTerm, enableSearchAndFilter }) => {
   const queryClientFnReady = useGlobalsQueryClientFnReady()
   const queryOptions = useGlobalsQueryOptions(queryKey)
   const { setQueryOptions } = useGlobalsActions()
   const { addMessage, resetMessages } = messageActions()
-  const activeView = useGlobalsActiveNavEntry()
+  const activeView = useGlobalsActiveView()
 
   // Fetch view main data
   const {

--- a/apps/heureka/src/components/shared/constants.js
+++ b/apps/heureka/src/components/shared/constants.js
@@ -10,5 +10,7 @@ module.exports = {
   ACTIVE_FILTERS: "f",
   SEARCH_TERM: "s",
   DETAILS_FOR: "d",
-  ACTIVE_NAV: "n",
+  ACTIVE_VIEW: "v",
+  SERVICE_NAME: "svc", // Abbreviation for service name
+  ISSUE_ID: "iid", // Abbreviation for issue ID
 }

--- a/apps/heureka/src/hooks/useAppStore.js
+++ b/apps/heureka/src/hooks/useAppStore.js
@@ -41,9 +41,8 @@ const useAppStore = (selector) => useStore(useContext(StoreContext), selector)
 // Globals exports
 export const useGlobalsEmbedded = () => useAppStore((state) => state.globals.embedded)
 export const useGlobalsQueryClientFnReady = () => useAppStore((state) => state.globals.queryClientFnReady)
-export const useGlobalsActiveNavEntry = () => useAppStore((state) => state.globals.activeView)
-export const useGlobalsQueryOptions = (navEntry) =>
-  useAppStore((state) => state.globals.navEntries[navEntry].queryOptions)
+export const useGlobalsActiveView = () => useAppStore((state) => state.globals.activeView)
+export const useGlobalsQueryOptions = (viewName) => useAppStore((state) => state.globals.views[viewName].queryOptions)
 export const useGlobalsApiEndpoint = () => useAppStore((state) => state.globals.apiEndpoint)
 export const useGlobalsShowPanel = () => useAppStore((state) => state.globals.showPanel)
 export const useGlobalsShowServiceDetail = () => useAppStore((state) => state.globals.showServiceDetail)

--- a/apps/heureka/src/lib/slices/createFiltersSlice.js
+++ b/apps/heureka/src/lib/slices/createFiltersSlice.js
@@ -153,7 +153,7 @@ const createFiltersSlice = (set, get) => ({
           `filters.setFiltersFromURL`
         ),
 
-      syncFiltersWithURL: (detailsFor, activeView) => {
+      syncFiltersWithURL: () => {
         const encodedSearchTerm = btoa(
           JSON.stringify({
             [ISSUEMATCHES]: get().filters[ISSUEMATCHES].search,
@@ -171,8 +171,6 @@ const createFiltersSlice = (set, get) => ({
         return {
           [constants.ACTIVE_FILTERS]: activeFilters,
           [constants.SEARCH_TERM]: encodedSearchTerm,
-          [constants.DETAILS_FOR]: detailsFor,
-          [constants.ACTIVE_NAV]: activeView,
         }
       },
     },

--- a/apps/heureka/src/lib/slices/createGlobalsSlice.js
+++ b/apps/heureka/src/lib/slices/createGlobalsSlice.js
@@ -12,12 +12,12 @@ const createGlobalsSlice = (set, get, options) => ({
     apiEndpoint: options?.apiEndpoint, //The API endpoint to use for fetching data.
     isUrlStateSetup: false, //Set to true when the URL state has been set up.
     queryClientFnReady: false, //Set to true when the queryClient function is ready to be used.
-    activeView: "Services", //Set to the active navEntry.
+    activeView: "Services", //Set to the active view.
     showPanel: constants.PANEL_NONE, //Set to the which panel should be shown (e.g service details panel, issue matches details panel and so on), if any.
 
     showServiceDetail: null,
     showIssueDetail: null,
-    navEntries: {
+    views: {
       Services: {
         queryOptions: {
           first: 20,
@@ -45,10 +45,10 @@ const createGlobalsSlice = (set, get, options) => ({
           "globals/setQueryClientFnReady"
         ),
 
-      setQueryOptions: (navEntry, options) =>
+      setQueryOptions: (viewName, options) =>
         set(
           produce((state) => {
-            state.globals.navEntries[navEntry].queryOptions = options
+            state.globals.views[viewName].queryOptions = options
           }),
           false,
           "globals/setQueryOptions"
@@ -96,6 +96,39 @@ const createGlobalsSlice = (set, get, options) => ({
           false,
           "globals/setShowIssueDetail"
         ),
+      // Helper function to set the service detail for deep linking
+      setServiceDetail: (serviceId) =>
+        set(
+          produce((state) => {
+            state.globals.showPanel = constants.PANEL_SERVICE
+            state.globals.showServiceDetail = serviceId
+          }),
+          false,
+          "globals/setServiceDetail"
+        ),
+
+      // Helper function to set the issue detail for deep linking
+      setIssueDetail: (issueId) =>
+        set(
+          produce((state) => {
+            state.globals.showPanel = constants.PANEL_ISSUE
+            state.globals.showIssueDetail = issueId
+          }),
+          false,
+          "globals/setIssueDetail"
+        ),
+
+      // Sync details state with the URL
+      syncDetailsWithURL: () => {
+        const state = get().globals
+        const updatedState = {
+          [constants.DETAILS_FOR]: state.showPanel,
+          // Include `iid` or `svn` immediately after `d:issue/service`
+          [state.showPanel === constants.PANEL_SERVICE ? constants.SERVICE_NAME : constants.ISSUE_ID]:
+            state.showPanel === constants.PANEL_SERVICE ? state.showServiceDetail : state.showIssueDetail,
+        }
+        return updatedState
+      },
     },
   },
 })


### PR DESCRIPTION
# Summary

This PR fixes the issue where reloading the app while the details panel is open would cause the panel to show a "busy" state indefinitely. The fix ensures that the details panel information is fully handled within the useUrlState hook, allowing for proper state restoration and display upon reload.

# Changes Made

- Added required functions to the Global slice store to manage and sync details panel info with the URL.
- Renamed some variables for clarity.


# Related Issues

- https://github.com/cloudoperators/heureka/issues/267

# Testing Instructions

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
