### PR TITLE
chore(ui): remove null children

### DIFF
--- a/packages/ui-components/src/components/Badge/Badge.component.tsx
+++ b/packages/ui-components/src/components/Badge/Badge.component.tsx
@@ -92,7 +92,7 @@ export const Badge: React.FC<BadgeProps> = ({
   icon = false,
   text = "",
   className = "",
-  children = null,
+  children,
   ...props
 }) => {
   const iconToRender = getIcon(icon, variant)

--- a/packages/ui-components/src/components/Box/Box.component.tsx
+++ b/packages/ui-components/src/components/Box/Box.component.tsx
@@ -39,7 +39,7 @@ export interface BoxProps extends React.HTMLAttributes<HTMLDivElement> {
  * Ideal for annotations, additional explanations, and remarks where a Message or InfoBox would be too visually emphasized.
  * Typically used for small text but can contain any child elements, as required.
  */
-export const Box: React.FC<BoxProps> = ({ children = null, unpad = false, className = "", ...props }) => {
+export const Box: React.FC<BoxProps> = ({ children, unpad = false, className = "", ...props }) => {
   const combinedClassName = `juno-box ${boxStyles} ${!unpad ? boxPadding : ""} ${className}`
   return (
     <div className={combinedClassName} {...props}>

--- a/packages/ui-components/src/components/BreadcrumbItem/BreadcrumbItem.component.tsx
+++ b/packages/ui-components/src/components/BreadcrumbItem/BreadcrumbItem.component.tsx
@@ -66,7 +66,7 @@ export const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({
   label = "Item",
   ariaLabel = "",
   active = false,
-  children = null,
+  children,
   disabled = false,
   onClick,
   className = "",

--- a/packages/ui-components/src/components/ButtonRow/ButtonRow.component.tsx
+++ b/packages/ui-components/src/components/ButtonRow/ButtonRow.component.tsx
@@ -7,7 +7,7 @@ import React from "react"
 import { Stack } from "../Stack/Stack.component"
 
 /** A container to hold one or multiple buttons and space and align them. */
-export const ButtonRow: React.FC<ButtonRowProps> = ({ children = null, className = "", ...props }) => {
+export const ButtonRow: React.FC<ButtonRowProps> = ({ children, className = "", ...props }) => {
   return (
     <Stack gap="2" distribution="end" className={`juno-button-row ${className}`} {...props}>
       {children}

--- a/packages/ui-components/src/components/CheckboxGroup/CheckboxGroup.component.tsx
+++ b/packages/ui-components/src/components/CheckboxGroup/CheckboxGroup.component.tsx
@@ -55,7 +55,7 @@ export const CheckboxGroupContext = createContext<CheckboxGroupContextProps | un
 export type CheckboxValue = string | undefined
 
 export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
-  children = null,
+  children,
   className = "",
   disabled = false,
   errortext = "",

--- a/packages/ui-components/src/components/Code/Code.component.tsx
+++ b/packages/ui-components/src/components/Code/Code.component.tsx
@@ -13,7 +13,7 @@ const codeStyles = `
 /** A basic inline <code> component.
  *   Accepts "content" prop or renders children as passed.
  */
-export const Code: React.FC<CodeProps> = ({ content = "", children = null, className = "", ...props }) => {
+export const Code: React.FC<CodeProps> = ({ content = "", children, className = "", ...props }) => {
   return (
     <code className={`juno-code ${codeStyles} ${className}`} {...props}>
       {content || children}

--- a/packages/ui-components/src/components/ContextMenu/ContextMenu.component.tsx
+++ b/packages/ui-components/src/components/ContextMenu/ContextMenu.component.tsx
@@ -51,7 +51,7 @@ export interface ContextMenuProps {
 export const ContextMenu: React.FC<ContextMenuProps> = ({
   /*icon,*/
   /*className,*/
-  children = null,
+  children,
   open = false,
   /*...props*/
 }) => {

--- a/packages/ui-components/src/components/DataGrid/DataGrid.component.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGrid.component.tsx
@@ -63,7 +63,7 @@ export const DataGrid: React.FC<DataGridProps> = ({
   gridColumnTemplate,
   cellVerticalAlignment = "center",
   className = "",
-  children = null,
+  children,
   ...props
 }) => {
   const dataGridConf = {

--- a/packages/ui-components/src/components/DataGridCell/DataGridCell.component.tsx
+++ b/packages/ui-components/src/components/DataGridCell/DataGridCell.component.tsx
@@ -36,7 +36,7 @@ const cellCustomStyles = (colSpan: number | undefined) => {
 }
 
 export const DataGridCell = forwardRef<HTMLDivElement, DataGridCellProps>(
-  ({ colSpan, nowrap = false, className = "", children = null, ...props }, ref) => {
+  ({ colSpan, nowrap = false, className = "", children, ...props }, ref) => {
     const dataGridContext = useDataGridContext() || {}
     const cellVerticalAlignment = dataGridContext.cellVerticalAlignment
 

--- a/packages/ui-components/src/components/DataGridFoot/DataGridFoot.component.tsx
+++ b/packages/ui-components/src/components/DataGridFoot/DataGridFoot.component.tsx
@@ -5,7 +5,7 @@
 
 import React from "react"
 
-export const DataGridFoot: React.FC<DataGridFootProps> = ({ className = "", children = null, ...props }) => {
+export const DataGridFoot: React.FC<DataGridFootProps> = ({ className = "", children, ...props }) => {
   return (
     <tfoot className={`juno-datagrid-foot ${className}`} {...props}>
       {children}

--- a/packages/ui-components/src/components/DataGridHeadCell/DataGridHeadCell.component.tsx
+++ b/packages/ui-components/src/components/DataGridHeadCell/DataGridHeadCell.component.tsx
@@ -20,7 +20,7 @@ export const DataGridHeadCell = forwardRef<HTMLDivElement, DataGridHeadCellProps
       colSpan,
       nowrap = false,
       className = "",
-      children = null,
+      children,
       ...props
     },
     ref

--- a/packages/ui-components/src/components/DataGridRow/DataGridRow.component.tsx
+++ b/packages/ui-components/src/components/DataGridRow/DataGridRow.component.tsx
@@ -12,7 +12,7 @@ const rowBaseStyle = `
 // 	jn-bg-theme-datagridrow-selected
 // `
 export const DataGridRow = forwardRef<HTMLDivElement, DataGridRowProps>(
-  ({ /* selected, disabled,*/ className = "", children = null, /*onChange,*/ ...props }, ref) => {
+  ({ /* selected, disabled,*/ className = "", children, /*onChange,*/ ...props }, ref) => {
     // const dataGridContext = useDataGridContext() || {}
     // const selectable = dataGridContext.selectable
 

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
@@ -19,12 +19,7 @@ const childrenWrapperStyles = `
 `
 
 /** This is the toolbar for use with a DataGrid. This is the place where you would put buttons and other controls that affect the items in the DataGrid (e.g. triggering batch actions). Optionally a search input can be added. */
-export const DataGridToolbar: React.FC<DataGridToolbarProps> = ({
-  search,
-  className = "",
-  children = null,
-  ...props
-}) => {
+export const DataGridToolbar: React.FC<DataGridToolbarProps> = ({ search, className = "", children, ...props }) => {
   return (
     <div className={`juno-datagrid-toolbar ${datagridtoolbarstyles} ${className}`} {...props}>
       {search && <div>{search}</div>}

--- a/packages/ui-components/src/components/FormattedText/FormattedText.component.tsx
+++ b/packages/ui-components/src/components/FormattedText/FormattedText.component.tsx
@@ -17,7 +17,7 @@ export interface FormattedTextProps extends React.HTMLAttributes<HTMLDivElement>
  */
 export const FormattedText: React.FC<FormattedTextProps> = ({
   className = "", // Default value for className
-  children = null, // Default value for children
+  children, // Default value for children
   ...props
 }) => {
   return (

--- a/packages/ui-components/src/components/Grid/Grid.component.tsx
+++ b/packages/ui-components/src/components/Grid/Grid.component.tsx
@@ -33,7 +33,7 @@ export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
  * A general-use grid component.
  * Used in conjunction with GridColumn and GridRow components to create a flexible grid layout.
  */
-export const Grid: React.FC<GridProps> = ({ auto = false, children = null, className = "", ...props }) => {
+export const Grid: React.FC<GridProps> = ({ auto = false, children, className = "", ...props }) => {
   const gridStyles = auto ? autoStyles : {}
 
   return (

--- a/packages/ui-components/src/components/GridColumn/GridColumn.component.tsx
+++ b/packages/ui-components/src/components/GridColumn/GridColumn.component.tsx
@@ -70,7 +70,7 @@ export const GridColumn: React.FC<GridColumnProps> = ({
   cols = null,
   auto = false,
   className = "",
-  children = null,
+  children,
   ...props
 }) => {
   const widthBasedStyles: React.CSSProperties = width

--- a/packages/ui-components/src/components/GridRow/GridRow.component.tsx
+++ b/packages/ui-components/src/components/GridRow/GridRow.component.tsx
@@ -27,7 +27,7 @@ export interface GridRowProps extends React.HTMLAttributes<HTMLDivElement> {
  * A grid row container to hold GridColumn elements inside a Grid.
  * This component ensures that its children are wrapped correctly in a flexbox layout.
  */
-export const GridRow: React.FC<GridRowProps> = ({ children = null, className = "", ...props }) => {
+export const GridRow: React.FC<GridRowProps> = ({ children, className = "", ...props }) => {
   return (
     <div className={`juno-grid-row ${baseRowStyles} ${className}`} {...props}>
       {children}

--- a/packages/ui-components/src/components/HeaderContainer/HeaderContainer.component.tsx
+++ b/packages/ui-components/src/components/HeaderContainer/HeaderContainer.component.tsx
@@ -18,7 +18,7 @@ const headerContainerStyles = `
 export const HeaderContainer: React.FC<HeaderContainerProps> = ({
   fullWidth = false,
   className = "",
-  children = null,
+  children,
   ...props
 }) => {
   return (

--- a/packages/ui-components/src/components/InputGroup/InputGroup.component.tsx
+++ b/packages/ui-components/src/components/InputGroup/InputGroup.component.tsx
@@ -64,7 +64,7 @@ const getClassNames = (baseClassName: string, variant: VariantTypes, disabled: b
  * Buttons, TextInput, and Select elements, providing a cohesive styling approach.
  */
 export const InputGroup: React.FC<InputGroupProps> = ({
-  children = null,
+  children,
   className = "",
   variant = "default",
   disabled = false,

--- a/packages/ui-components/src/components/MainContainer/MainContainer.component.tsx
+++ b/packages/ui-components/src/components/MainContainer/MainContainer.component.tsx
@@ -15,7 +15,7 @@ const mainStyles = `
  * Only needed if you want to build your app's scaffold manually. In most cases it is better to use the AppShell component instead.
  * The main container for app content.
  */
-export const MainContainer: React.FC<MainContainerProps> = ({ className = "", children = null, ...props }) => {
+export const MainContainer: React.FC<MainContainerProps> = ({ className = "", children, ...props }) => {
   return (
     <main className={`juno-main ${mainStyles} ${className}`} {...props}>
       {children}

--- a/packages/ui-components/src/components/MainContainerInner/MainContainerInner.component.tsx
+++ b/packages/ui-components/src/components/MainContainerInner/MainContainerInner.component.tsx
@@ -22,7 +22,7 @@ const constrainWithSideNavStyles = `
 
 /** An inner wrapper to constrain page / view content width. */
 export const MainContainerInner: React.FC<MainContainerInnerProps> = ({
-  children = null,
+  children,
   fullWidth = false,
   hasSideNav = false,
   className = "",

--- a/packages/ui-components/src/components/MainTabs/MainTabs.component.tsx
+++ b/packages/ui-components/src/components/MainTabs/MainTabs.component.tsx
@@ -12,7 +12,7 @@ import { TabPanelProps } from "../TabPanel/TabPanel.component"
 Main Tabs are used at the top of the content area when using the tabs to switch the complete content area content. If you only want to have tabs for parts of the content use 'Tabs' instead and place them in the part of the content where the tabbed content should live. You will probably want to use a 'Container' inside the TabPanels to get nice padding.
  */
 export const MainTabs: React.FC<MainTabsProps> = ({
-  children = null,
+  children,
   defaultIndex,
   selectedIndex,
   onSelect,

--- a/packages/ui-components/src/components/Menu/Menu.component.tsx
+++ b/packages/ui-components/src/components/Menu/Menu.component.tsx
@@ -37,7 +37,7 @@ interface MenuContextType {
 export const MenuContext = createContext<MenuContextType | undefined>(undefined)
 
 /** A generic menu component */
-export const Menu: React.FC<MenuProps> = ({ children = null, variant = "normal", className = "", ...props }) => {
+export const Menu: React.FC<MenuProps> = ({ children, variant = "normal", className = "", ...props }) => {
   return (
     <MenuContext.Provider
       value={{

--- a/packages/ui-components/src/components/MenuItem/MenuItem.component.tsx
+++ b/packages/ui-components/src/components/MenuItem/MenuItem.component.tsx
@@ -66,7 +66,7 @@ interface MenuContextType {
  Can render `<a>`, `<button>`, or `<div>` based on props.
  */
 export const MenuItem: FC<MenuItemProps> = ({
-  children = null,
+  children,
   className = "",
   disabled = false,
   href = "",

--- a/packages/ui-components/src/components/MenuSection/MenuSection.component.tsx
+++ b/packages/ui-components/src/components/MenuSection/MenuSection.component.tsx
@@ -19,7 +19,7 @@ const titleStyles = `
 	jn-p-2
 `
 /** Use MenuSection to structure and sub-divide MenuItems in a menu. All but the last MenuSection will render a visible divider at the bottom. Optionally, a MenuSection can have a title.*/
-export const MenuSection: React.FC<MenuSectionProps> = ({ title = "", children = null, className = "", ...props }) => {
+export const MenuSection: React.FC<MenuSectionProps> = ({ title = "", children, className = "", ...props }) => {
   return (
     <div className={`juno-menu-section ${sectionStyles} ${className}`} {...props}>
       {title ? <div className={`juno-menu-section-title ${titleStyles}`}>{title}</div> : ""}

--- a/packages/ui-components/src/components/Modal/Modal.component.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.component.tsx
@@ -87,7 +87,7 @@ export const Modal: React.FC<ModalProps> = ({
   cancelButtonLabel = "",
   confirmButtonIcon = null,
   confirmButtonLabel = "",
-  children = null,
+  children,
   closeable = true,
   closeOnBackdropClick = false,
   closeOnEsc = true,

--- a/packages/ui-components/src/components/ModalFooter/ModalFooter.component.tsx
+++ b/packages/ui-components/src/components/ModalFooter/ModalFooter.component.tsx
@@ -30,7 +30,7 @@ Can alternatively render all custom children as passed.
 */
 
 export const ModalFooter: React.FC<ModalFooterProps> = ({
-  children = null,
+  children,
   confirmButtonLabel = "",
   cancelButtonLabel = "",
   confirmButtonIcon = null,

--- a/packages/ui-components/src/components/Navigation/Navigation.component.tsx
+++ b/packages/ui-components/src/components/Navigation/Navigation.component.tsx
@@ -40,7 +40,7 @@ interface NavigationMappingItem {
 export const Navigation: React.FC<NavigationProps> = ({
   activeItem = "",
   ariaLabel = "",
-  children = null,
+  children,
   className = "",
   disabled = false,
   onActiveItemChange,

--- a/packages/ui-components/src/components/NavigationItem/NavigationItem.component.tsx
+++ b/packages/ui-components/src/components/NavigationItem/NavigationItem.component.tsx
@@ -25,7 +25,7 @@ export const NavigationItem: React.FC<NavigationItemProps> = ({
   active = false,
   activeItemStyles = "",
   ariaLabel = "",
-  children = null,
+  children,
   className = "",
   disabled = false,
   icon = null,

--- a/packages/ui-components/src/components/PageFooter/PageFooter.component.tsx
+++ b/packages/ui-components/src/components/PageFooter/PageFooter.component.tsx
@@ -30,7 +30,7 @@ const logoStyles = `
 /**
  * The page footer component renders a footer at the bottom of the website. Place as last child of AppBody.
  */
-export const PageFooter: React.FC<PageFooterProps> = ({ className = "", children = null, ...props }) => {
+export const PageFooter: React.FC<PageFooterProps> = ({ className = "", children, ...props }) => {
   return (
     <div className={`juno-pagefooter ${basePageFooter} ${className}`} role="contentinfo" {...props}>
       {children}

--- a/packages/ui-components/src/components/PageHeader/PageHeader.component.tsx
+++ b/packages/ui-components/src/components/PageHeader/PageHeader.component.tsx
@@ -59,7 +59,7 @@ const headingStyles = `
 export const PageHeader: React.FC<PageHeaderProps> = ({
   heading = null,
   className = "",
-  children = null,
+  children,
   logo = undefined,
   onClick,
   ...props

--- a/packages/ui-components/src/components/PortalProvider/PortalProvider.Portal.component.tsx
+++ b/packages/ui-components/src/components/PortalProvider/PortalProvider.Portal.component.tsx
@@ -19,7 +19,7 @@ const portalStyles: React.CSSProperties = {
  *   </PortalProvider.Portal>
  *  ```
  */
-export const Portal = ({ children = null }: PortalProviderPortalProps) => {
+export const Portal = ({ children }: PortalProviderPortalProps) => {
   const rootRef = useContext(PortalContext)
   const [isMounted, setIsMounted] = useState(false)
 

--- a/packages/ui-components/src/components/PortalProvider/PortalProvider.component.tsx
+++ b/packages/ui-components/src/components/PortalProvider/PortalProvider.component.tsx
@@ -71,11 +71,7 @@ export function usePortalRef() {
  * It renders a portal root container, creates a context to expose a ref the container, a `PortalProvider.Portal` component to render content into a portal, and a `usePortalRef` hook to render content into a portal.
  * Normally, there is no need to include `PortalProvider` manually, when using `AppShell` `PortalProvider` is already included in the app.
  */
-export const PortalProvider = ({
-  children = null,
-  className = "",
-  id = DEFAULT_PORTAL_ROOT_ID,
-}: PortalProviderProps) => {
+export const PortalProvider = ({ children, className = "", id = DEFAULT_PORTAL_ROOT_ID }: PortalProviderProps) => {
   const portalRootRef = useRef<HTMLDivElement | null>(null)
   const [isMounted, setIsMounted] = useState(false)
 

--- a/packages/ui-components/src/components/RadioGroup/RadioGroup.component.tsx
+++ b/packages/ui-components/src/components/RadioGroup/RadioGroup.component.tsx
@@ -75,7 +75,7 @@ export const RadioGroupContext = createContext<RadioGroupContextProps>({})
 A component to wrap and group individual Radio components: All contained child Radio elements will share the same `name`-attribute passed as a prop to the group, and thus make the Radios work with each other as expected.
 */
 export const RadioGroup: React.FC<RadioGroupProps> = ({
-  children = null,
+  children,
   className = "",
   disabled = false,
   errortext = "",

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -143,7 +143,7 @@ export interface SelectProps
 */
 export const Select: React.FC<SelectProps> = ({
   ariaLabel = "",
-  children = null,
+  children,
   className = "",
   defaultValue,
   disabled = false,

--- a/packages/ui-components/src/components/ShadowRoot/ShadowRoot.component.tsx
+++ b/packages/ui-components/src/components/ShadowRoot/ShadowRoot.component.tsx
@@ -41,7 +41,7 @@ import React, { useRef, useState } from "react"
  * in to the current parent element. ShadowRoot allows html to be isolated from the rest of the DOM. If styles are given, these and
  * the children are added to the shadow element. The themeClass is added to a wrapper div surrounding the children.
  */
-export const ShadowRoot: React.FC<ShadowRootProps> = ({ mode = "open", delegatesFocus = false, children = null }) => {
+export const ShadowRoot: React.FC<ShadowRootProps> = ({ mode = "open", delegatesFocus = false, children }) => {
   // reference element which is replaced by the shadow dom element
   const ref = useRef<HTMLDivElement | null>(null)
   // hold shadow element in the state

--- a/packages/ui-components/src/components/SideNavigation/SideNavigation.component.tsx
+++ b/packages/ui-components/src/components/SideNavigation/SideNavigation.component.tsx
@@ -19,7 +19,7 @@ Place SideNavigationItem components as children.
 export const SideNavigation: React.FC<SideNavigationProps> = ({
   activeItem = "",
   ariaLabel,
-  children = null,
+  children,
   className = "",
   disabled = false,
   onActiveItemChange,

--- a/packages/ui-components/src/components/StyleProvider/StyleProvider.component.tsx
+++ b/packages/ui-components/src/components/StyleProvider/StyleProvider.component.tsx
@@ -51,7 +51,7 @@ export const DEFAULT_THEME_NAME = "theme-dark"
 export const StyleProvider = ({
   stylesWrapper = "inline",
   theme: themeProp,
-  children = null,
+  children,
   shadowRootMode,
 }: StyleProviderProps) => {
   // Determine the default value to init the storedTheme by using the prop if passed, or default:

--- a/packages/ui-components/src/components/Tab/Tab.component.tsx
+++ b/packages/ui-components/src/components/Tab/Tab.component.tsx
@@ -35,7 +35,7 @@ const iconStyles = `
 
 
 */
-export const Tab = ({ children = null, label = "", icon, disabled = false, className = "", ...props }: TabProps) => {
+export const Tab = ({ children, label = "", icon, disabled = false, className = "", ...props }: TabProps) => {
   return (
     <ReactTab
       className={`juno-tab ${tabStyles} ${className}`}

--- a/packages/ui-components/src/components/TabList/TabList.component.tsx
+++ b/packages/ui-components/src/components/TabList/TabList.component.tsx
@@ -34,7 +34,7 @@ const getVariantStyles = (variant: TabsVariant) => {
 
 /** A tabList component wraps all individual Tabs inside a parent Tabs component */
 
-export const TabList = ({ variant = "content", children = null, ...props }: TabListProps) => {
+export const TabList = ({ variant = "content", children, ...props }: TabListProps) => {
   const tabsContext = useTabsContext() || {}
   const tabsVariant = tabsContext.variant || variant
 

--- a/packages/ui-components/src/components/TabNavigation/TabNavigation.component.tsx
+++ b/packages/ui-components/src/components/TabNavigation/TabNavigation.component.tsx
@@ -20,7 +20,7 @@ export const TabNavigationContext = createContext<TabNavigationContextType | und
 export const TabNavigation: React.FC<TabNavigationProps> = ({
   activeItem = "",
   ariaLabel,
-  children = null,
+  children,
   className = "",
   disabled = false,
   onActiveItemChange,

--- a/packages/ui-components/src/components/TabNavigationItem/TabNavigationItem.component.tsx
+++ b/packages/ui-components/src/components/TabNavigationItem/TabNavigationItem.component.tsx
@@ -32,7 +32,7 @@ const tabNavActiveItemStyles = `
 export const TabNavigationItem: React.FC<TabNavigationItemProps> = ({
   active = false,
   ariaLabel,
-  children = null,
+  children,
   className = "",
   disabled = false,
   href,

--- a/packages/ui-components/src/components/TabPanel/TabPanel.component.tsx
+++ b/packages/ui-components/src/components/TabPanel/TabPanel.component.tsx
@@ -10,7 +10,7 @@ import { TabPanel as ReactTabPanel, TabPanelProps as ReactTabPanelProps } from "
 The TabPanel holds content related to a Tab in a TabList in a wrapping Tab component. Not to be used standalone / outside a Tabs wrapper.
 */
 
-export const TabPanel = ({ children = null, className = "", ...props }: TabPanelProps) => {
+export const TabPanel = ({ children, className = "", ...props }: TabPanelProps) => {
   return (
     <ReactTabPanel className={`juno-tabpanel ${className}`} selectedClassName="juno-tabpanel-selected" {...props}>
       {children}

--- a/packages/ui-components/src/components/Tabs/Tabs.component.tsx
+++ b/packages/ui-components/src/components/Tabs/Tabs.component.tsx
@@ -23,7 +23,7 @@ Tabs are used to provide a tabbed section within the content area when combining
 */
 
 export const Tabs = ({
-  children = null,
+  children,
   defaultIndex,
   selectedIndex,
   onSelect,

--- a/packages/ui-components/src/components/Toast/Toast.component.tsx
+++ b/packages/ui-components/src/components/Toast/Toast.component.tsx
@@ -53,7 +53,7 @@ A Toast component. Use for short-lived, temporary/transient messaging to users r
 
 export const Toast: React.FC<ToastProps> = ({
   variant = "info",
-  children = null,
+  children,
   text = "",
   autoDismiss = false,
   autoDismissTimeout = 10000,

--- a/packages/ui-components/src/components/Tooltip/Tooltip.component.tsx
+++ b/packages/ui-components/src/components/Tooltip/Tooltip.component.tsx
@@ -58,7 +58,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   open,
   triggerEvent = "click",
   disabled = false,
-  children = null,
+  children,
   ...props
 }) => {
   // This can accept any floating ui props as options, e.g. `placement`,

--- a/packages/ui-components/src/components/TooltipContent/TooltipContent.component.tsx
+++ b/packages/ui-components/src/components/TooltipContent/TooltipContent.component.tsx
@@ -49,7 +49,7 @@ export interface TooltipContentProps extends React.HTMLAttributes<HTMLDivElement
  * Put content for a tooltip here. See Tooltip for more in-depth explanation and examples.
  */
 export const TooltipContent = React.forwardRef<HTMLElement, TooltipContentProps>(function TooltipContent(
-  { className = "", children = null, ...props },
+  { className = "", children, ...props },
   propRef
 ) {
   // get tooltip state

--- a/packages/ui-components/src/components/TooltipTrigger/TooltipTrigger.component.tsx
+++ b/packages/ui-components/src/components/TooltipTrigger/TooltipTrigger.component.tsx
@@ -24,7 +24,7 @@ type CustomProps = React.HTMLProps<HTMLElement> & {
  * This is the trigger element for a tooltip. See Tooltip for more in-depth explanation and examples.
  */
 export const TooltipTrigger = React.forwardRef<HTMLElement, TooltipTriggerProps>(function TooltipTrigger(
-  { children = null, asChild = false, className = "", ...props },
+  { children, asChild = false, className = "", ...props },
   propRef
 ) {
   // get state

--- a/packages/ui-components/src/components/TopNavigation/TopNavigation.component.tsx
+++ b/packages/ui-components/src/components/TopNavigation/TopNavigation.component.tsx
@@ -20,7 +20,7 @@ Place `TopNavigationItem` elements as children.
 export const TopNavigation: React.FC<TopNavigationProps> = ({
   activeItem = "",
   ariaLabel,
-  children = null,
+  children,
   className = "",
   disabled = false,
   onActiveItemChange,

--- a/packages/ui-components/src/components/TopNavigationItem/TopNavigationItem.component.tsx
+++ b/packages/ui-components/src/components/TopNavigationItem/TopNavigationItem.component.tsx
@@ -42,7 +42,7 @@ An individual item of a top level navigation. Place inside TopNavigation.
 export const TopNavigationItem: React.FC<TopNavigationItemProps> = ({
   active = false,
   ariaLabel,
-  children = null,
+  children,
   className = "",
   disabled = false,
   href = "",

--- a/packages/ui-components/src/deprecated_js/ContentArea/ContentArea.component.jsx
+++ b/packages/ui-components/src/deprecated_js/ContentArea/ContentArea.component.jsx
@@ -16,7 +16,7 @@ const containerStyles = `
 /**
  * Deprecated: This component used to be used internally by AppShell but has been removed there since. It was only needed to manually scaffold an app. Use AppShell to scaffold an app layout..
  */
-export const ContentArea = ({ className = "", children = null, ...props }) => {
+export const ContentArea = ({ className = "", children, ...props }) => {
   return (
     <div className={`juno-content-area ${containerStyles} ${className}`} {...props}>
       {children}

--- a/packages/ui-components/src/deprecated_js/ContentAreaWrapper/ContentAreaWrapper.component.jsx
+++ b/packages/ui-components/src/deprecated_js/ContentAreaWrapper/ContentAreaWrapper.component.jsx
@@ -19,7 +19,7 @@ const containerStyles = `
 /**
  * Deprecated: Will be deleted!
  */
-export const ContentAreaWrapper = ({ className = "", children = null, ...props }) => {
+export const ContentAreaWrapper = ({ className = "", children, ...props }) => {
   return (
     <div className={`juno-content-area-wrapper ${containerStyles} ${className}`} {...props}>
       {children}

--- a/packages/ui-components/src/deprecated_js/DataList/DataList.component.jsx
+++ b/packages/ui-components/src/deprecated_js/DataList/DataList.component.jsx
@@ -10,7 +10,7 @@ const DataListContext = React.createContext()
 
 export const useDataListContext = () => React.useContext(DataListContext)
 
-export const DataList = ({ selectable = false, className = "", children = null, ...props }) => {
+export const DataList = ({ selectable = false, className = "", children, ...props }) => {
   const dataListConf = {
     selectable: selectable,
   }

--- a/packages/ui-components/src/deprecated_js/DataListCell/DataListCell.component.jsx
+++ b/packages/ui-components/src/deprecated_js/DataListCell/DataListCell.component.jsx
@@ -95,14 +95,7 @@ const colsClass = (cols) => {
   }
 }
 
-export const DataListCell = ({
-  cols = null,
-  width = null,
-  auto = false,
-  className = "",
-  children = null,
-  ...props
-}) => {
+export const DataListCell = ({ cols = null, width = null, auto = false, className = "", children, ...props }) => {
   // auto cell:
   const autoStyles = {
     flexGrow: "1",

--- a/packages/ui-components/src/deprecated_js/DataListRow/DataListRow.component.jsx
+++ b/packages/ui-components/src/deprecated_js/DataListRow/DataListRow.component.jsx
@@ -20,7 +20,7 @@ const rowselectedstyle = `
 	jn-bg-theme-datalistrow-selected
 `
 
-export const DataListRow = ({ selected, disabled, onChange, className = "", children = null, ...props }) => {
+export const DataListRow = ({ selected, disabled, onChange, className = "", children, ...props }) => {
   const dataListContext = useDataListContext() || {}
   const selectable = dataListContext.selectable
 

--- a/packages/ui-components/src/deprecated_js/FormHint/FormHint.component.jsx
+++ b/packages/ui-components/src/deprecated_js/FormHint/FormHint.component.jsx
@@ -22,7 +22,7 @@ const variantStyles = (variant) => {
   }
 }
 
-export const FormHint = ({ children = null, text = "", variant = "help", className, ...props }) => {
+export const FormHint = ({ children, text = "", variant = "help", className, ...props }) => {
   return (
     <div
       className={`

--- a/packages/ui-components/src/deprecated_js/FormRow/FormRow.component.jsx
+++ b/packages/ui-components/src/deprecated_js/FormRow/FormRow.component.jsx
@@ -14,7 +14,7 @@ const formRowStyles = `
 A generic FormRow component.
 Used to layout and structure forms. Pass Form elements such as TextInput, Textarea, Select, or Radio and CheckboxGroups as children.
 */
-export const FormRow = ({ children = null, className = "", ...props }) => {
+export const FormRow = ({ children, className = "", ...props }) => {
   return (
     <div className={`juno-form-row ${formRowStyles} ${className}`} {...props}>
       {children}

--- a/packages/ui-components/src/deprecated_js/PortalProvider/PortalProvider.component.jsx
+++ b/packages/ui-components/src/deprecated_js/PortalProvider/PortalProvider.component.jsx
@@ -30,7 +30,7 @@ const portalStyles = {
  *   </PortalProvider.Portal>
  *  ```
  */
-const Portal = ({ children = null }) => {
+const Portal = ({ children }) => {
   const rootRef = useContext(PortalContext)
   const [isMounted, setIsMounted] = useState(false)
 
@@ -107,7 +107,7 @@ export function usePortalRef() {
  * It renders a portal root container, creates a context to expose a ref the container, a `PortalProvider.Portal` component to render content into a portal, and a `usePortalRef` hook to render content into a portal.
  * Normally, there is no need to include `PortalProvider` manually, when using `AppShell` `PortalProvider` is already included in the app.
  */
-export const PortalProvider = ({ children = null, className = "", id = DEFAULT_PORTAL_ROOT_ID }) => {
+export const PortalProvider = ({ children, className = "", id = DEFAULT_PORTAL_ROOT_ID }) => {
   const portalRootRef = useRef()
   const [isMounted, setIsMounted] = useState(false)
 

--- a/packages/ui-components/src/deprecated_js/Select/Select.component.jsx
+++ b/packages/ui-components/src/deprecated_js/Select/Select.component.jsx
@@ -77,7 +77,7 @@ export const SelectContext = createContext()
 */
 export const Select = ({
   ariaLabel = "",
-  children = null,
+  children,
   className = "",
   defaultValue,
   disabled = false,

--- a/packages/ui-components/src/deprecated_js/ShadowRoot/ShadowRoot.component.jsx
+++ b/packages/ui-components/src/deprecated_js/ShadowRoot/ShadowRoot.component.jsx
@@ -44,7 +44,7 @@ import PropTypes from "prop-types"
  * @param {Object} props
  * @returns {function} component
  */
-export const ShadowRoot = ({ mode = "open", delegatesFocus = false, children = null }) => {
+export const ShadowRoot = ({ mode = "open", delegatesFocus = false, children }) => {
   // reference element which is replaced by the shadow dom element
   const ref = useRef()
   // hold shadow element in the state

--- a/packages/ui-components/src/deprecated_js/StyleProvider/StyleProvider.component.jsx
+++ b/packages/ui-components/src/deprecated_js/StyleProvider/StyleProvider.component.jsx
@@ -36,7 +36,7 @@ const DEFAULT_THEME_NAME = "theme-dark"
  * @param {object} props
  * @returns
  */
-export const StyleProvider = ({ stylesWrapper = "inline", theme: themeProp, children = null, shadowRootMode }) => {
+export const StyleProvider = ({ stylesWrapper = "inline", theme: themeProp, children, shadowRootMode }) => {
   // Determine the default value to init the storedTheme by using the prop if passed, or default:
   const themeClass = themeProp || DEFAULT_THEME_NAME
 


### PR DESCRIPTION
# Summary

Removed `null = children` default as React always treats it correctly as `null`.

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- https://github.com/cloudoperators/juno/issues/678

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
