### PR TITLE
fix(ui): ensure main and header container default for fullwidth behaviour is the same

### DIFF
--- a/apps/template/src/App.tsx
+++ b/apps/template/src/App.tsx
@@ -55,6 +55,7 @@ export const App = (props: AppProps) => {
         embedded={props.embedded === "true" || props.embedded === true}
         sideNavigation={null}
         topNavigation={null}
+        fullWidthContent={false}
       >
         <ErrorBoundary fallbackRender={fallbackRender}>
           <AppContent />

--- a/apps/template/src/App.tsx
+++ b/apps/template/src/App.tsx
@@ -12,6 +12,7 @@ import { ErrorBoundary } from "react-error-boundary"
 interface AppProps {
   theme?: string
   embedded?: string | boolean
+  fullWidthContent?: string | boolean
   endpoint?: string
   currentHost?: string
 }
@@ -48,6 +49,16 @@ export const App = (props: AppProps) => {
     )
   }
 
+  // ensure that the fullWidthContent prop is a boolean or undefined if not passed
+  // TODO: this is a workaround to avoid passing a string to the AppShell component but it is ugly.
+  // We should find a better way to normalize the prop to boolean in some central location. The same applies to the embedded prop.
+  const calculatedFullWidthContentValue =
+    props.fullWidthContent === "true" || props.fullWidthContent === true
+      ? true
+      : props.fullWidthContent === "false" || props.fullWidthContent === false
+        ? false
+        : undefined
+
   return (
     <QueryClientProvider client={queryClient}>
       <AppShell
@@ -55,7 +66,7 @@ export const App = (props: AppProps) => {
         embedded={props.embedded === "true" || props.embedded === true}
         sideNavigation={null}
         topNavigation={null}
-        fullWidthContent={false}
+        fullWidthContent={calculatedFullWidthContentValue}
       >
         <ErrorBoundary fallbackRender={fallbackRender}>
           <AppContent />

--- a/packages/ui-components/src/components/AppShell/AppShell.component.tsx
+++ b/packages/ui-components/src/components/AppShell/AppShell.component.tsx
@@ -18,10 +18,10 @@ import { HeaderContainer } from "../HeaderContainer/index"
 export const AppShell: React.FC<AppShellProps> = ({
   children,
   className = "",
-  contentHeading = "",
   embedded = false,
   pageHeader = <PageHeader />,
   pageFooter = <PageFooter />,
+  fullWidthContent, // Must be undefined by default, as we need to differentiate between explicitly passed false and not passed at all.
   sideNavigation,
   topNavigation,
   ...props
@@ -29,38 +29,21 @@ export const AppShell: React.FC<AppShellProps> = ({
   // Determine whether to pass set fullWidth to true in embedded mode or not:
   // In non-embedded mode, fullWidthContent should default to false, unless explicitly set to true.
   // In embedded mode though, fullWidthContent should default to true, unless explicitly passed as false.
-
-  if (contentHeading && contentHeading.length) {
-    console.warn(
-      "AppShell: The contentHeading prop is obsolete and will be removed in a future version. In order to render a content heading, use a ContentHeading element as a child in your main content."
-    )
-  }
-  const { fullWidthContent } = props
-  const renderHeaderContainer = (
-    pageHeader?: AppShellProps["pageHeader"],
-    topNavigation?: AppShellProps["topNavigation"]
-  ) => {
-    if (!pageHeader && !topNavigation) {
-      return null
-    }
-    return (
-      <HeaderContainer fullWidth={fullWidthContent === true}>
-        {pageHeader && typeof pageHeader === "string" ? <PageHeader heading={pageHeader} /> : pageHeader}
-        {topNavigation}
-        {/* Wrap everything except page header and footer and navigations in a main container. Add top margin to MainContainerInner as we are not in embedded mode here. */}
-      </HeaderContainer>
-    )
+  let fullWidthOrDefault
+  if (embedded) {
+    fullWidthOrDefault = fullWidthContent === false ? false : true
+  } else {
+    fullWidthOrDefault = fullWidthContent === true ? true : false
   }
 
   return (
     <AppBody className={className} {...props}>
-      {contentHeading || ""}
       {embedded ? (
         <>
-          {topNavigation && <HeaderContainer>{topNavigation}</HeaderContainer>}
+          {topNavigation && <HeaderContainer fullWidth={fullWidthOrDefault}>{topNavigation}</HeaderContainer>}
           <MainContainer>
             <MainContainerInner
-              fullWidth={fullWidthContent === false ? false : true}
+              fullWidth={fullWidthOrDefault}
               hasSideNav={sideNavigation ? true : false}
               className={`${topNavigation ? "jn-mt-[3.875rem]" : ""}`}
             >
@@ -71,10 +54,14 @@ export const AppShell: React.FC<AppShellProps> = ({
         </>
       ) : (
         <>
-          {renderHeaderContainer(pageHeader, topNavigation)}
+          <HeaderContainer fullWidth={fullWidthOrDefault}>
+            {pageHeader && typeof pageHeader === "string" ? <PageHeader heading={pageHeader} /> : pageHeader}
+            {topNavigation}
+          </HeaderContainer>
+          {/* Wrap everything except page header and footer and navigations in a main container. Add top margin to MainContainerInner as we are not in embedded mode here. */}
           <MainContainer>
             <MainContainerInner
-              fullWidth={fullWidthContent === true ? true : false}
+              fullWidth={fullWidthOrDefault}
               hasSideNav={sideNavigation ? true : false}
               className="jn-mt-[3.875rem]"
             >
@@ -101,8 +88,6 @@ export interface AppShellProps extends React.HTMLAttributes<HTMLElement> {
   topNavigation?: React.ReactNode
   /** Optional. If specified expects a `<SideNavigation>` component. If undefined no side navigation is rendered. */
   sideNavigation?: React.ReactNode
-  /** OBSOLETE: The contentHeading prop is obsolete and will be removed in a future version. In order to render a content heading, use a `<ContentHeading>` element as a child in your main content. */
-  contentHeading?: string
   /** Optional: Defaults to false. Set embedded to true if app is to be rendered embedded in another app/page.
    * In this case only the content area and children are rendered, a TopNavigation if passed, but no header/footer or remaining layout components */
   embedded?: boolean

--- a/packages/ui-components/src/components/AppShell/AppShell.component.tsx
+++ b/packages/ui-components/src/components/AppShell/AppShell.component.tsx
@@ -27,14 +27,9 @@ export const AppShell: React.FC<AppShellProps> = ({
   ...props
 }) => {
   // Determine whether to pass set fullWidth to true in embedded mode or not:
+  // In embedded mode (i.e. embedded == true), fullWidthContent should default to true, unless explicitly passed as false.
   // In non-embedded mode, fullWidthContent should default to false, unless explicitly set to true.
-  // In embedded mode though, fullWidthContent should default to true, unless explicitly passed as false.
-  let fullWidthOrDefault
-  if (embedded) {
-    fullWidthOrDefault = fullWidthContent === false ? false : true
-  } else {
-    fullWidthOrDefault = fullWidthContent === true ? true : false
-  }
+  const fullWidthOrDefault = embedded ? fullWidthContent !== false : fullWidthContent === true
 
   return (
     <AppBody className={className} {...props}>

--- a/packages/ui-components/src/components/AppShell/AppShell.test.tsx
+++ b/packages/ui-components/src/components/AppShell/AppShell.test.tsx
@@ -23,15 +23,6 @@ describe("AppShell", () => {
     expect(screen.getByTestId("app-shell")).toHaveClass("juno-body")
   })
 
-  test("logs a deprecation warning to the console when user passed obsolete contentHeading prop", () => {
-    const consoleWarnSpy = vi.spyOn(console, "warn")
-    render(<AppShell contentHeading="My Content Heading" />)
-    expect(consoleWarnSpy).toHaveBeenCalled()
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      "AppShell: The contentHeading prop is obsolete and will be removed in a future version. In order to render a content heading, use a ContentHeading element as a child in your main content."
-    )
-  })
-
   test("renders an app shell with page header passed as String", () => {
     render(<AppShell data-testid="app-shell" pageHeader="My Page Header" />)
     expect(screen.getByTestId("app-shell")).toBeInTheDocument()
@@ -117,23 +108,26 @@ describe("AppShell", () => {
     expect(screen.getByRole("button")).toBeInTheDocument()
   })
 
-  // The following test whether the MainContainerInner element rendered by AppShell does the right thing depending of props passed to AppShell:
-  test("does not render a fullwidth main container in non-embedded mode by default", () => {
+  // The following test whether the MainContainerInner element rendered by AppShell does the right thing depending of props passed to AppShell
+  // They also check that the HeaderContainer within the AppShell behaves the same as the MainContainerInner
+  test("does not render a fullwidth main and header container in non-embedded mode by default", () => {
     render(
       <AppShell>
         <button></button>
       </AppShell>
     )
     expect(document.querySelector(".juno-main-inner")).not.toHaveClass("juno-main-inner-fullwidth")
+    expect(document.querySelector(".juno-header-container")).not.toHaveClass("juno-header-container-fullwidth")
   })
 
-  test("renders a fullwidth main container in non-embedded mode if passed explicitly", () => {
+  test("renders a fullwidth main and header container in non-embedded mode if passed explicitly", () => {
     render(
       <AppShell fullWidthContent={true}>
         <button></button>
       </AppShell>
     )
     expect(document.querySelector(".juno-main-inner")).toHaveClass("juno-main-inner-fullwidth")
+    expect(document.querySelector(".juno-header-container")).toHaveClass("juno-header-container-fullwidth")
   })
 
   test("renders a fullwidth main inner container in embedded mode by default", () => {
@@ -145,6 +139,16 @@ describe("AppShell", () => {
     expect(document.querySelector(".juno-main-inner")).toHaveClass("juno-main-inner-fullwidth")
   })
 
+  test("renders a fullwidth main and header container in embedded mode with topnav by default", () => {
+    render(
+      <AppShell embedded topNavigation={<TopNavigation></TopNavigation>}>
+        <button></button>
+      </AppShell>
+    )
+    expect(document.querySelector(".juno-main-inner")).toHaveClass("juno-main-inner-fullwidth")
+    expect(document.querySelector(".juno-header-container")).toHaveClass("juno-header-container-fullwidth")
+  })
+
   test("renders a non-fullwidth, size-restricted main inner container in embedded mode if passed explicitly", () => {
     render(
       <AppShell embedded fullWidthContent={false}>
@@ -152,6 +156,16 @@ describe("AppShell", () => {
       </AppShell>
     )
     expect(document.querySelector(".juno-main-inner")).not.toHaveClass("juno-main-inner-fullwidth")
+  })
+
+  test("renders a non-fullwidth, size-restricted main inner and header container in embedded mode with topnav if passed explicitly", () => {
+    render(
+      <AppShell embedded fullWidthContent={false} topNavigation={<TopNavigation></TopNavigation>}>
+        <button></button>
+      </AppShell>
+    )
+    expect(document.querySelector(".juno-main-inner")).not.toHaveClass("juno-main-inner-fullwidth")
+    expect(document.querySelector(".juno-header-container")).not.toHaveClass("juno-header-container-fullwidth")
   })
 
   test("renders a custom className", () => {

--- a/packages/ui-components/src/components/HeaderContainer/HeaderContainer.component.tsx
+++ b/packages/ui-components/src/components/HeaderContainer/HeaderContainer.component.tsx
@@ -25,7 +25,7 @@ export const HeaderContainer: React.FC<HeaderContainerProps> = ({
     <div
       className={`
     juno-header-container 
-    ${!fullWidth ? "jn-w-full 2xl:jn-container 2xl:jn-mx-auto" : ""}
+    ${!fullWidth ? "jn-w-full 2xl:jn-container 2xl:jn-mx-auto" : "juno-header-container-fullwidth"}
     ${headerContainerStyles} 
     ${className}`}
       {...props}


### PR DESCRIPTION
# Summary

This PR ensures that the default fullWidth behaviour is the same for both the main container and the header container.

Default behaviour is meant to be as follows:
* In non-embedded mode, fullWidthContent should default to false, unless explicitly set to true.
* In embedded mode though, fullWidthContent should default to true, unless explicitly passed as false.

If using `AppShell` for layout the main container (which holds the app content) followed this logic. However the recently added `HeaderContainer` did not, it always defaulted to `false`. This PR ensures that they both behave in the same way when it comes to defaults for this prop.

# Changes Made

- Ensured fullWidth default is applied to both `HeaderContainer` and main container in `AppShell`
- Refactored `AppShell`: moved `HeaderContainer` to jsx section instead of rendering it via function
- Added tests to `AppShell` to ensure main and header container behave the same in all combinations of `embedded` and `fullWidthContent`
- Had to update `apps/template/App.tsx` because the typecheck was failing if `fullWidthContent` wasn't passed to `AppShell` <-- I don't understand this, the prop is marked as optional in the type ??!?

# Testing Instructions

1. `npm i`
2. `npm run test`
3. start an app with `TopNavigation`  and run it with `embedded = true` --> both header (i.e. top nav) and main app content should default to full width
4. run the app with `embedded = false` --> both header and main app content should default to max width rendering (i.e. not full width)
5. `embedded = true` + `fullWidthContent = false` --> same behaviour as 4.
6. `embedded = false` + `fullWidthContent = true` --> same behaviour as 3.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
