### PR TITLE
chore(ui): update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "assigneesFromCodeOwners": true,
-  "extends": ["config:recommended"],
+  "extends": ["config:best-practices"],
+  "enabledManagers": ["npm", "github-actions"],
+  "includePaths": ["packages/ui-components/**"],
   "packageRules": [
     {
       "groupName": "github actions",
@@ -12,20 +14,12 @@
     },
     {
       "groupName": "dependencies for ui-components",
-      "matchFileNames": ["packages/ui-components/package.json"],
       "matchDatasources": ["npm"],
+      "matchFileNames": ["packages/ui-components/**"],
       "matchUpdateTypes": ["patch"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "schedule": "every weekend"
     }
   ],
-  "separateMinorPatch": true,
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["Makefile$", "\\.sh$"],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_(VERSION|version) *[?:]?= *\"?(?<currentValue>.+?)\"?\\s"
-      ]
-    }
-  ]
+  "separateMinorPatch": true
 }


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
Renovate was still scanning dependencies of all packages and apps. This PRs limits managers to just `npm` and `github-actions` as well as only scans dependencies for `ui-components` using `includePaths`.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Limited managers to `npm` and `github-actions`
- Changed scan schedule
- Extended recommended config `config:best-practices`
- Removed customManager as it was just copied over from greenhouse project and not needed at the moment

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- https://github.com/cloudoperators/juno/issues/637

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
