### PR TITLE
feat(supernova): integrate new url structure behind a feature flag

### DIFF
--- a/.changeset/purple-feet-swim.md
+++ b/.changeset/purple-feet-swim.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-supernova": minor
+---
+
+Supernova supports new URL structure behind a feature flat `enableNewUrlStructure` but this is not enabled by default but it can be enabled via app props.

--- a/apps/supernova/package.json
+++ b/apps/supernova/package.json
@@ -45,7 +45,6 @@
     "clean:cache": "rm -rf .turbo"
   },
   "dependencies": {
-    "@cloudoperators/juno-communicator": "*",
     "@cloudoperators/juno-messages-provider": "*",
     "@cloudoperators/juno-ui-components": "*",
     "@cloudoperators/juno-url-state-provider-v1": "^1.3.2",

--- a/apps/supernova/package.json
+++ b/apps/supernova/package.json
@@ -49,6 +49,7 @@
     "@cloudoperators/juno-messages-provider": "*",
     "@cloudoperators/juno-ui-components": "*",
     "@cloudoperators/juno-url-state-provider-v1": "^1.3.2",
+    "@cloudoperators/juno-url-state-provider": "*",
     "react-error-boundary": "^4.0.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/supernova/src/App.jsx
+++ b/apps/supernova/src/App.jsx
@@ -14,6 +14,7 @@ import CustomAppShell from "./components/CustomAppShell"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ErrorBoundary } from "react-error-boundary"
 import useUrlState from "./hooks/useUrlState"
+import useUrlQueryState from "./hooks/useUrlQueryState"
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -27,10 +28,6 @@ const queryClient = new QueryClient({
 })
 
 function App(props = {}) {
-  // syncs navigation relevat states with the url for deep links
-  // gets the state from the URL in the beginning
-  // sets the URL from state information
-  useUrlState()
   const preErrorClasses = `
     custom-error-pre
     border-theme-error
@@ -62,13 +59,31 @@ function App(props = {}) {
   )
 }
 
+const AppWithOldUrlStructure = (props) => {
+  // syncs navigation relevant states with the url for deep links
+  // gets the state from the URL in the beginning
+  // sets the URL from state information
+  useUrlState()
+  return <App {...props} />
+}
+
+const AppWithNewUrlStructure = (props) => {
+  /**
+   * [TODO]
+   * move the URL state changes closer to the origins of the change
+   * so the whole app does not unnecessarily re-render.
+   */
+  useUrlQueryState()
+  return <App {...props} />
+}
+
 const StyledApp = (props) => {
   return (
     <AppShellProvider theme={`${props.theme ? props.theme : "theme-dark"}`}>
       {/* load appstyles inside the shadow dom */}
       <style>{styles.toString()}</style>
       <StoreProvider options={props}>
-        <App {...props} />
+        {props?.enableNewUrlStructure ? <AppWithNewUrlStructure {...props} /> : <AppWithOldUrlStructure {...props} />}
       </StoreProvider>
     </AppShellProvider>
   )

--- a/apps/supernova/src/components/StoreProvider.jsx
+++ b/apps/supernova/src/components/StoreProvider.jsx
@@ -87,3 +87,16 @@ export const useSilencesRegEx = () => useAppStore((state) => state.silences.regE
 export const useSilenceTemplates = () => useAppStore((state) => state.silences.templates)
 
 export const useSilencesActions = () => useAppStore((state) => state.silences.actions)
+
+export const useGetStateForUrl = () =>
+  useAppStore((state) => ({
+    activeFilters: state.filters.activeFilters,
+    pausedFilters: state.filters.pausedFilters,
+    activePredefinedFilter: state.filters.activePredefinedFilter,
+    searchTerm: state.filters.searchTerm,
+    activeSelectedTab: state.globals.activeSelectedTab,
+    showDetailsFor: state.globals.showDetailsFor,
+    silencesRegExp: state.silences.regEx,
+    silencesStatus: state.silences.status,
+    showDetailsForSilence: state.silences.showDetailsForSilence,
+  }))

--- a/apps/supernova/src/hooks/useUrlQueryState/index.ts
+++ b/apps/supernova/src/hooks/useUrlQueryState/index.ts
@@ -1,0 +1,44 @@
+import React, { useEffect, useLayoutEffect } from "react"
+import { readStateFromUrl, saveStateToUrl } from "@cloudoperators/juno-url-state-provider"
+import {
+  useFilterLabels,
+  useGetStateForUrl,
+  useGlobalsActions,
+  useSilencesActions,
+  useFilterActions,
+} from "../../components/StoreProvider"
+import { transformAppStateToUrlState, transformUrlStateToAppState } from "./utils"
+
+const useUrlQueryState = () => {
+  const urlReadRef = React.useRef(false)
+  const { setActiveFilters, setActivePredefinedFilter, setSearchTerm } = useFilterActions()
+  const { setSilencesRegEx, setSilencesStatus } = useSilencesActions()
+  const { setShowDetailsFor, setActiveSelectedTab } = useGlobalsActions()
+  const filterLabels = useFilterLabels()
+  const appState = useGetStateForUrl()
+
+  // Reflect app state to the URL
+  useEffect(() => {
+    if (urlReadRef.current && urlReadRef.current) {
+      saveStateToUrl(transformAppStateToUrlState(appState))
+    }
+  }, [appState])
+
+  // Read URL state and set it to the app state this typically happens on the first render
+  useLayoutEffect(() => {
+    const stateFromTheUrl = readStateFromUrl()
+    if (Object.keys(stateFromTheUrl).length !== 0) {
+      const appState = transformUrlStateToAppState(stateFromTheUrl, filterLabels)
+      setActiveFilters(appState.activeFilters)
+      setSearchTerm(appState.searchTerm)
+      setActivePredefinedFilter(appState.activePredefinedFilter)
+      setShowDetailsFor(appState.showDetailsFor)
+      setActiveSelectedTab(appState.activeSelectedTab)
+      setSilencesRegEx(appState.silenceRegEx)
+      setSilencesStatus(appState.silenceStatus)
+    }
+    urlReadRef.current = true
+  }, [])
+}
+
+export default useUrlQueryState

--- a/apps/supernova/src/hooks/useUrlQueryState/utils.ts
+++ b/apps/supernova/src/hooks/useUrlQueryState/utils.ts
@@ -1,0 +1,70 @@
+const ACTIVE_FILTERS_PREFIX = "f_"
+const ACTIVE_PREDEFINED_FILTER = "predefined_filter"
+const DETAILS_FOR = "details_for"
+const SEARCH_TERM = "search_term"
+const ACTIVE_TAB = "active_tab"
+const SILENCE_REG_EXP = "silence_exp"
+const SILENCE_STATUS = "silence_status"
+const SILENCE_DETAIL = "silence_detail_for"
+
+// This utility extracts filters from the parsed query string
+const transformFiltersToAppState = ({ urlState, filterLabels, prefix }) =>
+  Object.entries(urlState).reduce((acc, [key, value]) => {
+    const [_, filter] = key.split(prefix)
+    //pick keys that are supposed to be filters
+    if (key.startsWith(ACTIVE_FILTERS_PREFIX) && filterLabels.includes(filter)) {
+      return {
+        ...acc,
+        [filter]: Array.isArray(value) ? value : [value],
+      }
+    }
+    return acc
+  }, {})
+
+// This prefixes each filter keys so it does not overlap with other keys in the URL querystring
+const transformFiltersToUrlState = ({ filters, prefix }) =>
+  Object.entries(filters).reduce((acc, [key, value]) => {
+    return {
+      ...acc,
+      [`${prefix}${key}`]: value,
+    }
+  }, {})
+
+// This utility transforms app state to the state that can be saved in the URL querystring
+export const transformAppStateToUrlState = (appState) => {
+  const {
+    activeFilters,
+    searchTerm,
+    activePredefinedFilter,
+    showDetailsFor,
+    activeSelectedTab,
+    silencesRegExp,
+    silencesStatus,
+    showDetailsForSilence,
+  } = appState
+
+  return {
+    ...transformFiltersToUrlState({ filters: activeFilters, prefix: ACTIVE_FILTERS_PREFIX }),
+    [ACTIVE_PREDEFINED_FILTER]: activePredefinedFilter,
+    [DETAILS_FOR]: showDetailsFor,
+    [ACTIVE_TAB]: activeSelectedTab,
+    [SEARCH_TERM]: searchTerm,
+    [SILENCE_REG_EXP]: silencesRegExp,
+    [SILENCE_STATUS]: silencesStatus,
+    [SILENCE_DETAIL]: showDetailsForSilence,
+  }
+}
+
+// This utility transforms state from the URL to the app state
+export const transformUrlStateToAppState = (urlState, filterLabels) => {
+  return {
+    activeFilters: transformFiltersToAppState({ urlState, filterLabels, prefix: ACTIVE_FILTERS_PREFIX }),
+    searchTerm: urlState[SEARCH_TERM],
+    activePredefinedFilter: urlState[ACTIVE_PREDEFINED_FILTER],
+    showDetailsFor: urlState[DETAILS_FOR],
+    activeSelectedTab: urlState[ACTIVE_TAB],
+    silenceRegEx: urlState[SILENCE_REG_EXP],
+    silenceStatus: urlState[SILENCE_STATUS],
+    silenceDetail: urlState[SILENCE_DETAIL],
+  }
+}

--- a/apps/supernova/turbo.json
+++ b/apps/supernova/turbo.json
@@ -5,21 +5,24 @@
       "dependsOn": [
         "@cloudoperators/juno-ui-components#build",
         "@cloudoperators/juno-messages-provider#build",
-        "@cloudoperators/juno-communicator#build"
+        "@cloudoperators/juno-communicator#build",
+        "@cloudoperators/juno-url-state-provider#build"
       ]
     },
     "build": {
       "dependsOn": [
         "@cloudoperators/juno-ui-components#build",
         "@cloudoperators/juno-messages-provider#build",
-        "@cloudoperators/juno-communicator#build"
+        "@cloudoperators/juno-communicator#build",
+        "@cloudoperators/juno-url-state-provider#build"
       ]
     },
     "build:static": {
       "dependsOn": [
         "@cloudoperators/juno-ui-components#build",
         "@cloudoperators/juno-messages-provider#build",
-        "@cloudoperators/juno-communicator#build"
+        "@cloudoperators/juno-communicator#build",
+        "@cloudoperators/juno-url-state-provider#build"
       ]
     },
     "serve": {

--- a/apps/supernova/turbo.json
+++ b/apps/supernova/turbo.json
@@ -5,7 +5,6 @@
       "dependsOn": [
         "@cloudoperators/juno-ui-components#build",
         "@cloudoperators/juno-messages-provider#build",
-        "@cloudoperators/juno-communicator#build",
         "@cloudoperators/juno-url-state-provider#build"
       ]
     },
@@ -13,7 +12,6 @@
       "dependsOn": [
         "@cloudoperators/juno-ui-components#build",
         "@cloudoperators/juno-messages-provider#build",
-        "@cloudoperators/juno-communicator#build",
         "@cloudoperators/juno-url-state-provider#build"
       ]
     },
@@ -21,7 +19,6 @@
       "dependsOn": [
         "@cloudoperators/juno-ui-components#build",
         "@cloudoperators/juno-messages-provider#build",
-        "@cloudoperators/juno-communicator#build",
         "@cloudoperators/juno-url-state-provider#build"
       ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1040,7 +1040,6 @@
       "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cloudoperators/juno-communicator": "*",
         "@cloudoperators/juno-messages-provider": "*",
         "@cloudoperators/juno-ui-components": "*",
         "@cloudoperators/juno-url-state-provider": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -716,7 +716,7 @@
     },
     "apps/greenhouse": {
       "name": "@cloudoperators/juno-app-greenhouse",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-app-doop": "*",
@@ -1043,6 +1043,7 @@
         "@cloudoperators/juno-communicator": "*",
         "@cloudoperators/juno-messages-provider": "*",
         "@cloudoperators/juno-ui-components": "*",
+        "@cloudoperators/juno-url-state-provider": "*",
         "@cloudoperators/juno-url-state-provider-v1": "^1.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1068,6 +1069,21 @@
         "util": "^0.12.4",
         "vitest": "^2.1.1",
         "zustand": "4.5.5"
+      }
+    },
+    "apps/supernova/node_modules/@cloudoperators/juno-url-state-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@cloudoperators/juno-url-state-provider/-/juno-url-state-provider-2.3.0.tgz",
+      "integrity": "sha512-bH0IUKZhkhqBC6nnuasFQ5HvObsSgR2WN2RMHMbMWfdPfDGHz7TsSP5Qc9BxUiKyVXNc+XFvOXQ+7iP1CqVgJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "history": "^5.3.0",
+        "juri": "^1.0.3",
+        "query-string": "9.1.1"
+      },
+      "engines": {
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
       }
     },
     "apps/supernova/node_modules/@tanstack/react-query": {
@@ -23923,7 +23939,7 @@
     },
     "packages/ui-components": {
       "name": "@cloudoperators/juno-ui-components",
-      "version": "2.35.2",
+      "version": "2.36.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@cloudoperators/juno-config": "*",
@@ -24692,7 +24708,7 @@
     },
     "packages/url-state-provider": {
       "name": "@cloudoperators/juno-url-state-provider",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "history": "^5.3.0",


### PR DESCRIPTION
# Summary

This PR integrates new way of saving and restoring app state from URL behind a feature flag. The idea was to develop an MVP in one app `supernova` with minimum possible changes so we could play around with it, that's why the new URL forcefully enabled but will be removed before merge.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Integrated `saveStateToUrl` and `readStateFromUrl` to use new URL structure.
- New URL structure is behind a feature flag.
- Forcefully enabled new feature. [**SHOULD BE REMOVED BEFORE MERGE**]
# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- #717 

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. Go to PR preview
2. See the new URL structure
3. Add/Remove filters etc

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
