### PR TITLE
fix(greenhouse): add support_group only if supportGroups exists and is an array

### DIFF
--- a/.changeset/curly-owls-rush.md
+++ b/.changeset/curly-owls-rush.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+add support_group only if supportGroups exists and is an array

--- a/apps/greenhouse/src/hooks/useApi.js
+++ b/apps/greenhouse/src/hooks/useApi.js
@@ -45,11 +45,16 @@ const useApi = () => {
           const url = conf.status?.uiApplication?.url
 
           // temporary fix to forward initialFilters to the Plugins until middleware is implemented
-          const appProps = { username: authData?.parsed?.fullName }
-          appProps.initialFilters = {
-            ...(Array.isArray(authData?.parsed?.supportGroups) && {
-              support_group: authData.parsed.supportGroups.map((group) => group),
-            }),
+          // Extract username and support group information for appProps
+          const appProps = {
+            username: authData?.parsed?.fullName,
+          }
+
+          // Conditionally add initialFilters if supportGroups exists and is an array
+          if (Array.isArray(authData?.parsed?.supportGroups)) {
+            appProps.initialFilters = {
+              support_group: authData.parsed.supportGroups.map((group) => String(group)),
+            }
           }
 
           const newConf = createPluginConfig({

--- a/apps/greenhouse/src/hooks/useApi.js
+++ b/apps/greenhouse/src/hooks/useApi.js
@@ -47,7 +47,9 @@ const useApi = () => {
           // temporary fix to forward initialFilters to the Plugins until middleware is implemented
           const appProps = { username: authData?.parsed?.fullName }
           appProps.initialFilters = {
-            support_group: authData?.parsed?.supportGroups?.map((group) => group),
+            ...(Array.isArray(authData?.parsed?.supportGroups) && {
+              support_group: authData.parsed.supportGroups.map((group) => group),
+            }),
           }
 
           const newConf = createPluginConfig({


### PR DESCRIPTION
# Summary

This PR improves the handling of the support_group key within initialFilters in appProps. Now, support_group is added only when authData.parsed.supportGroups exists and is a valid array. If supportGroups is undefined, null, or not an array, support_group will be omitted from initialFilters, ensuring cleaner and more reliable data handling. Fixes the issue that prevented colleagues without a supportGroups value from accessing Supernova and Doop.

Related task #611

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Added a conditional spread operator to include support_group only if supportGroups is an array.
- If supportGroups does not exist or is not an array, support_group is excluded from initialFilters.

# Screenshots (if applicable)

Error when no support group is set to the logged user:

![Screenshot 2024-11-14 at 12 06 54](https://github.com/user-attachments/assets/3bfefa7b-edc9-4f0d-8de5-0e4658ec3ef6)


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. Remove from the Auth Object the supportGroup `delete authData.parsed.supportGroups`
4. `npx turbo dev --filter @cloudoperators/juno-app-greenhouse`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
