### PR TITLE
fix(ui): adds high z-index to portal root

### DIFF
--- a/.changeset/tiny-cooks-try.md
+++ b/.changeset/tiny-cooks-try.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+adds very high z-index (9999) to portal root container

--- a/packages/ui-components/src/components/Label/Label.component.tsx
+++ b/packages/ui-components/src/components/Label/Label.component.tsx
@@ -13,6 +13,7 @@ const labelstyles = `
   jn-transition-all 
   jn-duration-100 
   jn-ease-in-out
+  jn-z-10
 `
 
 const floatingStyles = `

--- a/packages/ui-components/src/components/PageHeader/PageHeader.component.tsx
+++ b/packages/ui-components/src/components/PageHeader/PageHeader.component.tsx
@@ -13,7 +13,7 @@ const pageHeaderStyles = `
   jn-top-0
   jn-px-6
   jn-py-3
-  jn-z-[1]
+  jn-z-50
 `
 
 const pageHeaderInnerStyles = `

--- a/packages/ui-components/src/components/PortalProvider/PortalProvider.component.tsx
+++ b/packages/ui-components/src/components/PortalProvider/PortalProvider.component.tsx
@@ -17,6 +17,7 @@ const portalRootStyles: React.CSSProperties = {
   position: "absolute",
   top: "0",
   left: "0",
+  zIndex: "9999",
 }
 
 /** A hook that creates a portal container in the current portal root, and returns this newly created container as a node to use in other components:

--- a/packages/ui-components/src/components/PortalProvider/PortalProvider.component.tsx
+++ b/packages/ui-components/src/components/PortalProvider/PortalProvider.component.tsx
@@ -13,6 +13,7 @@ interface PortalContextType {
 }
 export const PortalContext = createContext<PortalContextType | undefined>(undefined)
 
+// ensure very high z-index on portal root element to help prevent z-stacking problems for portaled components
 const portalRootStyles: React.CSSProperties = {
   position: "absolute",
   top: "0",

--- a/packages/ui-components/src/deprecated_js/PortalProvider/PortalProvider.component.js
+++ b/packages/ui-components/src/deprecated_js/PortalProvider/PortalProvider.component.js
@@ -15,6 +15,7 @@ const portalRootStyles = {
   position: "absolute",
   top: "0",
   left: "0",
+  zIndex: "9999",
 }
 
 const portalStyles = {


### PR DESCRIPTION
# Summary

This PR tries to improve upon the previous fix for the z-index stacking problem introduced in the recent refactoring of `PortalProvider`. While the previous fix in https://github.com/cloudoperators/juno/pull/565 solved the issue for Juno apps we still had potential z-index stacking issues if a Juno app was embedded into a host app with its own z-index stack. This is because the solution from the previous PR aimed to standardize all z-index on the root level to `1` and then added stacks above this in the portaled components as necessary. 

In the cases where a Juno app is embedded in a host app with z-indexes higher than `1` the whole thing would break.

This PR aims to fix this by setting a very high z-index (`9999`) for the portal root div which acts as the wrapper for all portals. So as long as the host app's z-index is at max `9999` the z-stacking will be correct.

# Changes Made

- Added `z-index: 9999` to portal root div in `PortalProvider`
- Undid `z-index` change to `PageHeader` and `Label` from PR#565 since the new portal root `z-index` ensure proper stacking above these components for portaled components

# Related Issues

- https://github.com/cloudoperators/juno/pull/565

# Testing Instructions

1. start exampleapp or supernova in this branch
2. open a Panel --> it should be stacked above the PageHeader
3. in Supernova scroll down so that the filter toolbar gets scrolled under PageHeader --> the Select's Label should not be visible

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
