### PR TITLE
feat(heureka): customizes search placeholder based on different views

### DIFF
--- a/.changeset/two-carrots-mate.md
+++ b/.changeset/two-carrots-mate.md
@@ -3,4 +3,4 @@
 "@cloudoperators/juno-app-greenhouse": patch
 ---
 
-customize search placeholder for issuematches and services views in heureka
+Customized search placeholder for IssueMatches and Services views in heureka

--- a/.changeset/two-carrots-mate.md
+++ b/.changeset/two-carrots-mate.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+customize search placeholder for issuematches and services views in heureka

--- a/apps/heureka/src/components/filters/FilterSelect.jsx
+++ b/apps/heureka/src/components/filters/FilterSelect.jsx
@@ -8,7 +8,15 @@ import { Button, InputGroup, SelectOption, Select, Stack, SearchInput } from "@c
 import { useFilterActions } from "../StoreProvider"
 import { humanizeString } from "../../lib/utils"
 
-const FilterSelect = ({ entityName, isLoading, filterLabels, filterLabelValues, activeFilters, searchTerm }) => {
+const FilterSelect = ({
+  entityName,
+  isLoading,
+  filterLabels,
+  filterLabelValues,
+  activeFilters,
+  searchTerm,
+  searchTargets,
+}) => {
   const [filterLabel, setFilterLabel] = useState("")
   const [filterValue, setFilterValue] = useState("")
 
@@ -65,7 +73,7 @@ const FilterSelect = ({ entityName, isLoading, filterLabels, filterLabelValues, 
         <Button label="Clear all" onClick={() => clearActiveFilters(entityName)} variant="subdued" />
       )}
       <SearchInput
-        placeholder="Search term"
+        placeholder={`search term for ${searchTargets}`}
         className="w-96 ml-auto"
         value={searchTerm || ""}
         onSearch={(value) => setSearchTerm(entityName, value)}

--- a/apps/heureka/src/components/filters/Filters.jsx
+++ b/apps/heureka/src/components/filters/Filters.jsx
@@ -17,7 +17,15 @@ const filtersStyles = `
   my-px
 `
 
-const Filters = ({ queryKey, entityName, filterLabels, filterLabelValues, activeFilters, searchTerm }) => {
+const Filters = ({
+  queryKey,
+  entityName,
+  filterLabels,
+  filterLabelValues,
+  activeFilters,
+  searchTerm,
+  searchTargets,
+}) => {
   const queryClientFnReady = useGlobalsQueryClientFnReady()
   const { setLabels, setFilterLabelValues } = useFilterActions()
 
@@ -59,6 +67,7 @@ const Filters = ({ queryKey, entityName, filterLabels, filterLabelValues, active
         filterLabels={filterLabels}
         filterLabelValues={filterLabelValues}
         searchTerm={searchTerm}
+        searchTargets={searchTargets}
       />
       <FilterPills entityName={entityName} activeFilters={activeFilters} />
     </Stack>

--- a/apps/heureka/src/components/issueMatches/IssueMatchesView.jsx
+++ b/apps/heureka/src/components/issueMatches/IssueMatchesView.jsx
@@ -32,6 +32,7 @@ const IssueMatchesView = () => {
           filterLabelValues={filterLabelValues}
           activeFilters={activeFilters}
           searchTerm={searchTerm}
+          searchTargets="primary name"
         />
         <ListController
           queryKey="IssueMatches"

--- a/apps/heureka/src/components/services/ServicesView.jsx
+++ b/apps/heureka/src/components/services/ServicesView.jsx
@@ -32,6 +32,7 @@ const ServicesView = () => {
           filterLabelValues={filterLabelValues}
           activeFilters={activeFilters}
           searchTerm={searchTerm}
+          searchTargets="service name"
         />
         <ListController
           queryKey="Services"


### PR DESCRIPTION
# Summary

Customized the search input placeholder for the following views:

- IssueMatches view: Placeholder now displays "search term for primary name."
- Services view: Placeholder now displays "search term for service name."

This change provides clearer context for users based on the specific field being searched in each view.


# Related Issues

- https://github.com/cloudoperators/heureka/issues/302

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
