### PR TITLE
chore(core): upgrade vitest to 3.0.7

### DIFF
--- a/apps/carbon/package.json
+++ b/apps/carbon/package.json
@@ -11,7 +11,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "scripts": {
     "dev": "vite",
@@ -44,7 +44,7 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "@vitejs/plugin-react-swc": "^3.7.0",
-    "@vitest/ui": "^1.6.0",
+    "@vitest/ui": "^3.0.7",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
@@ -60,6 +60,6 @@
     "vite": "^5.4.7",
     "vite-plugin-svgr": "^4.2.0",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^1.6.0"
+    "vitest": "^3.0.7"
   }
 }

--- a/apps/doop/package.json
+++ b/apps/doop/package.json
@@ -31,7 +31,7 @@
     "shadow-dom-testing-library": "^1.11.3",
     "tailwindcss": "^3.3.1",
     "vite": "^5.4.8",
-    "vitest": "^2.1.1",
+    "vitest": "^3.0.7",
     "zustand": "4.5.5"
   },
   "scripts": {

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "devDependencies": {
     "@cloudoperators/juno-config": "*",
@@ -30,7 +30,7 @@
     "react-test-renderer": "^18.2.0",
     "sass": "^1.60.0",
     "vite": "^5.4.8",
-    "vitest": "^2.1.1"
+    "vitest": "^3.0.7"
   },
   "dependencies": {
     "@cloudoperators/juno-messages-provider": "*",

--- a/apps/greenhouse/package.json
+++ b/apps/greenhouse/package.json
@@ -33,7 +33,7 @@
     "ts-luxon": "^4.6.2",
     "vite": "^5.4.9",
     "vite-plugin-svgr": "^4.2.0",
-    "vitest": "^2.1.2",
+    "vitest": "^3.0.7",
     "zustand": "4.5.5"
   },
   "scripts": {

--- a/apps/heureka-next/package.json
+++ b/apps/heureka-next/package.json
@@ -11,7 +11,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "scripts": {
     "dev": "vite",
@@ -46,7 +46,7 @@
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
     "@vitejs/plugin-react-swc": "3.7.2",
-    "@vitest/ui": "1.6.0",
+    "@vitest/ui": "^3.0.7",
     "autoprefixer": "10.4.20",
     "eslint": "8.57.1",
     "eslint-config-prettier": "9.1.0",
@@ -61,6 +61,6 @@
     "typescript": "5.7.3",
     "vite": "5.4.14",
     "vite-tsconfig-paths": "4.3.2",
-    "vitest": "1.6.0"
+    "vitest": "^3.0.7"
   }
 }

--- a/apps/heureka/package.json
+++ b/apps/heureka/package.json
@@ -29,7 +29,7 @@
     "sass": "^1.77.5",
     "shadow-dom-testing-library": "^1.11.3",
     "tailwindcss": "^3.3.1",
-    "vitest": "^2.1.1",
+    "vitest": "^3.0.7",
     "zustand": "4.5.5"
   },
   "scripts": {

--- a/apps/supernova/package.json
+++ b/apps/supernova/package.json
@@ -30,7 +30,7 @@
     "sass": "^1.77.5",
     "shadow-dom-testing-library": "^1.11.3",
     "tailwindcss": "^3.3.1",
-    "vitest": "^2.1.1",
+    "vitest": "^3.0.7",
     "util": "^0.12.4",
     "zustand": "4.5.5"
   },

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -11,7 +11,7 @@
   "private": true,
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "scripts": {
     "dev": "vite",
@@ -42,7 +42,7 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "@vitejs/plugin-react-swc": "^3.7.0",
-    "@vitest/ui": "^1.6.0",
+    "@vitest/ui": "^3.0.7",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
@@ -57,6 +57,6 @@
     "typescript": "^5.6.2",
     "vite": "^5.4.7",
     "vite-tsconfig-paths": "^4.3.2",
-    "vitest": "^1.6.0"
+    "vitest": "^3.0.7"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "@vitejs/plugin-react-swc": "^3.7.0",
-        "@vitest/ui": "^1.6.0",
+        "@vitest/ui": "^3.0.7",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
@@ -67,11 +67,11 @@
         "vite": "^5.4.7",
         "vite-plugin-svgr": "^4.2.0",
         "vite-tsconfig-paths": "^4.3.2",
-        "vitest": "^1.6.0"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "apps/carbon/node_modules/@tanstack/query-core": {
@@ -330,7 +330,7 @@
         "shadow-dom-testing-library": "^1.11.3",
         "tailwindcss": "^3.3.1",
         "vite": "^5.4.8",
-        "vitest": "^2.1.1",
+        "vitest": "^3.0.7",
         "zustand": "4.5.5"
       }
     },
@@ -347,28 +347,6 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
-      }
-    },
-    "apps/doop/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
       }
     },
     "apps/doop/node_modules/jsdom": {
@@ -410,69 +388,6 @@
         }
       }
     },
-    "apps/doop/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
     "apps/example": {
       "name": "@cloudoperators/juno-app-example",
       "version": "1.2.0",
@@ -503,11 +418,11 @@
         "shadow-dom-testing-library": "^1.11.3",
         "tailwindcss": "^3.3.1",
         "vite": "^5.4.8",
-        "vitest": "^2.1.1"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "apps/example/node_modules/@svgr/core": {
@@ -583,28 +498,6 @@
         }
       }
     },
-    "apps/example/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
-      }
-    },
     "apps/example/node_modules/jsdom": {
       "version": "25.0.1",
       "dev": true,
@@ -652,69 +545,6 @@
         "node": ">=12"
       }
     },
-    "apps/example/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
     "apps/greenhouse": {
       "name": "@cloudoperators/juno-app-greenhouse",
       "version": "0.4.2",
@@ -748,7 +578,7 @@
         "ts-luxon": "^4.6.2",
         "vite": "^5.4.9",
         "vite-plugin-svgr": "^4.2.0",
-        "vitest": "^2.1.2",
+        "vitest": "^3.0.7",
         "zustand": "4.5.5"
       }
     },
@@ -768,91 +598,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
-      }
-    },
-    "apps/greenhouse/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
-      }
-    },
-    "apps/greenhouse/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
       }
     },
     "apps/heureka": {
@@ -885,7 +630,7 @@
         "sass": "^1.77.5",
         "shadow-dom-testing-library": "^1.11.3",
         "tailwindcss": "^3.3.1",
-        "vitest": "^2.1.1",
+        "vitest": "^3.0.7",
         "zustand": "4.5.5"
       }
     },
@@ -909,7 +654,7 @@
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
         "@vitejs/plugin-react-swc": "3.7.2",
-        "@vitest/ui": "1.6.0",
+        "@vitest/ui": "^3.0.7",
         "autoprefixer": "10.4.20",
         "eslint": "8.57.1",
         "eslint-config-prettier": "9.1.0",
@@ -924,15 +669,15 @@
         "typescript": "5.7.3",
         "vite": "5.4.14",
         "vite-tsconfig-paths": "4.3.2",
-        "vitest": "1.6.0"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "apps/heureka-next": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-messages-provider": "*",
@@ -955,7 +700,7 @@
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
         "@vitejs/plugin-react-swc": "3.7.2",
-        "@vitest/ui": "1.6.0",
+        "@vitest/ui": "^3.0.7",
         "autoprefixer": "10.4.20",
         "eslint": "8.57.1",
         "eslint-config-prettier": "9.1.0",
@@ -970,11 +715,11 @@
         "typescript": "5.7.3",
         "vite": "5.4.14",
         "vite-tsconfig-paths": "4.3.2",
-        "vitest": "1.6.0"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "apps/heureka-next/node_modules/@testing-library/jest-dom": {
@@ -1405,28 +1150,6 @@
         "react": "^18.0.0"
       }
     },
-    "apps/heureka/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
-      }
-    },
     "apps/heureka/node_modules/immer": {
       "version": "10.1.1",
       "dev": true,
@@ -1475,72 +1198,9 @@
         }
       }
     },
-    "apps/heureka/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
     "apps/supernova": {
       "name": "@cloudoperators/juno-app-supernova",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-messages-provider": "*",
@@ -1569,7 +1229,7 @@
         "shadow-dom-testing-library": "^1.11.3",
         "tailwindcss": "^3.3.1",
         "util": "^0.12.4",
-        "vitest": "^2.1.1",
+        "vitest": "^3.0.7",
         "zustand": "4.5.5"
       }
     },
@@ -1585,7 +1245,7 @@
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "apps/supernova/node_modules/@tanstack/react-query": {
@@ -1601,28 +1261,6 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
-      }
-    },
-    "apps/supernova/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
       }
     },
     "apps/supernova/node_modules/immer": {
@@ -1673,69 +1311,6 @@
         }
       }
     },
-    "apps/supernova/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
     "apps/template": {
       "name": "@cloudoperators/juno-app-template",
       "version": "2.0.1",
@@ -1758,7 +1333,7 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "@vitejs/plugin-react-swc": "^3.7.0",
-        "@vitest/ui": "^1.6.0",
+        "@vitest/ui": "^3.0.7",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
@@ -1773,11 +1348,11 @@
         "typescript": "^5.6.2",
         "vite": "^5.4.7",
         "vite-tsconfig-paths": "^4.3.2",
-        "vitest": "^1.6.0"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "apps/template/node_modules/@tanstack/query-core": {
@@ -7819,6 +7394,8 @@
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.28",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
+      "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11153,35 +10730,76 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "2.1.3",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.7.tgz",
+      "integrity": "sha512-QP25f+YJhzPfHrHfYHtvRn+uvkCFCqFtW9CktfBxmB+25QqWsx7VB2As6f4GmwllHLDhXNHvqedwhvMmSnNmjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "tinyrainbow": "^1.2.0"
+        "@vitest/spy": "3.0.7",
+        "@vitest/utils": "3.0.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/mocker": {
-      "version": "2.1.3",
+    "node_modules/@vitest/expect/node_modules/@vitest/pretty-format": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.7.tgz",
+      "integrity": "sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.7.tgz",
+      "integrity": "sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.0.7",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.7.tgz",
+      "integrity": "sha512-qui+3BLz9Eonx4EAuR/i+QlCX6AUZ35taDQgwGkK/Tw6/WgwodSrjN1X2xf69IA/643ZX5zNKIn2svvtZDrs4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.0.7",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.11"
+        "magic-string": "^0.30.17"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/spy": "2.1.3",
-        "msw": "^2.3.5",
-        "vite": "^5.0.0"
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -11194,6 +10812,8 @@
     },
     "node_modules/@vitest/mocker/node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11212,119 +10832,188 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "2.1.3",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.7.tgz",
+      "integrity": "sha512-WeEl38Z0S2ZcuRTeyYqaZtm4e26tq6ZFqh5y8YD9YxfWuu0OFiGFUbnxNynwLjNRHPsXyee2M9tV7YxOTPZl2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "pathe": "^1.1.2"
+        "@vitest/utils": "3.0.7",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.7.tgz",
+      "integrity": "sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.7.tgz",
+      "integrity": "sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.0.7",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "2.1.3",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.7.tgz",
+      "integrity": "sha512-eqTUryJWQN0Rtf5yqCGTQWsCFOQe4eNz5Twsu21xYEcnFJtMU5XvmG0vgebhdLlrHQTSq5p8vWHJIeJQV8ovsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.3",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2"
+        "@vitest/pretty-format": "3.0.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/spy": {
-      "version": "2.1.3",
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.7.tgz",
+      "integrity": "sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.0"
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.7.tgz",
+      "integrity": "sha512-4T4WcsibB0B6hrKdAZTM37ekuyFZt2cGbEGd2+L0P8ov15J1/HUsUaqkXEQPNAWr4BtPPe1gI+FYfMHhEKfR8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "1.6.0",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.0.7.tgz",
+      "integrity": "sha512-bogkkSaVdSTRj02TfypjrqrLCeEc/tA5V4gAVM843Rp5JtIub3xaij+qjsSnS6CseLQJUSdDCFaFqPMmymRJKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "1.6.0",
-        "fast-glob": "^3.3.2",
-        "fflate": "^0.8.1",
-        "flatted": "^3.2.9",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
-        "sirv": "^2.0.4"
+        "@vitest/utils": "3.0.7",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.12",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "1.6.0"
+        "vitest": "3.0.7"
       }
     },
-    "node_modules/@vitest/ui/node_modules/@vitest/utils": {
-      "version": "1.6.0",
+    "node_modules/@vitest/ui/node_modules/@vitest/pretty-format": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.7.tgz",
+      "integrity": "sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "diff-sequences": "^29.6.3",
-        "estree-walker": "^3.0.3",
-        "loupe": "^2.3.7",
-        "pretty-format": "^29.7.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/ui/node_modules/ansi-styles": {
-      "version": "5.2.0",
+    "node_modules/@vitest/ui/node_modules/@vitest/utils": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.7.tgz",
+      "integrity": "sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=10"
+      "dependencies": {
+        "@vitest/pretty-format": "3.0.7",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/ui/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/@vitest/ui/node_modules/loupe": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
-    "node_modules/@vitest/ui/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@vitest/ui/node_modules/react-is": {
-      "version": "18.3.1",
+    "node_modules/@vitest/ui/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/ui/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@vitest/utils": {
       "version": "2.1.3",
@@ -12606,6 +12295,8 @@
     },
     "node_modules/cac": {
       "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12750,7 +12441,9 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.1.2",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13587,7 +13280,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.7",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14208,10 +13903,11 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.4",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -15237,6 +14933,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.0.tgz",
+      "integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "dev": true,
@@ -15481,7 +15187,9 @@
       "license": "MIT"
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
     },
@@ -15680,14 +15388,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -19216,7 +18916,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "3.1.2",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
       "dev": true,
       "license": "MIT"
     },
@@ -19262,7 +18964,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.12",
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19671,7 +19375,8 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -20364,7 +20069,9 @@
       }
     },
     "node_modules/mrmime": {
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23066,7 +22773,9 @@
       "dev": true
     },
     "node_modules/sirv": {
-      "version": "2.0.4",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
+      "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23075,7 +22784,7 @@
         "totalist": "^3.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/sisteransi": {
@@ -23633,22 +23342,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strip-literal": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/style-loader": {
       "version": "3.3.4",
@@ -24229,30 +23922,35 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.1",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.10",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
+      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "fdir": "^6.4.2",
+        "fdir": "^6.4.3",
         "picomatch": "^4.0.2"
       },
       "engines": {
         "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.2",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
+      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -24264,10 +23962,10 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24276,7 +23974,9 @@
       }
     },
     "node_modules/tinypool": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -24355,6 +24055,8 @@
     },
     "node_modules/totalist": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25403,24 +25105,34 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "2.1.3",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.7.tgz",
+      "integrity": "sha512-2fX0QwX4GkkkpULXdT1Pf4q0tC1i1lFOyseKoonavXUNlQ77KpW2XqBGGNIm/J4Ows4KxgGJzDguYVPKwG/n5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.3.6",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite-plugin-dts": {
       "version": "4.3.0",
@@ -25827,50 +25539,56 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.6.0",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.7.tgz",
+      "integrity": "sha512-IP7gPK3LS3Fvn44x30X1dM9vtawm0aesAa2yBIZ9vQf+qB69NXC5776+Qmcr7ohUXIQuLhk7xQR0aSUIDPqavg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "1.6.0",
-        "@vitest/runner": "1.6.0",
-        "@vitest/snapshot": "1.6.0",
-        "@vitest/spy": "1.6.0",
-        "@vitest/utils": "1.6.0",
-        "acorn-walk": "^8.3.2",
-        "chai": "^4.3.10",
-        "debug": "^4.3.4",
-        "execa": "^8.0.1",
-        "local-pkg": "^0.5.0",
-        "magic-string": "^0.30.5",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
-        "std-env": "^3.5.0",
-        "strip-literal": "^2.0.0",
-        "tinybench": "^2.5.1",
-        "tinypool": "^0.8.3",
-        "vite": "^5.0.0",
-        "vite-node": "1.6.0",
-        "why-is-node-running": "^2.2.2"
+        "@vitest/expect": "3.0.7",
+        "@vitest/mocker": "3.0.7",
+        "@vitest/pretty-format": "^3.0.7",
+        "@vitest/runner": "3.0.7",
+        "@vitest/snapshot": "3.0.7",
+        "@vitest/spy": "3.0.7",
+        "@vitest/utils": "3.0.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.0",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinypool": "^1.0.2",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0",
+        "vite-node": "3.0.7",
+        "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.6.0",
-        "@vitest/ui": "1.6.0",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.0.7",
+        "@vitest/ui": "3.0.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {
@@ -25890,373 +25608,49 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "1.6.0",
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.7.tgz",
+      "integrity": "sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "1.6.0",
-        "@vitest/utils": "1.6.0",
-        "chai": "^4.3.10"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/runner": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "1.6.0",
-        "p-limit": "^5.0.0",
-        "pathe": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/snapshot": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "magic-string": "^0.30.5",
-        "pathe": "^1.1.1",
-        "pretty-format": "^29.7.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^2.2.0"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "1.6.0",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.7.tgz",
+      "integrity": "sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "diff-sequences": "^29.6.3",
-        "estree-walker": "^3.0.3",
-        "loupe": "^2.3.7",
-        "pretty-format": "^29.7.0"
+        "@vitest/pretty-format": "3.0.7",
+        "loupe": "^3.1.3",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vitest/node_modules/acorn": {
-      "version": "8.12.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/vitest/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/vitest/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/vitest/node_modules/assertion-error": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/vitest/node_modules/chai": {
-      "version": "4.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vitest/node_modules/check-error": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/vitest/node_modules/deep-eql": {
-      "version": "4.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/vitest/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/vitest/node_modules/execa": {
-      "version": "8.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/vitest/node_modules/get-stream": {
-      "version": "8.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/human-signals": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/vitest/node_modules/is-stream": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/loupe": {
-      "version": "2.3.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
-    "node_modules/vitest/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/onetime": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/p-limit": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/path-key": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/pathval": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/vitest/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/vitest/node_modules/react-is": {
-      "version": "18.3.1",
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/vitest/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/vitest/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/vitest/node_modules/tinypool": {
-      "version": "0.8.4",
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vitest/node_modules/tinyspy": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vitest/node_modules/type-detect": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/vitest/node_modules/vite-node": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.3.4",
-        "pathe": "^1.1.1",
-        "picocolors": "^1.0.0",
-        "vite": "^5.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vscode-uri": {
@@ -26896,96 +26290,11 @@
         "typescript": "^5.5.4",
         "vite": "^5.4.0",
         "vite-plugin-dts": "^4.0.3",
-        "vitest": "^2.0.4"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
-      }
-    },
-    "packages/communicator/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
-      }
-    },
-    "packages/communicator/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "packages/config": {
@@ -27041,12 +26350,12 @@
         "typescript": "^5.6.2",
         "vite": "^5.4.8",
         "vite-plugin-dts": "^4.2.3",
-        "vitest": "^2.1.1",
+        "vitest": "^3.0.7",
         "zustand": "^4.5.2"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
+        "npm": ">=10.0.0 <=11.0.0"
       },
       "peerDependencies": {
         "react": "^18.2.0",
@@ -27075,28 +26384,6 @@
         "yarn": ">=1"
       }
     },
-    "packages/messages-provider/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
-      }
-    },
     "packages/messages-provider/node_modules/chalk": {
       "version": "3.0.0",
       "dev": true,
@@ -27107,69 +26394,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "packages/messages-provider/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
       }
     },
     "packages/oauth": {
@@ -27185,11 +26409,11 @@
         "typescript": "^5.5.4",
         "vite": "^5.4.0",
         "vite-plugin-dts": "^4.0.3",
-        "vitest": "^2.0.4"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "packages/oauth/node_modules/@esbuild/android-arm": {
@@ -27543,28 +26767,6 @@
         "node": ">=12"
       }
     },
-    "packages/oauth/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
-      }
-    },
     "packages/oauth/node_modules/esbuild": {
       "version": "0.17.19",
       "dev": true,
@@ -27601,69 +26803,6 @@
         "@esbuild/win32-x64": "0.17.19"
       }
     },
-    "packages/oauth/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
     "packages/template": {
       "name": "@cloudoperators/juno-package-template",
       "version": "1.1.1",
@@ -27675,96 +26814,11 @@
         "typescript": "^5.5.4",
         "vite": "^5.4.0",
         "vite-plugin-dts": "^4.0.3",
-        "vitest": "^2.0.4"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
-      }
-    },
-    "packages/template/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
-      }
-    },
-    "packages/template/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "packages/ui-components": {
@@ -27827,11 +26881,11 @@
         "vite-plugin-glob": "0.3.2",
         "vite-plugin-svgr": "4.3.0",
         "vite-tsconfig-paths": "5.1.4",
-        "vitest": "2.1.1"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
+        "npm": ">=10.0.0 <=11.0.0"
       },
       "peerDependencies": {
         "prop-types": "15.8.1",
@@ -28141,48 +27195,6 @@
         "yarn": ">=1"
       }
     },
-    "packages/ui-components/node_modules/@vitest/expect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.1.tgz",
-      "integrity": "sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==",
-      "dev": true,
-      "dependencies": {
-        "@vitest/spy": "2.1.1",
-        "@vitest/utils": "2.1.1",
-        "chai": "^5.1.1",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/ui-components/node_modules/@vitest/mocker": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.1.tgz",
-      "integrity": "sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==",
-      "dev": true,
-      "dependencies": {
-        "@vitest/spy": "^2.1.0-beta.1",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.11"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/spy": "2.1.1",
-        "msw": "^2.3.5",
-        "vite": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
     "packages/ui-components/node_modules/@vitest/pretty-format": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.1.tgz",
@@ -28193,68 +27205,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/ui-components/node_modules/@vitest/runner": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.1.tgz",
-      "integrity": "sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==",
-      "dev": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.1",
-        "pathe": "^1.1.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/ui-components/node_modules/@vitest/snapshot": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.1.tgz",
-      "integrity": "sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==",
-      "dev": true,
-      "dependencies": {
-        "@vitest/pretty-format": "2.1.1",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/ui-components/node_modules/@vitest/spy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.1.tgz",
-      "integrity": "sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==",
-      "dev": true,
-      "dependencies": {
-        "tinyspy": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "packages/ui-components/node_modules/@vitest/ui": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.1.1.tgz",
-      "integrity": "sha512-IIxo2LkQDA+1TZdPLYPclzsXukBWd5dX2CKpGqH8CCt8Wh0ZuDn4+vuQ9qlppEju6/igDGzjWF/zyorfsf+nHg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.1",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.1"
       }
     },
     "packages/ui-components/node_modules/@vitest/utils": {
@@ -28432,27 +27382,6 @@
         }
       }
     },
-    "packages/ui-components/node_modules/vite-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.1.tgz",
-      "integrity": "sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==",
-      "dev": true,
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.3.6",
-        "pathe": "^1.1.2",
-        "vite": "^5.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "packages/ui-components/node_modules/vite-tsconfig-paths": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
@@ -28468,70 +27397,6 @@
       },
       "peerDependenciesMeta": {
         "vite": {
-          "optional": true
-        }
-      }
-    },
-    "packages/ui-components/node_modules/vitest": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.1.tgz",
-      "integrity": "sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==",
-      "dev": true,
-      "dependencies": {
-        "@vitest/expect": "2.1.1",
-        "@vitest/mocker": "2.1.1",
-        "@vitest/pretty-format": "^2.1.1",
-        "@vitest/runner": "2.1.1",
-        "@vitest/snapshot": "2.1.1",
-        "@vitest/spy": "2.1.1",
-        "@vitest/utils": "2.1.1",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.1",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.1",
-        "@vitest/ui": "2.1.1",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
           "optional": true
         }
       }
@@ -28553,33 +27418,11 @@
         "typescript": "^5.5.4",
         "vite": "^5.4.8",
         "vite-plugin-dts": "^4.0.3",
-        "vitest": "^2.1.1"
+        "vitest": "^3.0.7"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
-      }
-    },
-    "packages/url-state-provider/node_modules/@vitest/ui": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "2.1.3",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.1",
-        "pathe": "^1.1.2",
-        "sirv": "^2.0.4",
-        "tinyglobby": "^0.2.6",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "2.1.3"
+        "npm": ">=10.0.0 <=11.0.0"
       }
     },
     "packages/url-state-provider/node_modules/acorn": {
@@ -28784,69 +27627,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "packages/url-state-provider/node_modules/vitest": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "2.1.3",
-        "@vitest/mocker": "2.1.3",
-        "@vitest/pretty-format": "^2.1.3",
-        "@vitest/runner": "2.1.3",
-        "@vitest/snapshot": "2.1.3",
-        "@vitest/spy": "2.1.3",
-        "@vitest/utils": "2.1.3",
-        "chai": "^5.1.1",
-        "debug": "^4.3.6",
-        "magic-string": "^0.30.11",
-        "pathe": "^1.1.2",
-        "std-env": "^3.7.0",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.0",
-        "tinypool": "^1.0.0",
-        "tinyrainbow": "^1.2.0",
-        "vite": "^5.0.0",
-        "vite-node": "2.1.3",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "2.1.3",
-        "@vitest/ui": "2.1.3",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
       }
     },
     "packages/url-state-provider/node_modules/w3c-xmlserializer": {

--- a/packages/communicator/package.json
+++ b/packages/communicator/package.json
@@ -19,7 +19,7 @@
   "module": "build/index.js",
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "scripts": {
     "test": "vitest run",
@@ -39,6 +39,6 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.0",
     "vite-plugin-dts": "^4.0.3",
-    "vitest": "^2.0.4"
+    "vitest": "^3.0.7"
   }
 }

--- a/packages/messages-provider/package.json
+++ b/packages/messages-provider/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",
@@ -33,7 +33,7 @@
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
     "vite-plugin-dts": "^4.2.3",
-    "vitest": "^2.1.1",
+    "vitest": "^3.0.7",
     "zustand": "^4.5.2"
   },
   "dependencies": {

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -15,13 +15,13 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "devDependencies": {
     "@cloudoperators/juno-config": "*",
     "esbuild": "^0.17.6",
     "typescript": "^5.5.4",
-    "vitest": "^2.0.4",
+    "vitest": "^3.0.7",
     "vite": "^5.4.0",
     "vite-plugin-dts": "^4.0.3"
   },

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -15,7 +15,7 @@
   ],
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "scripts": {
     "test": "vitest run",
@@ -35,6 +35,6 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.0",
     "vite-plugin-dts": "^4.0.3",
-    "vitest": "^2.0.4"
+    "vitest": "^3.0.7"
   }
 }

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -29,7 +29,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "devDependencies": {
     "@cloudoperators/juno-config": "*",
@@ -87,7 +87,7 @@
     "vite-plugin-glob": "0.3.2",
     "vite-plugin-svgr": "4.3.0",
     "vite-tsconfig-paths": "5.1.4",
-    "vitest": "2.1.1"
+    "vitest": "^3.0.7"
   },
   "peerDependencies": {
     "prop-types": "15.8.1",

--- a/packages/url-state-provider/package.json
+++ b/packages/url-state-provider/package.json
@@ -14,6 +14,7 @@
   "source": "src/index.js",
   "main": "build/index.js",
   "module": "build/index.js",
+  "type": "module",
   "types": "build/index.d.ts",
   "files": [
     "build"

--- a/packages/url-state-provider/package.json
+++ b/packages/url-state-provider/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "npm": ">=10.0.0 <11.0.0"
+    "npm": ">=10.0.0 <=11.0.0"
   },
   "scripts": {
     "build": "vite build",
@@ -40,7 +40,7 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.8",
     "vite-plugin-dts": "^4.0.3",
-    "vitest": "^2.1.1"
+    "vitest": "^3.0.7"
   },
   "babel": {
     "presets": [

--- a/packages/url-state-provider/vitest.config.ts
+++ b/packages/url-state-provider/vitest.config.ts
@@ -13,5 +13,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./vitest.setup.ts",
     watch: true,
+    testTimeout: 7000,
   },
 })


### PR DESCRIPTION
# Summary

This PR upgrades vitest and @vitest/ui to version 3.0.7, resolving the reported vulnerability alerts.
# Changes Made

<!-- List the changes that were made in this pull request. -->

- upgrade vitest to 3.0.7
- upgrade @vitest/ui to 3.0.7

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
