### PR TITLE
chore(heureka): harmonizes filter names in different viewes

### DIFF
--- a/.changeset/sweet-items-rescue.md
+++ b/.changeset/sweet-items-rescue.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+harmonizes filter names across different views

--- a/apps/heureka/src/components/filters/FilterSelect.jsx
+++ b/apps/heureka/src/components/filters/FilterSelect.jsx
@@ -6,7 +6,6 @@
 import React, { useState } from "react"
 import { Button, InputGroup, SelectOption, Select, Stack, SearchInput } from "@cloudoperators/juno-ui-components"
 import { useFilterActions } from "../StoreProvider"
-import { humanizeString } from "../../lib/utils"
 
 const FilterSelect = ({
   entityName,
@@ -48,19 +47,19 @@ const FilterSelect = ({
           name="filter"
           className="filter-label-select w-64 mb-0"
           label="Filter"
-          value={humanizeString(filterLabel)}
+          value={filterLabel}
           onChange={handleFilterLabelChange}
           disabled={isLoading}
         >
-          {filterLabels?.map((filter) => (
-            <SelectOption value={filter} label={humanizeString(filter)} key={filter} />
+          {filterLabels?.map(({ displayName, filterName }) => (
+            <SelectOption value={filterName} label={displayName} key={filterName} />
           ))}
         </Select>
         <Select
           name="filterValue"
           value={filterValue}
           onChange={handleFilterValueChange}
-          disabled={!filterLabelValues[filterLabel]?.length}
+          disabled={!filterLabelValues?.[filterLabel]?.length}
           className="filter-value-select w-96 bg-theme-background-lvl-0"
         >
           {filterOptions?.map((value) => (

--- a/apps/heureka/src/components/filters/Filters.jsx
+++ b/apps/heureka/src/components/filters/Filters.jsx
@@ -51,7 +51,7 @@ const Filters = ({
   }, [data, queryKey])
 
   useEffect(() => {
-    // Set filter labels and values in the store
+    // Set filter labels, names and values in the store
     // It is done in this control as the fetch filter label and values is done above here
     if (filters.length > 0) {
       setLabels(entityName, filters)

--- a/apps/heureka/src/components/filters/Filters.jsx
+++ b/apps/heureka/src/components/filters/Filters.jsx
@@ -35,7 +35,7 @@ const Filters = ({
   })
 
   const filters = useMemo(() => {
-    //Since there is a custom query to fetch filter labels and values for each entity in API
+    //Since there is a custom query to fetch filter labels, names and values for each entity in API
     //We need to map the data to the format that the FilterSelect component expects
     //You can check the response structure of custom query e.g in /lib/queries/serviceFilterValues.js
     if (!data || !data[queryKey]) return []
@@ -43,8 +43,9 @@ const Filters = ({
     return Object.keys(data[queryKey]).map((key) => {
       const field = data[queryKey][key]
       return {
-        label: field.filterName, // Collecting filterName as filterLabel
-        values: field.values, // Collecting values as filterValues
+        displayName: field.displayName, // Display name of the filter
+        filterName: field.filterName, // Name of the filter to build the query
+        values: field.values,
       }
     })
   }, [data, queryKey])
@@ -53,8 +54,7 @@ const Filters = ({
     // Set filter labels and values in the store
     // It is done in this control as the fetch filter label and values is done above here
     if (filters.length > 0) {
-      const filterLabels = filters.map((filter) => filter.label)
-      setLabels(entityName, filterLabels)
+      setLabels(entityName, filters)
       setFilterLabelValues(entityName, filters)
     }
   }, [filters, setLabels, setFilterLabelValues, entityName])


### PR DESCRIPTION
# Summary

This PR updates the filter label display logic to utilize the displayName returned from the API when retrieving filter information. This ensures consistency in filter labels across different views.

# Changes Made

- Integrated displayName into the labels of initialFilters for each entity in the filter slice.
- Modified the Filter and FilterSelect components to use displayName as labels and filterName as values, enhancing the filter prop construction in the fetch query.
- Updated the filter slice tests to reflect these changes.

# Related Issues

- https://github.com/cloudoperators/heureka/issues/306


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
