### PR TITLE
fix(supernova): activeFilters are not rendered if value is not an array

### DIFF
--- a/.changeset/clean-plums-notice.md
+++ b/.changeset/clean-plums-notice.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-supernova": patch
+---
+
+fix(supernova): non array values in the activeFilter are now ignored and not rendered

--- a/.changeset/clean-plums-notice.md
+++ b/.changeset/clean-plums-notice.md
@@ -1,5 +1,0 @@
----
-"@cloudoperators/juno-app-supernova": patch
----
-
-fix(supernova): non array values in the activeFilter are now ignored and not rendered

--- a/.changeset/plenty-windows-check.md
+++ b/.changeset/plenty-windows-check.md
@@ -2,4 +2,4 @@
 "@cloudoperators/juno-app-supernova": patch
 ---
 
-InitialFilters which value is not an Array are not added to ActiveFilters
+InitialFilters whose value is not an array are not added to ActiveFilters.

--- a/.changeset/plenty-windows-check.md
+++ b/.changeset/plenty-windows-check.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-supernova": patch
+---
+
+InitialFilters which value is not an Array are not added to ActiveFilters

--- a/apps/supernova/src/components/filters/FilterPills.jsx
+++ b/apps/supernova/src/components/filters/FilterPills.jsx
@@ -30,28 +30,30 @@ const FilterPills = () => {
   return (
     <Stack gap="2" wrap={true}>
       {Object.entries(activeFilters).map(([key, filterItems]) => {
-        return filterItems.map((item) =>
-          pausedFilters[key]?.includes(item) ? (
-            <Pill
-              className="bg-theme-background-lvl-4 opacity-70	"
-              pillKey={key}
-              pillValue={item}
-              closeable
-              onClose={() => deleteFilter(key, item)}
-              key={`${key}:${item}`}
-              onClick={() => activateFilter(key, item)}
-            />
-          ) : (
-            <Pill
-              pillKey={key}
-              pillValue={item}
-              closeable
-              onClose={() => deleteFilter(key, item)}
-              key={`${key}:${item}`}
-              onClick={() => pauseFilter(key, item)}
-            />
+        if (Array.isArray(filterItems)) {
+          return filterItems.map((item) =>
+            pausedFilters[key]?.includes(item) ? (
+              <Pill
+                className="bg-theme-background-lvl-4 opacity-70	"
+                pillKey={key}
+                pillValue={item}
+                closeable
+                onClose={() => deleteFilter(key, item)}
+                key={`${key}:${item}`}
+                onClick={() => activateFilter(key, item)}
+              />
+            ) : (
+              <Pill
+                pillKey={key}
+                pillValue={item}
+                closeable
+                onClose={() => deleteFilter(key, item)}
+                key={`${key}:${item}`}
+                onClick={() => pauseFilter(key, item)}
+              />
+            )
           )
-        )
+        }
       })}
     </Stack>
   )

--- a/apps/supernova/src/components/filters/FilterPills.jsx
+++ b/apps/supernova/src/components/filters/FilterPills.jsx
@@ -31,7 +31,7 @@ const FilterPills = () => {
     <Stack gap="2" wrap={true}>
       {Object.entries(activeFilters).map(([key, filterItems]) => {
         if (Array.isArray(filterItems)) {
-          return filterItems.map((item) =>
+          return filterItems?.map((item) =>
             pausedFilters[key]?.includes(item) ? (
               <Pill
                 className="bg-theme-background-lvl-4 opacity-70	"

--- a/apps/supernova/src/components/filters/FilterPills.jsx
+++ b/apps/supernova/src/components/filters/FilterPills.jsx
@@ -30,30 +30,28 @@ const FilterPills = () => {
   return (
     <Stack gap="2" wrap={true}>
       {Object.entries(activeFilters).map(([key, filterItems]) => {
-        if (Array.isArray(filterItems)) {
-          return filterItems?.map((item) =>
-            pausedFilters[key]?.includes(item) ? (
-              <Pill
-                className="bg-theme-background-lvl-4 opacity-70"
-                pillKey={key}
-                pillValue={item}
-                closeable
-                onClose={() => deleteFilter(key, item)}
-                key={`${key}:${item}`}
-                onClick={() => activateFilter(key, item)}
-              />
-            ) : (
-              <Pill
-                pillKey={key}
-                pillValue={item}
-                closeable
-                onClose={() => deleteFilter(key, item)}
-                key={`${key}:${item}`}
-                onClick={() => pauseFilter(key, item)}
-              />
-            )
+        return filterItems?.map((item) =>
+          pausedFilters[key]?.includes(item) ? (
+            <Pill
+              className="bg-theme-background-lvl-4 opacity-70"
+              pillKey={key}
+              pillValue={item}
+              closeable
+              onClose={() => deleteFilter(key, item)}
+              key={`${key}:${item}`}
+              onClick={() => activateFilter(key, item)}
+            />
+          ) : (
+            <Pill
+              pillKey={key}
+              pillValue={item}
+              closeable
+              onClose={() => deleteFilter(key, item)}
+              key={`${key}:${item}`}
+              onClick={() => pauseFilter(key, item)}
+            />
           )
-        }
+        )
       })}
     </Stack>
   )

--- a/apps/supernova/src/components/filters/FilterPills.jsx
+++ b/apps/supernova/src/components/filters/FilterPills.jsx
@@ -34,7 +34,7 @@ const FilterPills = () => {
           return filterItems?.map((item) =>
             pausedFilters[key]?.includes(item) ? (
               <Pill
-                className="bg-theme-background-lvl-4 opacity-70	"
+                className="bg-theme-background-lvl-4 opacity-70"
                 pillKey={key}
                 pillValue={item}
                 closeable

--- a/apps/supernova/src/components/filters/PredefinedFilters.jsx
+++ b/apps/supernova/src/components/filters/PredefinedFilters.jsx
@@ -25,7 +25,7 @@ const PredefinedFilters = () => {
     <Stack>
       {predefinedFilters && selectedItem && (
         <TabNavigation activeItem={selectedItem} onActiveItemChange={handleTabSelect}>
-          {predefinedFilters.map((filter) => (
+          {predefinedFilters?.map((filter) => (
             <TabNavigationItem key={filter.name} value={filter.name} label={filter.displayName} />
           ))}
         </TabNavigation>

--- a/apps/supernova/src/lib/createFiltersSlice.jsx
+++ b/apps/supernova/src/lib/createFiltersSlice.jsx
@@ -33,8 +33,6 @@ const parseInitialFilters = (initialFilters, filterLabels) => {
     return {}
   }
 
-  console.log("initialFilters", initialFilters)
-
   // Check if all values are arrays
   initialFilters = Object.entries(initialFilters).reduce((acc, [key, value]) => {
     if (Array.isArray(value)) {
@@ -44,8 +42,6 @@ const parseInitialFilters = (initialFilters, filterLabels) => {
     }
     return acc
   }, {})
-
-  console.log("initialFilters2", initialFilters)
 
   // Check if all keys are in filterLabelValues
   if (!Object.keys(initialFilters).every((key) => filterLabels.includes(key))) {

--- a/apps/supernova/src/lib/createFiltersSlice.jsx
+++ b/apps/supernova/src/lib/createFiltersSlice.jsx
@@ -28,10 +28,24 @@ const parsePredefinedFilters = (predefinedFilters) => {
 const parseInitialFilters = (initialFilters, filterLabels) => {
   if (!initialFilters) return initialFiltersState.initialFilters
 
-  if (typeof initialFilters !== "object") {
+  if (typeof initialFilters !== "object" || initialFilters === null) {
     console.warn("[supernova]::parseInitialFilters: initialFilters object is not an object")
     return {}
   }
+
+  console.log("initialFilters", initialFilters)
+
+  // Check if all values are arrays
+  initialFilters = Object.entries(initialFilters).reduce((acc, [key, value]) => {
+    if (Array.isArray(value)) {
+      acc[key] = value // valid key-value pair
+    } else {
+      console.warn(`[supernova]::parseInitialFilters: Value for "${key}" is not an Array.`)
+    }
+    return acc
+  }, {})
+
+  console.log("initialFilters2", initialFilters)
 
   // Check if all keys are in filterLabelValues
   if (!Object.keys(initialFilters).every((key) => filterLabels.includes(key))) {

--- a/apps/supernova/src/lib/createFiltersSlice.test.jsx
+++ b/apps/supernova/src/lib/createFiltersSlice.test.jsx
@@ -310,6 +310,37 @@ describe("createFiltersSlice", () => {
       spy.mockRestore()
     })
 
+    it("warns because some keys are not in filterLabels and filters initialFilters to only include valid keys", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      const props = {
+        initialFilters: {
+          region: "europe",
+          app: ["frontendapp", "monitoring", "store"],
+        },
+        filterLabels: ["region", "app"],
+      }
+
+      const expectedFilters = {
+        app: ["frontendapp", "monitoring", "store"],
+      } // Only app is a valid filter label, because region is not an array, we except it to be filtered out
+
+      const wrapper = ({ children }) => <StoreProvider options={props}>{children}</StoreProvider>
+
+      const store = renderHook(
+        () => ({
+          activeFilters: useActiveFilters(),
+        }),
+        { wrapper }
+      )
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('[supernova]::parseInitialFilters: Value for "region" is not an Array.')
+      )
+      expect(store.result.current.activeFilters).toEqual(expectedFilters)
+      spy.mockRestore()
+    })
+
     it("warns because initial filters is not a object", () => {
       const spy = vi.spyOn(console, "warn").mockImplementation(() => {})
 

--- a/apps/supernova/src/lib/createFiltersSlice.test.jsx
+++ b/apps/supernova/src/lib/createFiltersSlice.test.jsx
@@ -339,6 +339,35 @@ describe("createFiltersSlice", () => {
       spy.mockRestore()
     })
 
+    it("warns because initial filters is not a object", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      const props = {
+        initialFilters: undefined,
+        filterLabels: ["region"],
+      }
+
+      const wrapper = ({ children }) => <StoreProvider options={props}>{children}</StoreProvider>
+
+      renderHook(
+        () => ({
+          activeFilters: useActiveFilters(),
+        }),
+        { wrapper }
+      )
+
+      const store = renderHook(
+        () => ({
+          activeFilters: useActiveFilters(),
+        }),
+        { wrapper }
+      )
+
+      expect(store.result.current.activeFilters).toEqual({})
+      expect(spy).toHaveBeenCalledWith("[supernova]::validateExcludedLabels: labels object is not an array of strings")
+      spy.mockRestore()
+    })
+
     it("initialFilters is empty", () => {
       const props = {
         initialFilters: {},


### PR DESCRIPTION
# Summary
Fix issue where activeFilters are not rendered if the value is not an array. Closes #609

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
