### PR TITLE
chore(ci): adds new flag to the changeset conf to enable update dependencies

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": []
 }


### PR DESCRIPTION
# Summary

This pull request adds a new flag to the to changeset `bumpVersionsWithWorkspaceProtocolOnly` to determines whether Changesets should only bump dependency ranges that use workspace protocol of packages that are part of the workspace.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Added flag to the changeset configuration

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.
