### PR TITLE
chore(ui): fix Grid stories after Typescript migration

### DIFF
--- a/packages/ui-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/ui-components/src/components/Grid/Grid.stories.tsx
@@ -62,7 +62,7 @@ export const Default = {
       <GridRow key="2">
         <GridColumn>Column</GridColumn>
         <GridColumn cols={3}>Column cols-3</GridColumn>
-        <GridColumn cols={5}>Column cols-5</GridColumn>
+        <GridColumn cols={6}>Column cols-6</GridColumn>
         <GridColumn cols={2}>Column cols-2</GridColumn>
       </GridRow>,
     ],

--- a/packages/ui-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/ui-components/src/components/Grid/Grid.stories.tsx
@@ -5,6 +5,7 @@
 
 import React from "react"
 import { StoryFn, Meta } from "@storybook/react"
+
 import { Grid, GridProps } from "./Grid.component"
 import { GridRow } from "../GridRow/GridRow.component"
 import { GridColumn } from "../GridColumn/GridColumn.component"
@@ -18,19 +19,18 @@ export default {
     },
   },
   decorators: [
-    (Story, context) => {
-      const storyParams = context.parameters
-      return (
-        <div className="juno-container jn-px-6 jn-py-6">
-          <Story {...storyParams} />
-        </div>
-      )
-    },
+    (Story, context) => (
+      <div className="juno-container jn-px-6 jn-py-6">
+        <Story {...context} />
+      </div>
+    ),
   ],
-} as Meta
+} as Meta<typeof Grid>
 
 const Template: StoryFn<GridProps> = (args, context) => (
-  <Grid {...args} className={`${args.className} ${context.className || ""}`} />
+  <Grid {...args} className={`jn-bg-juno-blue-3 jn-text-juno-grey-blue ${args.className}`}>
+    {context.args.children}
+  </Grid>
 )
 
 export const Default = {

--- a/packages/ui-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/ui-components/src/components/Grid/Grid.stories.tsx
@@ -5,7 +5,7 @@
 
 import React from "react"
 import { StoryFn, Meta } from "@storybook/react"
-import { Grid } from "./Grid.component"
+import { Grid, GridProps } from "./Grid.component"
 import { GridRow } from "../GridRow/GridRow.component"
 import { GridColumn } from "../GridColumn/GridColumn.component"
 
@@ -13,18 +13,25 @@ export default {
   title: "Layout/Grid/Grid",
   component: Grid,
   argTypes: {
-    children: { control: false },
+    children: {
+      control: false,
+    },
   },
   decorators: [
-    (Story) => (
-      <div className="jn-bg-juno-blue-3 jn-text-juno-grey-blue">
-        <Story />
-      </div>
-    ),
+    (Story, context) => {
+      const storyParams = context.parameters
+      return (
+        <div className="juno-container jn-px-6 jn-py-6">
+          <Story {...storyParams} />
+        </div>
+      )
+    },
   ],
-} as Meta<typeof Grid>
+} as Meta
 
-const Template: StoryFn<typeof Grid> = (args) => <Grid {...args} />
+const Template: StoryFn<GridProps> = (args, context) => (
+  <Grid {...args} className={`${args.className} ${context.className || ""}`} />
+)
 
 export const Default = {
   render: Template,

--- a/packages/ui-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/ui-components/src/components/Grid/Grid.stories.tsx
@@ -19,18 +19,16 @@ export default {
     },
   },
   decorators: [
-    (Story, context) => (
+    (Story) => (
       <div className="juno-container jn-px-6 jn-py-6">
-        <Story {...context} />
+        <Story />
       </div>
     ),
   ],
 } as Meta<typeof Grid>
 
-const Template: StoryFn<GridProps> = (args, context) => (
-  <Grid {...args} className={`jn-bg-juno-blue-3 jn-text-juno-grey-blue ${args.className}`}>
-    {context.args.children}
-  </Grid>
+const Template: StoryFn<GridProps> = (args) => (
+  <Grid {...args} className={`jn-bg-juno-blue-3 jn-text-juno-grey-blue ${args.className || ""}`} />
 )
 
 export const Default = {

--- a/packages/ui-components/src/components/GridColumn/GridColumn.stories.tsx
+++ b/packages/ui-components/src/components/GridColumn/GridColumn.stories.tsx
@@ -4,28 +4,27 @@
  */
 
 import React from "react"
-import { StoryFn, Meta } from "@storybook/react"
-
-import { GridColumn, GridColumnProps } from "./GridColumn.component" // Ensure the type is imported correctly
+import { Meta, StoryFn } from "@storybook/react"
+import { GridColumn, GridColumnProps } from "./GridColumn.component"
 
 export default {
   title: "Layout/Grid/GridColumn",
   component: GridColumn,
   argTypes: {
-    children: {
-      control: false,
-    },
+    children: { control: false },
   },
   decorators: [
-    (Story) => (
-      <div className="jn-bg-juno-blue-3 jn-text-juno-grey-blue">
-        <Story />
+    (Story, context) => (
+      <div className="juno-container jn-px-6 jn-py-6">
+        <Story {...context.args} />
       </div>
     ),
   ],
 } as Meta
 
-const Template: StoryFn<GridColumnProps> = (args) => <GridColumn {...args} />
+const Template: StoryFn<GridColumnProps> = (args) => {
+  return <GridColumn {...args} className={`${args.className} jn-bg-juno-blue-3 jn-text-juno-grey-blue`} />
+}
 
 export const Default = {
   render: Template,

--- a/packages/ui-components/src/components/GridRow/GridRow.stories.tsx
+++ b/packages/ui-components/src/components/GridRow/GridRow.stories.tsx
@@ -18,11 +18,14 @@ export default {
     },
   },
   decorators: [
-    (Story) => (
-      <div className="jn-bg-juno-blue-3 jn-text-juno-grey-blue">
-        <Story />
-      </div>
-    ),
+    (Story, context) => {
+      const { parameters } = context
+      return (
+        <div className={`jn-bg-juno-blue-3 jn-text-juno-grey-blue ${parameters.className || ""}`}>
+          <Story {...parameters} />
+        </div>
+      )
+    },
   ],
 } as Meta<typeof GridRow>
 

--- a/packages/ui-components/src/components/GridRow/GridRow.stories.tsx
+++ b/packages/ui-components/src/components/GridRow/GridRow.stories.tsx
@@ -18,14 +18,11 @@ export default {
     },
   },
   decorators: [
-    (Story, context) => {
-      const { parameters } = context
-      return (
-        <div className={`jn-bg-juno-blue-3 jn-text-juno-grey-blue ${parameters.className || ""}`}>
-          <Story {...parameters} />
-        </div>
-      )
-    },
+    (Story) => (
+      <div className="jn-bg-juno-blue-3 jn-text-juno-grey-blue">
+        <Story />
+      </div>
+    ),
   ],
 } as Meta<typeof GridRow>
 


### PR DESCRIPTION
# Summary

After merging the `Grid`, `GridColumn` and `GridRow` migration [PR](https://github.com/cloudoperators/juno/pull/595), I found that Storybook had a few unintended styling changes (as below). This PR fixes these documentation changes.

**Issues Found**: Old Storybook on left, after migration on right:
<img width="1728" alt="Screenshot 2024-11-08 at 10 30 27" src="https://github.com/user-attachments/assets/3cfc287c-f639-42b1-be25-d03438fac85d">
<img width="1728" alt="Screenshot 2024-11-08 at 10 30 51" src="https://github.com/user-attachments/assets/40ae8ff1-de50-4772-9cc9-b9bd2d1ba944">
<img width="1525" alt="Screenshot 2024-11-08 at 10 31 03" src="https://github.com/user-attachments/assets/5e4bbfb4-855b-43cc-8635-a96d11518071">
<img width="1728" alt="Screenshot 2024-11-08 at 10 31 41" src="https://github.com/user-attachments/assets/8f6ee2c7-a305-4f64-89d7-2f16f8da6529">
<img width="1728" alt="Screenshot 2024-11-08 at 10 32 01" src="https://github.com/user-attachments/assets/01112fc3-83a0-42c2-b281-9b02eea55ffc">

# Changes Made

Fixed Storybook, as was.

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- https://github.com/cloudoperators/juno/issues/229

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

- Check `Grid`, `GridColumn` and `GridRow` Storybook

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
