### PR TITLE
chore(ci): do not use relative asset paths in prod builds

### DIFF
--- a/.github/scripts/build-vite-app.sh
+++ b/.github/scripts/build-vite-app.sh
@@ -7,7 +7,7 @@ build_folder=$(dirname $entry_file)
 package_name=$(jq -r '.name' $PACKAGE_PATH/package.json)
 
 # Run build using turbo
-npx turbo run build:static --filter $package_name
+npx turbo run build:static --filter $package_name -- --base ./
 
 # Copy build folder to deploy path
 mkdir -p "$DEPLOY_PATH/$TARGET_FOLDER"
@@ -15,5 +15,5 @@ cp -r "$PACKAGE_PATH/$build_folder/." "$DEPLOY_PATH/$TARGET_FOLDER"
 
 # Generate appProps.json if APP_PROPS_BASE64 is non-empty
 if [ -n "$APP_PROPS_BASE64" ]; then
-  echo "$APP_PROPS_BASE64" | base64 -d > "$DEPLOY_PATH/$TARGET_FOLDER/appProps.json"
+  echo "$APP_PROPS_BASE64" | base64 -d >"$DEPLOY_PATH/$TARGET_FOLDER/appProps.json"
 fi

--- a/apps/carbon/vite.config.ts
+++ b/apps/carbon/vite.config.ts
@@ -37,7 +37,6 @@ export default defineConfig(({ mode }) => {
   if (mode === "static") {
     return {
       ...sharedConfig,
-      base: "./", // Relative Path in Generated index.html
       build: {
         outDir: "build",
       },

--- a/apps/doop/vite.config.ts
+++ b/apps/doop/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig(({ mode }) => {
   if (mode === "static") {
     return {
       ...sharedConfig,
-      base: "./", // Relative Path in Generated index.html
       build: {
         outDir: "build",
       },

--- a/apps/example/vite.config.ts
+++ b/apps/example/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig(({ mode }) => {
   if (mode === "static") {
     return {
       ...sharedConfig,
-      base: "./", // Relative Path in Generated index.html
       build: {
         outDir: "build",
       },

--- a/apps/greenhouse/vite.config.ts
+++ b/apps/greenhouse/vite.config.ts
@@ -31,7 +31,6 @@ export default defineConfig(({ mode }) => {
   if (mode === "static") {
     return {
       ...sharedConfig,
-      base: "./", // Relative Path in Generated index.html
       build: {
         outDir: "build",
       },

--- a/apps/heureka/vite.config.ts
+++ b/apps/heureka/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig(({ mode }) => {
   if (mode === "static") {
     return {
       ...sharedConfig,
-      base: "./", // Relative Path in Generated index.html
       build: {
         outDir: "build",
       },

--- a/apps/supernova/vite.config.ts
+++ b/apps/supernova/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig(({ mode }) => {
   if (mode === "static") {
     return {
       ...sharedConfig,
-      base: "./", // Relative Path in Generated index.html
       build: {
         outDir: "build",
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -681,7 +681,7 @@
     },
     "apps/greenhouse": {
       "name": "@cloudoperators/juno-app-greenhouse",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-app-doop": "*",
@@ -826,7 +826,7 @@
     },
     "apps/heureka": {
       "name": "@cloudoperators/juno-app-heureka",
-      "version": "2.9.2",
+      "version": "2.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-communicator": "*",
@@ -29600,7 +29600,7 @@
     },
     "packages/ui-components": {
       "name": "@cloudoperators/juno-ui-components",
-      "version": "2.28.0",
+      "version": "2.29.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/plugin-transform-parameters": "^7.22.15",
@@ -29811,7 +29811,7 @@
     },
     "packages/url-state-provider": {
       "name": "@cloudoperators/juno-url-state-provider",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "juri": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "generate:app": "turbo gen workspace --type app --copy @cloudoperators/juno-app-template --name",
     "format": "prettier --log-level warn --write \"**/*.{js,jsx,ts,tsx,md}\"",
     "check-format": "prettier --config ./.prettierrc --check \"**/*.{js,jsx,ts,tsx,md}\" ",
+    "check-format-no-md": "prettier --config ./.prettierrc --check \"**/*.{js,jsx,ts,tsx}\" ",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "npm run build && changeset publish",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "generate:app": "turbo gen workspace --type app --copy @cloudoperators/juno-app-template --name",
     "format": "prettier --log-level warn --write \"**/*.{js,jsx,ts,tsx,md}\"",
     "check-format": "prettier --config ./.prettierrc --check \"**/*.{js,jsx,ts,tsx,md}\" ",
-    "check-format-no-md": "prettier --config ./.prettierrc --check \"**/*.{js,jsx,ts,tsx}\" ",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "npm run build && changeset publish",


### PR DESCRIPTION
# Summary

This PR removes the base option from vite.config.js in all apps to prevent building relative paths for assets in production. To maintain support for previews deployed under a specific path, the base option is now configured directly in the preview workflow.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- remove `base` option from all vite configs 
- add `base`option to build-asset.sh 

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
