### PR TITLE
fix(supernova): errors from the silencesAPI are just parsed if they are not string

### DIFF
--- a/apps/supernova/src/AppContent.jsx
+++ b/apps/supernova/src/AppContent.jsx
@@ -40,11 +40,13 @@ const AppContent = () => {
   const activeSelectedTab = useGlobalsActiveSelectedTab()
 
   useEffect(() => {
+    const errorMessage = typeof silencesError === "string" ? silencesError : parseError(silencesError)
+
     // since the API call is done in a web worker and not logging aware, we need to show the error just in case the user is logged in
     if (!silencesError) return
     addMessage({
       variant: "error",
-      text: parseError(silencesError),
+      text: errorMessage,
     })
   }, [silencesError])
 

--- a/apps/supernova/src/components/silences/SilenceScheduled.jsx
+++ b/apps/supernova/src/components/silences/SilenceScheduled.jsx
@@ -125,7 +125,7 @@ const SilenceScheduled = (props) => {
       .catch((error) => {
         addMessage({
           variant: "error",
-          text: parseError(error),
+          text: `${parseError(error)}`,
         })
       })
   }


### PR DESCRIPTION
fixes #474 

# Changes Made

Checks if error message is a string and not a object and does not parse if its a string.

# Testing Instructions

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
