### PR TITLE
fix(ui): fixes glob import of scss files

### DIFF
--- a/.changeset/selfish-crabs-notice.md
+++ b/.changeset/selfish-crabs-notice.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+Import components styles manually in global.scss

--- a/package-lock.json
+++ b/package-lock.json
@@ -718,7 +718,7 @@
     },
     "apps/greenhouse": {
       "name": "@cloudoperators/juno-app-greenhouse",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-app-doop": "*",
@@ -857,7 +857,7 @@
     },
     "apps/heureka": {
       "name": "@cloudoperators/juno-app-heureka",
-      "version": "2.11.2",
+      "version": "2.11.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-communicator": "*",
@@ -2007,17 +2007,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -3674,17 +3663,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "juri": "^1.0.3"
-      }
-    },
-    "node_modules/@comandeer/babel-plugin-banner": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -5838,114 +5816,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/plugin-babel": {
-      "version": "6.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.18.6",
-        "@rollup/pluginutils": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-commonjs": {
-      "version": "24.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "commondir": "^1.0.1",
-        "estree-walker": "^2.0.2",
-        "glob": "^8.0.3",
-        "is-reference": "1.2.1",
-        "magic-string": "^0.27.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.68.0||^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
-      "version": "0.27.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "@types/resolve": "1.20.2",
-        "deepmerge": "^4.2.2",
-        "is-module": "^1.0.0",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.78.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-typescript": {
-      "version": "11.1.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.1.0",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.14.0||^3.0.0||^4.0.0",
-        "tslib": "*",
-        "typescript": ">=3.7.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        },
-        "tslib": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.3",
       "dev": true,
@@ -7861,227 +7731,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@svgr/rollup": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.19.6",
-        "@babel/plugin-transform-react-constant-elements": "^7.18.12",
-        "@babel/preset-env": "^7.19.4",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@rollup/pluginutils": "^4.2.1",
-        "@svgr/core": "^6.5.1",
-        "@svgr/plugin-jsx": "^6.5.1",
-        "@svgr/plugin-svgo": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/babel-plugin-add-jsx-attribute": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/babel-plugin-svg-dynamic-title": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/babel-plugin-svg-em-dimensions": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/babel-plugin-transform-react-native-svg": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/babel-plugin-transform-svg-component": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/babel-preset": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@svgr/babel-plugin-add-jsx-attribute": "^6.5.1",
-        "@svgr/babel-plugin-remove-jsx-attribute": "*",
-        "@svgr/babel-plugin-remove-jsx-empty-expression": "*",
-        "@svgr/babel-plugin-replace-jsx-attribute-value": "^6.5.1",
-        "@svgr/babel-plugin-svg-dynamic-title": "^6.5.1",
-        "@svgr/babel-plugin-svg-em-dimensions": "^6.5.1",
-        "@svgr/babel-plugin-transform-react-native-svg": "^6.5.1",
-        "@svgr/babel-plugin-transform-svg-component": "^6.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/core": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.19.6",
-        "@svgr/babel-preset": "^6.5.1",
-        "@svgr/plugin-jsx": "^6.5.1",
-        "camelcase": "^6.2.0",
-        "cosmiconfig": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/hast-util-to-babel-ast": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.20.0",
-        "entities": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/@svgr/plugin-jsx": {
-      "version": "6.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.19.6",
-        "@svgr/babel-preset": "^6.5.1",
-        "@svgr/hast-util-to-babel-ast": "^6.5.1",
-        "svg-parser": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/gregberge"
-      },
-      "peerDependencies": {
-        "@svgr/core": "^6.0.0"
-      }
-    },
-    "node_modules/@svgr/rollup/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@svgr/webpack": {
       "version": "6.5.1",
       "dev": true,
@@ -8645,15 +8294,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "dev": true,
@@ -8778,11 +8418,6 @@
     },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
       "dev": true,
       "license": "MIT"
     },
@@ -9618,18 +9253,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "dev": true,
@@ -10014,41 +9637,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/babel-helper-evaluate-path": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-helper-flip-expressions": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-helper-is-nodes-equiv": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-helper-is-void-0": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-helper-mark-eval-scopes": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-helper-remove-or-void": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-helper-to-multiple-sequence-expressions": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "dev": true,
@@ -10116,89 +9704,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/babel-plugin-minify-builtins": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-minify-constant-folding": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-evaluate-path": "^0.5.0"
-      }
-    },
-    "node_modules/babel-plugin-minify-dead-code-elimination": {
-      "version": "0.5.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-evaluate-path": "^0.5.0",
-        "babel-helper-mark-eval-scopes": "^0.4.3",
-        "babel-helper-remove-or-void": "^0.4.3",
-        "lodash": "^4.17.11"
-      }
-    },
-    "node_modules/babel-plugin-minify-flip-comparisons": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-is-void-0": "^0.4.3"
-      }
-    },
-    "node_modules/babel-plugin-minify-guarded-expressions": {
-      "version": "0.4.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-evaluate-path": "^0.5.0",
-        "babel-helper-flip-expressions": "^0.4.3"
-      }
-    },
-    "node_modules/babel-plugin-minify-infinity": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-minify-mangle-names": {
-      "version": "0.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-mark-eval-scopes": "^0.4.3"
-      }
-    },
-    "node_modules/babel-plugin-minify-numeric-literals": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-minify-replace": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-minify-simplify": {
-      "version": "0.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-evaluate-path": "^0.5.0",
-        "babel-helper-flip-expressions": "^0.4.3",
-        "babel-helper-is-nodes-equiv": "^0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
-      }
-    },
-    "node_modules/babel-plugin-minify-type-constructors": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-is-void-0": "^0.4.3"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.11",
       "dev": true,
@@ -10243,67 +9748,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/babel-plugin-transform-inline-consecutive-adds": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-transform-member-expression-literals": {
-      "version": "6.9.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-transform-merge-sibling-variables": {
-      "version": "6.9.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-transform-minify-booleans": {
-      "version": "6.9.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-transform-property-literals": {
-      "version": "6.9.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      }
-    },
-    "node_modules/babel-plugin-transform-regexp-constructors": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-transform-remove-console": {
-      "version": "6.9.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-transform-remove-debugger": {
-      "version": "6.9.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-transform-remove-undefined": {
-      "version": "0.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-helper-evaluate-path": "^0.5.0"
-      }
-    },
-    "node_modules/babel-plugin-transform-simplify-comparison-operators": {
-      "version": "6.9.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-transform-undefined-to-void": {
-      "version": "6.9.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.1.0",
       "dev": true,
@@ -10342,36 +9786,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/babel-preset-minify": {
-      "version": "0.5.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-minify-builtins": "^0.5.0",
-        "babel-plugin-minify-constant-folding": "^0.5.0",
-        "babel-plugin-minify-dead-code-elimination": "^0.5.2",
-        "babel-plugin-minify-flip-comparisons": "^0.4.3",
-        "babel-plugin-minify-guarded-expressions": "^0.4.4",
-        "babel-plugin-minify-infinity": "^0.4.3",
-        "babel-plugin-minify-mangle-names": "^0.5.1",
-        "babel-plugin-minify-numeric-literals": "^0.4.3",
-        "babel-plugin-minify-replace": "^0.5.0",
-        "babel-plugin-minify-simplify": "^0.5.1",
-        "babel-plugin-minify-type-constructors": "^0.4.3",
-        "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
-        "babel-plugin-transform-member-expression-literals": "^6.9.4",
-        "babel-plugin-transform-merge-sibling-variables": "^6.9.5",
-        "babel-plugin-transform-minify-booleans": "^6.9.4",
-        "babel-plugin-transform-property-literals": "^6.9.4",
-        "babel-plugin-transform-regexp-constructors": "^0.4.3",
-        "babel-plugin-transform-remove-console": "^6.9.4",
-        "babel-plugin-transform-remove-debugger": "^6.9.4",
-        "babel-plugin-transform-remove-undefined": "^0.5.0",
-        "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
-        "babel-plugin-transform-undefined-to-void": "^6.9.4",
-        "lodash": "^4.17.11"
       }
     },
     "node_modules/bail": {
@@ -10510,17 +9924,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/builtin-modules": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "dev": true,
@@ -10579,17 +9982,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/caniuse-api": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
       }
     },
     "node_modules/caniuse-lite": {
@@ -10799,14 +10191,6 @@
         "node": ">= 10.0"
       }
     },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -10867,11 +10251,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/colord": {
-      "version": "2.9.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -10940,14 +10319,6 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/concat-with-sourcemaps": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -11098,17 +10469,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-declaration-sorter": {
-      "version": "6.4.1",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.9"
-      }
-    },
     "node_modules/css-jss": {
       "version": "10.10.0",
       "dev": true,
@@ -11213,79 +10573,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/cssnano": {
-      "version": "5.1.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-default": "^5.2.14",
-        "lilconfig": "^2.0.3",
-        "yaml": "^1.10.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/cssnano"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/cssnano-preset-default": {
-      "version": "5.2.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-declaration-sorter": "^6.3.1",
-        "cssnano-utils": "^3.1.0",
-        "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.1",
-        "postcss-convert-values": "^5.1.3",
-        "postcss-discard-comments": "^5.1.2",
-        "postcss-discard-duplicates": "^5.1.0",
-        "postcss-discard-empty": "^5.1.1",
-        "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.7",
-        "postcss-merge-rules": "^5.1.4",
-        "postcss-minify-font-values": "^5.1.0",
-        "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.4",
-        "postcss-minify-selectors": "^5.2.1",
-        "postcss-normalize-charset": "^5.1.0",
-        "postcss-normalize-display-values": "^5.1.0",
-        "postcss-normalize-positions": "^5.1.1",
-        "postcss-normalize-repeat-style": "^5.1.1",
-        "postcss-normalize-string": "^5.1.0",
-        "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.1",
-        "postcss-normalize-url": "^5.1.0",
-        "postcss-normalize-whitespace": "^5.1.1",
-        "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.2",
-        "postcss-reduce-transforms": "^5.1.0",
-        "postcss-svgo": "^5.1.0",
-        "postcss-unique-selectors": "^5.1.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/cssnano-utils": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
       }
     },
     "node_modules/csso": {
@@ -11528,72 +10815,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/del": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globby": "^10.0.1",
-        "graceful-fs": "^4.2.2",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.1",
-        "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/del/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/del/node_modules/globby": {
-      "version": "10.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/del/node_modules/p-map": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/delayed-stream": {
@@ -12940,11 +12161,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "dev": true,
@@ -13403,22 +12619,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generic-names": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^3.2.0"
-      }
-    },
-    "node_modules/generic-names/node_modules/loader-utils": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
       }
     },
     "node_modules/gensync": {
@@ -14046,11 +13246,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/icss-replace-symbols": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/icss-utils": {
       "version": "5.1.0",
       "dev": true,
@@ -14083,17 +13278,6 @@
       "version": "5.0.3",
       "license": "MIT"
     },
-    "node_modules/import-cwd": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "dev": true,
@@ -14115,17 +13299,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/import-from": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/import-lazy": {
@@ -14495,11 +13668,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-module": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "dev": true,
@@ -14546,14 +13714,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "dev": true,
@@ -14577,14 +13737,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-reference": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -16639,11 +15791,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
@@ -18016,17 +17163,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/npm-normalize-package-bin": {
       "version": "3.0.1",
       "dev": true,
@@ -18268,14 +17404,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "dev": true,
@@ -18336,32 +17464,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/p-queue": {
-      "version": "6.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-finally": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -18668,94 +17770,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-calc": {
-      "version": "8.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.2"
-      }
-    },
-    "node_modules/postcss-colormin": {
-      "version": "5.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-api": "^3.0.0",
-        "colord": "^2.9.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-convert-values": {
-      "version": "5.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-comments": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-duplicates": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-empty": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-discard-overridden": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
     "node_modules/postcss-import": {
       "version": "15.1.0",
       "license": "MIT",
@@ -18786,34 +17800,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.21"
-      }
-    },
-    "node_modules/postcss-load-config": {
-      "version": "3.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^2.0.5",
-        "yaml": "^1.10.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "postcss": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
       }
     },
     "node_modules/postcss-loader": {
@@ -18869,116 +17855,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/postcss-merge-longhand": {
-      "version": "5.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-merge-rules": {
-      "version": "5.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^3.1.0",
-        "postcss-selector-parser": "^6.0.5"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-font-values": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-gradients": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "colord": "^2.9.1",
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-params": {
-      "version": "5.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-minify-selectors": {
-      "version": "5.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-modules": {
-      "version": "4.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "generic-names": "^4.0.0",
-        "icss-replace-symbols": "^1.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "string-hash": "^1.1.1"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -19059,175 +17935,6 @@
         "postcss": "^8.2.14"
       }
     },
-    "node_modules/postcss-normalize-charset": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-display-values": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-positions": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-repeat-style": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-string": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-timing-functions": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-unicode": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-url": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "normalize-url": "^6.0.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-normalize-whitespace": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-ordered-values": {
-      "version": "5.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-utils": "^3.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-reduce-initial": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-api": "^3.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-reduce-transforms": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "license": "MIT",
@@ -19237,35 +17944,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/postcss-svgo": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0",
-        "svgo": "^2.7.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-unique-selectors": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.5"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-url": {
@@ -19372,14 +18050,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/promise.series": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/prompts": {
@@ -20165,6 +18835,7 @@
       "version": "3.29.5",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -20176,124 +18847,6 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup-plugin-analyzer": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-babel-minify": {
-      "version": "10.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.8.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@comandeer/babel-plugin-banner": "^5.0.0",
-        "babel-preset-minify": "^0.5.1",
-        "sourcemap-codec": "^1.4.8"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "rollup": ">=1.6.0"
-      }
-    },
-    "node_modules/rollup-plugin-delete": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "del": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "rollup": "*"
-      }
-    },
-    "node_modules/rollup-plugin-includepaths": {
-      "version": "0.2.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rollup-plugin-node-resolve": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/resolve": "0.0.8",
-        "builtin-modules": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.11.1",
-        "rollup-pluginutils": "^2.8.1"
-      },
-      "peerDependencies": {
-        "rollup": ">=1.11.0"
-      }
-    },
-    "node_modules/rollup-plugin-node-resolve/node_modules/@types/resolve": {
-      "version": "0.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/rollup-plugin-postcss": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "concat-with-sourcemaps": "^1.1.0",
-        "cssnano": "^5.0.1",
-        "import-cwd": "^3.0.0",
-        "p-queue": "^6.6.2",
-        "pify": "^5.0.0",
-        "postcss-load-config": "^3.0.0",
-        "postcss-modules": "^4.0.0",
-        "promise.series": "^0.2.0",
-        "resolve": "^1.19.0",
-        "rollup-pluginutils": "^2.8.2",
-        "safe-identifier": "^0.4.2",
-        "style-inject": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "postcss": "8.x"
-      }
-    },
-    "node_modules/rollup-plugin-postcss/node_modules/pify": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
-    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
@@ -20356,11 +18909,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safe-identifier": {
-      "version": "0.4.2",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -20875,11 +19423,6 @@
         "node": ">=0.6.19"
       }
     },
-    "node_modules/string-hash": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/string-length": {
       "version": "6.0.0",
       "dev": true,
@@ -21115,11 +19658,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/style-inject": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/style-loader": {
       "version": "3.3.4",
       "dev": true,
@@ -21141,21 +19679,6 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.4"
-      }
-    },
-    "node_modules/stylehacks": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.21.4",
-        "postcss-selector-parser": "^6.0.4"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.15"
       }
     },
     "node_modules/sucrase": {
@@ -22735,6 +21258,7 @@
       "resolved": "https://registry.npmjs.org/vite-plugin-glob/-/vite-plugin-glob-0.3.2.tgz",
       "integrity": "sha512-RoOm67e9eQ7bbWfnVbErjMcqnWCLjNtLy/fhOu8eqWbNi8Pz4T/co2j8uF9v2/P6KaGz02+4jFL83lDCAZ5StQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.7.1",
         "fast-glob": "^3.2.11",
@@ -25066,7 +23590,7 @@
     },
     "packages/ui-components": {
       "name": "@cloudoperators/juno-ui-components",
-      "version": "2.34.0",
+      "version": "2.35.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/plugin-transform-parameters": "7.25.9",
@@ -25078,10 +23602,6 @@
         "@headlessui/react": "1.7.19",
         "@material-design-icons/svg": "0.14.13",
         "@mdx-js/react": "2.3.0",
-        "@rollup/plugin-babel": "6.0.4",
-        "@rollup/plugin-commonjs": "24.1.0",
-        "@rollup/plugin-node-resolve": "15.3.0",
-        "@rollup/plugin-typescript": "11.1.6",
         "@storybook/addon-docs": "8.4.6",
         "@storybook/addon-essentials": "8.4.6",
         "@storybook/addon-interactions": "8.4.6",
@@ -25093,7 +23613,6 @@
         "@storybook/react": "8.4.6",
         "@storybook/react-webpack5": "8.4.6",
         "@storybook/test": "8.4.6",
-        "@svgr/rollup": "6.5.1",
         "@svgr/webpack": "6.5.1",
         "@testing-library/dom": "10.4.0",
         "@testing-library/jest-dom": "6.6.3",
@@ -25123,13 +23642,6 @@
         "react-tabs": "4.3.0",
         "react-test-renderer": "18.3.1",
         "regenerator-runtime": "0.14.1",
-        "rollup": "4.28.0",
-        "rollup-plugin-analyzer": "4.0.0",
-        "rollup-plugin-babel-minify": "10.0.0",
-        "rollup-plugin-delete": "2.1.0",
-        "rollup-plugin-includepaths": "0.2.4",
-        "rollup-plugin-node-resolve": "5.2.0",
-        "rollup-plugin-postcss": "4.0.2",
         "sass": "^1.81.1",
         "sass-loader": "12.6.0",
         "storybook": "8.4.6",

--- a/packages/ui-components/src/global.scss
+++ b/packages/ui-components/src/global.scss
@@ -41,4 +41,4 @@
   }
 }
 
-
+@import "./components/**/*.scss"

--- a/packages/ui-components/src/global.scss
+++ b/packages/ui-components/src/global.scss
@@ -1,6 +1,14 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
 // SPDX-License-Identifier: Apache-2.0
 @use "../lib/variables";
+@use './components/Button/button.scss';
+@use './components/DateTimePicker/datetimepicker.scss';
+@use './components/FormattedText/formatted-text.scss';
+@use './components/InputGroup/input-group.scss';
+@use './components/SearchInput/searchinput.scss';
+@use './components/Select/select.scss';
+@use './components/TextInput/textinput.scss';
+@use './components/ThemeToggle/themeToggle.scss';
 
 @tailwind base;
 
@@ -40,5 +48,3 @@
     flex-basis: auto;
   }
 }
-
-@import "./components/**/*.scss"

--- a/packages/ui-components/vite.config.ts
+++ b/packages/ui-components/vite.config.ts
@@ -3,13 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { defineConfig } from "vite"
+import { defineConfig, PluginOption } from "vite"
 import react from "@vitejs/plugin-react"
 import tailwindcss from "tailwindcss"
 import autoprefixer from "autoprefixer"
 import dts from "vite-plugin-dts"
-import viteGlobPlugin from "vite-plugin-glob"
-
 import svgr from "vite-plugin-svgr"
 
 export default defineConfig({
@@ -31,13 +29,12 @@ export default defineConfig({
     outDir: "build",
   },
   plugins: [
-    viteGlobPlugin(),
     dts({
       exclude: ["./__tests__/**/*.test.ts", "vitest.setup.ts"],
       insertTypesEntry: true, // Ensure types are properly exported
       outDir: "build/types", // Specify where to output the types
-    }),
-    react(),
+    }) as PluginOption,
+    react() as PluginOption,
     svgr({
       svgrOptions: {
         ref: true,
@@ -45,6 +42,6 @@ export default defineConfig({
         titleProp: true,
       },
       include: "**/*.svg",
-    }),
+    }) as PluginOption,
   ],
 })


### PR DESCRIPTION
# Summary

This PR resolves a regression that occurred while transitioning to Vite, which affected the ability to use glob imports for all SCSS files within the components directory. The fix ensures that SCSS files are properly imported maintaining the expected behavior and styling consistency.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Remove glob import from global.scss
- Import all scss files from components manually via `@use`

# Related Issues

- #687 

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
