### PR TITLE
feat(heureka): adds initialFilters support group as default filter in services

### DIFF
--- a/.changeset/chilled-fireants-joke.md
+++ b/.changeset/chilled-fireants-joke.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+---
+
+Adds initialFilters support group as default filter in services

--- a/apps/heureka/README.md
+++ b/apps/heureka/README.md
@@ -89,3 +89,4 @@ These are the customizable application properties (appProps) that you can define
 - **theme** (optional): Overrides the default theme. Acceptable values are `"theme-light"` or `"theme-dark"` (default).
 - **apiEndpoint** (required): The URL of the API endpoint the app will interact with.
 - **embedded** (optional): Set to `true` if the app will be embedded within another app or page. When `true`, the app will not display the header or footer, rendering only the content. Default is `false`.
+- **initialFilters** (optional): The initialFilters set default filters using an object that contains a key (the filter field) and a value (an array of filter criteria). For example, `{ "support_group": ["containers"] }`.

--- a/apps/heureka/appProps.template.json
+++ b/apps/heureka/appProps.template.json
@@ -1,7 +1,6 @@
 {
   "apiEndpoint": "YOUR_GRAPHQL_API_ENDPOINT",
   "embedded": false,
-  "theme": "light",
   "initialFilters": {
     "support_group": ["your_support_group"]
   }

--- a/apps/heureka/appProps.template.json
+++ b/apps/heureka/appProps.template.json
@@ -1,5 +1,8 @@
 {
   "apiEndpoint": "YOUR_GRAPHQL_API_ENDPOINT",
   "embedded": false,
-  "theme": "light"
+  "theme": "light",
+  "initialFilters": {
+    "support_group": ["your_support_group"]
+  }
 }

--- a/apps/heureka/src/App.tsx
+++ b/apps/heureka/src/App.tsx
@@ -11,10 +11,15 @@ import { Shell } from "./components/Shell"
 import { ApolloProvider } from "@apollo/client"
 import { getClient } from "./apollo-client"
 
+export type InitialFilters = {
+  support_group?: string[]
+}
+
 export type AppProps = {
   theme?: "theme-dark" | "theme-light"
   apiEndpoint?: string
   embedded?: boolean
+  initialFilters?: InitialFilters
 }
 
 const App = (props: AppProps) => (

--- a/apps/heureka/src/components/Issues/Issues.tsx
+++ b/apps/heureka/src/components/Issues/Issues.tsx
@@ -4,5 +4,8 @@
  */
 
 import React from "react"
+import { InitialFilters } from "../../App"
 
-export const Issues = () => <div>render issues here...</div>
+export const Issues: React.FC<{ initialFilters?: InitialFilters }> = ({ initialFilters }) => (
+  <div>render issues here...</div>
+)

--- a/apps/heureka/src/components/Services/Services.tsx
+++ b/apps/heureka/src/components/Services/Services.tsx
@@ -27,7 +27,7 @@ export type ServiceType = {
   serviceOwners: string[]
 }
 
-const initializeFilterSettings = (initialFilters?: InitialFilters): FilterSettings => {
+const getInitialFilters = (initialFilters?: InitialFilters): FilterSettings => {
   const supportGroupFilters =
     initialFilters?.support_group?.map((sg) => ({ name: "supportGroupCcrn", value: sg })) ?? []
   return {
@@ -36,7 +36,7 @@ const initializeFilterSettings = (initialFilters?: InitialFilters): FilterSettin
   }
 }
 export const Services: React.FC<{ initialFilters?: InitialFilters }> = ({ initialFilters }) => {
-  const [filterSettings, setFilterSettings] = useState<FilterSettings>(initializeFilterSettings(initialFilters))
+  const [filterSettings, setFilterSettings] = useState<FilterSettings>(getInitialFilters(initialFilters))
   const { serviceFilters } = useFetchServiceFilters()
 
   return (

--- a/apps/heureka/src/components/Services/Services.tsx
+++ b/apps/heureka/src/components/Services/Services.tsx
@@ -10,6 +10,7 @@ import { ServicesList } from "./ServicesList"
 import { Panel } from "../common/Panel"
 import { FilterSettings } from "../common/Filters/types"
 import { useFetchServiceFilters } from "./useFetchServiceFilters"
+import { InitialFilters } from "../../App"
 
 export type ServiceType = {
   id: string
@@ -26,13 +27,16 @@ export type ServiceType = {
   serviceOwners: string[]
 }
 
-const defaultFilterSettings = {
-  selectedFilters: [],
-  searchTerm: "",
+const initializeFilterSettings = (initialFilters?: InitialFilters): FilterSettings => {
+  const supportGroupFilters =
+    initialFilters?.support_group?.map((sg) => ({ name: "supportGroupCcrn", value: sg })) ?? []
+  return {
+    selectedFilters: supportGroupFilters,
+    searchTerm: "",
+  }
 }
-
-export const Services = () => {
-  const [filterSettings, setFilterSettings] = useState<FilterSettings>(defaultFilterSettings)
+export const Services: React.FC<{ initialFilters?: InitialFilters }> = ({ initialFilters }) => {
+  const [filterSettings, setFilterSettings] = useState<FilterSettings>(initializeFilterSettings(initialFilters))
   const { serviceFilters } = useFetchServiceFilters()
 
   return (

--- a/apps/heureka/src/components/Shell/Shell.tsx
+++ b/apps/heureka/src/components/Shell/Shell.tsx
@@ -10,6 +10,7 @@ import { Navigation } from "../Navigation"
 import { SERVICES, ISSUES } from "../../constants"
 import { Services } from "../Services"
 import { Issues } from "../Issues"
+import { InitialFilters } from "../../App"
 
 const getViewComponent = (selectedView: ReactNode) => {
   switch (selectedView) {
@@ -25,9 +26,10 @@ const getViewComponent = (selectedView: ReactNode) => {
 type ShellProps = {
   embedded?: boolean
   defaultSelectedView?: ReactNode
+  initialFilters?: InitialFilters
 }
 
-export const Shell = ({ embedded, defaultSelectedView = SERVICES }: ShellProps) => {
+export const Shell = ({ embedded, defaultSelectedView = SERVICES, initialFilters }: ShellProps) => {
   const [selectedView, setSelectedView] = useState<ReactNode>(defaultSelectedView)
   const SelectedViewComponent = getViewComponent(selectedView)
 
@@ -41,7 +43,7 @@ export const Shell = ({ embedded, defaultSelectedView = SERVICES }: ShellProps) 
         <MessagesProvider>
           <Messages />
         </MessagesProvider>
-        <SelectedViewComponent />
+        <SelectedViewComponent initialFilters={initialFilters} />
       </Container>
     </AppShell>
   )


### PR DESCRIPTION
# Summary

Adds `initialFilters.support_group` as the default filter in `Services` and maps `supportGroupCcrn` to `support_group` for consistency.

# Changes Made

- Added initialFilters type
- Passed InitialFilters to Services and Issues
- Set as default filter in Services

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->
<img width="560" alt="Screenshot 2025-03-18 at 00 01 40" src="https://github.com/user-attachments/assets/6e7c3223-07f9-42a7-9123-4b2be98e35ee" />

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npx turbo dev --filter @cloudoperators/juno-app-heureka` --> add before the appProps

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
