### PR TITLE
fix(build): output types to correct directory

### DIFF
--- a/.changeset/four-kings-lay.md
+++ b/.changeset/four-kings-lay.md
@@ -1,0 +1,10 @@
+---
+"@cloudoperators/juno-url-state-provider": patch
+"@cloudoperators/juno-messages-provider": patch
+"@cloudoperators/juno-communicator": patch
+"@cloudoperators/juno-k8s-client": patch
+"@cloudoperators/juno-package-template": patch
+"@cloudoperators/juno-oauth": patch
+---
+
+Output types to the correct directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -716,19 +716,19 @@
     },
     "apps/greenhouse": {
       "name": "@cloudoperators/juno-app-greenhouse",
-      "version": "0.3.12",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cloudoperators/juno-url-state-provider-v1": "^1.3.2"
-      },
-      "devDependencies": {
         "@cloudoperators/juno-app-doop": "*",
         "@cloudoperators/juno-app-heureka": "*",
         "@cloudoperators/juno-app-supernova": "*",
-        "@cloudoperators/juno-config": "*",
         "@cloudoperators/juno-messages-provider": "*",
         "@cloudoperators/juno-oauth": "*",
         "@cloudoperators/juno-ui-components": "*",
+        "@cloudoperators/juno-url-state-provider-v1": "^1.3.2"
+      },
+      "devDependencies": {
+        "@cloudoperators/juno-config": "*",
         "@svgr/plugin-jsx": "^7.0.0",
         "@tailwindui/react": "^0.1.1",
         "@testing-library/react": "^16.0.1",
@@ -1037,7 +1037,7 @@
     },
     "apps/supernova": {
       "name": "@cloudoperators/juno-app-supernova",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-messages-provider": "*",

--- a/packages/communicator/vite.config.ts
+++ b/packages/communicator/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       exclude: ["**/*.test.ts", "vitest.setup.ts"], // Exclude test files from type generation
       include: ["src/**/*.ts", "types/**/*.ts"], // Include your source and global types
       insertTypesEntry: true, // Ensure types are properly exported
-      outDir: "build/types", // Specify where to output the types
+      outDir: "build", // Specify where to output the types
       tsconfigPath: "./tsconfig.json",
       copyDtsFiles: true,
       compilerOptions: {

--- a/packages/k8s-client/vite.config.ts
+++ b/packages/k8s-client/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     dts({
       exclude: ["./test/**/*.test.ts", "vitest.setup.ts"],
       insertTypesEntry: true, // Ensure types are properly exported
-      outDir: "build/types", // Specify where to output the types
+      outDir: "build", // Specify where to output the types
     }),
   ],
 })

--- a/packages/messages-provider/vite.config.ts
+++ b/packages/messages-provider/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
       exclude: ["**/*.test.ts", "vitest.setup.ts"], // Exclude test files from type generation
       include: ["src/**/*.ts", "types/**/*.ts"], // Include your source and global types
       insertTypesEntry: true, // Ensure types are properly exported
-      outDir: "build/types", // Specify where to output the types
+      outDir: "build", // Specify where to output the types
       tsconfigPath: "./tsconfig.json",
       copyDtsFiles: true,
       compilerOptions: {

--- a/packages/oauth/vite.config.ts
+++ b/packages/oauth/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     dts({
       exclude: ["./__tests__/**/*.test.ts", "vitest.setup.ts"],
       insertTypesEntry: true, // Ensure types are properly exported
-      outDir: "build/types", // Specify where to output the types
+      outDir: "build", // Specify where to output the types
     }),
   ],
 })

--- a/packages/template/vite.config.ts
+++ b/packages/template/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       exclude: ["**/*.test.ts", "vitest.setup.ts"], // Exclude test files from type generation
       include: ["src/**/*.ts", "types/**/*.ts"], // Include your source and global types
       insertTypesEntry: true, // Ensure types are properly exported
-      outDir: "build/types", // Specify where to output the types
+      outDir: "build", // Specify where to output the types
       tsconfigPath: "./tsconfig.json",
       copyDtsFiles: true,
       compilerOptions: {

--- a/packages/url-state-provider/vite.config.ts
+++ b/packages/url-state-provider/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     dts({
       exclude: ["./__tests__/**/*.test.ts", "vitest.setup.ts"],
       insertTypesEntry: true, // Ensure types are properly exported
-      outDir: "build/types", // Specify where to output the types
+      outDir: "build", // Specify where to output the types
     }),
   ],
 })


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
We recently fixed issue in `ui-components` package where the types emitted to the wrong directory. I found the same issue when using `message-provider` package in new Hueraka and therefore fixing it for all remaining packages.

**Problem:**
This was an unintentional misconfiguration due to which the type definition file `index.d.ts` was being output in `build/types` where as it should co-locate with `index.js` inside `build` so the types can be recognized.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- output types to `build` rather than `build/types`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.
