### PR TITLE
feat(url-state-provider): export utilities to read/write state to the URL

### DIFF
--- a/.changeset/wicked-lies-cover.md
+++ b/.changeset/wicked-lies-cover.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-url-state-provider": minor
+---
+
+Exports new `saveStateToUrl` and `readStateFromUrl` utilities to save and read state from the url by using new encoder and decoder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13538,6 +13538,15 @@
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "license": "MIT"
     },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "dev": true,
@@ -24686,6 +24695,7 @@
       "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "history": "^5.3.0",
         "juri": "^1.0.3",
         "query-string": "9.1.1"
       },

--- a/packages/url-state-provider/package.json
+++ b/packages/url-state-provider/package.json
@@ -48,6 +48,7 @@
     ]
   },
   "dependencies": {
+    "history": "^5.3.0",
     "juri": "^1.0.3",
     "query-string": "9.1.1"
   }

--- a/packages/url-state-provider/src/index.ts
+++ b/packages/url-state-provider/src/index.ts
@@ -325,4 +325,4 @@ export {
   encode,
 }
 
-export { encode as encodeV2, decode as decodeV2 } from "./v2"
+export { encode as encodeV2, decode as decodeV2, saveStateToUrl, readStateFromUrl } from "./v2"

--- a/packages/url-state-provider/src/v2/index.ts
+++ b/packages/url-state-provider/src/v2/index.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import encode from "./encode"
-import decode from "./decode"
-
-export { encode, decode }
+export { default as encode } from "./encode"
+export { default as decode } from "./decode"
+export { saveStateToUrl, readStateFromUrl } from "./utils"

--- a/packages/url-state-provider/src/v2/utils.spec.ts
+++ b/packages/url-state-provider/src/v2/utils.spec.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readStateFromUrl, saveStateToUrl } from "./utils"
+
+describe("saveStateToUrl", () => {
+  it("should save state to url", () => {
+    saveStateToUrl({ key1: "value1", key2: "value2" })
+
+    expect(window.location.search).toBe("?key1=value1&key2=value2")
+  })
+})
+
+describe("readStateFromUrl", () => {
+  it("should read state from the url", () => {
+    saveStateToUrl({ key3: "value3", key4: "value4" })
+
+    expect(readStateFromUrl()).toMatchObject({
+      key3: "value3",
+      key4: "value4",
+    })
+  })
+})

--- a/packages/url-state-provider/src/v2/utils.ts
+++ b/packages/url-state-provider/src/v2/utils.ts
@@ -1,0 +1,16 @@
+import history from "history/browser"
+import encode from "./encode"
+import decode from "./decode"
+import { ObjectToEncode } from "./types"
+
+export const saveStateToUrl = (state: ObjectToEncode, replace?: boolean) => {
+  const search = encode(state)
+
+  if (replace) {
+    history.replace({ search })
+  } else {
+    history.push({ search })
+  }
+}
+
+export const readStateFromUrl = () => decode(history.location.search)


### PR DESCRIPTION
# Summary

`url-state-provider` now exports new utilities to save and read application state to the url. 

_Note:_
_These changes have been locally tested together with the `supernova` app for which the changes will follow after merging this PR._
 
# Changes Made

<!-- List the changes that were made in this pull request. -->

- exported `saveStateToUrl` that takes the application state, encodes it and saves it to the URL.
- exported `readStateFromUrl` that reads and decodes state saved in the URL.

# Related Issues

- #732 

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
