### PR TITLE
feat(heureka): adds an image version details info to service details page

### DIFF
--- a/.changeset/angry-sloths-clean.md
+++ b/.changeset/angry-sloths-clean.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-heureka": minor
+---
+
+adds service image version details into service details page

--- a/.changeset/fair-moose-check.md
+++ b/.changeset/fair-moose-check.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+adds an image version details info to service details page

--- a/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
+++ b/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
@@ -113,6 +113,7 @@ export const ServiceDetails = () => {
         <Stack className="w-full">
           <ServiceImageVersions
             service={selectedService}
+            showFullTable={false}
             onVersionSelect={(version) => {
               setSelectedImageVersion(version)
             }}

--- a/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
+++ b/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
@@ -14,15 +14,16 @@ import { Breadcrumb } from "../../common/Breadcrumb"
 export const ServiceDetails = () => {
   const { selectedView } = useStore()
   const [showOccurrences, setShowOccurrences] = useState(false)
-  
+
   const selectedService =
     selectedView.viewId === UserView.ServiceDetails
       ? (selectedView as SelectServiceDetailsPayload).params.service
       : undefined
 
-  const selectedImageVersion = selectedView.viewId === UserView.ServiceDetails
-    ? (selectedView as SelectServiceDetailsPayload).params.imageVersion
-    : undefined
+  const selectedImageVersion =
+    selectedView.viewId === UserView.ServiceDetails
+      ? (selectedView as SelectServiceDetailsPayload).params.imageVersion
+      : undefined
 
   if (typeof selectedService === "undefined") {
     return null
@@ -111,8 +112,8 @@ export const ServiceDetails = () => {
 
         {/* Image Versions Section */}
         <Stack className="w-full">
-          <ServiceImageVersions 
-            service={selectedService} 
+          <ServiceImageVersions
+            service={selectedService}
             onVersionSelect={(version) => {
               // This will be handled by the store through the ServiceImageVersions component
             }}
@@ -182,7 +183,7 @@ export const ServiceDetails = () => {
                   <Label text="Image Instances: " />
                   <a
                     href="#"
-                    onClick={(e) =>  {
+                    onClick={(e) => {
                       e.stopPropagation()
                       setShowOccurrences(!showOccurrences)
                     }}
@@ -194,7 +195,9 @@ export const ServiceDetails = () => {
                 {showOccurrences && (
                   <Stack gap="4" direction="vertical" className="pl-4">
                     {/* TODO: Add list of image instances details here after being available from API*/}
-                    <span className="text-theme-light">List of image instances with details will be displayed here</span>
+                    <span className="text-theme-light">
+                      List of image instances with details will be displayed here
+                    </span>
                   </Stack>
                 )}
               </Stack>
@@ -205,5 +208,3 @@ export const ServiceDetails = () => {
     </MessagesProvider>
   )
 }
-
-

--- a/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
+++ b/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
@@ -184,20 +184,58 @@ export const ServiceDetails = () => {
                   <a
                     href="#"
                     onClick={(e) => {
-                      e.stopPropagation()
+                      e.preventDefault()
                       setShowOccurrences(!showOccurrences)
                     }}
                     className="hover:underline text-sm"
                   >
-                    {showOccurrences ? "Hide Occurrences" : "Show Occurrences"}
+                    {showOccurrences ? "Hide Occurrences" : "Show Occurrences"} (
+                    {selectedImageVersion.componentInstances?.totalCount || 0})
                   </a>
                 </Stack>
                 {showOccurrences && (
                   <Stack gap="4" direction="vertical" className="pl-4">
-                    {/* TODO: Add list of image instances details here after being available from API*/}
-                    <span className="text-theme-light">
-                      List of image instances with details will be displayed here
-                    </span>
+                    {selectedImageVersion.componentInstances &&
+                    selectedImageVersion.componentInstances.edges.length > 0 ? (
+                      <Stack gap="2" direction="vertical">
+                        {selectedImageVersion.componentInstances.edges.map((edge) => (
+                          <Stack key={`${edge?.node?.ccrn}-${edge?.node?.id}`} gap="2" direction="horizontal" wrap>
+                            <Pill
+                              pillKey="region"
+                              pillKeyLabel="region"
+                              pillValue={edge?.node?.region || ""}
+                              pillValueLabel={edge?.node?.region || ""}
+                            />
+                            <Pill
+                              pillKey="cluster"
+                              pillKeyLabel="cluster"
+                              pillValue={edge?.node?.cluster || ""}
+                              pillValueLabel={edge?.node?.cluster || ""}
+                            />
+                            <Pill
+                              pillKey="namespace"
+                              pillKeyLabel="namespace"
+                              pillValue={edge?.node?.namespace || ""}
+                              pillValueLabel={edge?.node?.namespace || ""}
+                            />
+                            <Pill
+                              pillKey="domain"
+                              pillKeyLabel="domain"
+                              pillValue={edge?.node?.domain || ""}
+                              pillValueLabel={edge?.node?.domain || ""}
+                            />
+                            <Pill
+                              pillKey="project"
+                              pillKeyLabel="project"
+                              pillValue={edge?.node?.project || ""}
+                              pillValueLabel={edge?.node?.project || ""}
+                            />
+                          </Stack>
+                        ))}
+                      </Stack>
+                    ) : (
+                      <span className="text-theme-light">No image instances found</span>
+                    )}
                   </Stack>
                 )}
               </Stack>

--- a/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
+++ b/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react"
+import React, { useState } from "react"
 import { ContentHeading, Stack, Badge, Pill, Label } from "@cloudoperators/juno-ui-components"
 import { ServiceImageVersions } from "../common/ServiceImageVersions"
 import { MessagesProvider, Messages } from "@cloudoperators/juno-messages-provider"
@@ -13,10 +13,16 @@ import { Breadcrumb } from "../../common/Breadcrumb"
 
 export const ServiceDetails = () => {
   const { selectedView } = useStore()
+  const [showOccurrences, setShowOccurrences] = useState(false)
+  
   const selectedService =
     selectedView.viewId === UserView.ServiceDetails
       ? (selectedView as SelectServiceDetailsPayload).params.service
       : undefined
+
+  const selectedImageVersion = selectedView.viewId === UserView.ServiceDetails
+    ? (selectedView as SelectServiceDetailsPayload).params.imageVersion
+    : undefined
 
   if (typeof selectedService === "undefined") {
     return null
@@ -29,7 +35,7 @@ export const ServiceDetails = () => {
       <Stack gap="8" direction="vertical" className="overflow-auto w-full">
         {/* Service Information Section */}
         <Stack gap="6" direction="vertical" className="w-full">
-          <ContentHeading>Service {selectedService.name} details</ContentHeading>
+          <ContentHeading>Service {selectedService.name} Information</ContentHeading>
           <Stack gap="4" direction="vertical">
             {/* Service Details Row */}
             <Stack gap="2" direction="horizontal">
@@ -105,9 +111,99 @@ export const ServiceDetails = () => {
 
         {/* Image Versions Section */}
         <Stack className="w-full">
-          <ServiceImageVersions service={selectedService} />
+          <ServiceImageVersions 
+            service={selectedService} 
+            onVersionSelect={(version) => {
+              // This will be handled by the store through the ServiceImageVersions component
+            }}
+          />
         </Stack>
+
+        {/* Selected Image Version Details Section */}
+        {selectedImageVersion && (
+          <Stack gap="6" direction="vertical" className="w-full">
+            <ContentHeading>Image {selectedImageVersion.imageRepository} Information</ContentHeading>
+            <Stack gap="4" direction="vertical">
+              {/* Component Details Row */}
+              <Stack gap="2" direction="horizontal">
+                <Label text="Image Details: " />
+                <Stack direction="horizontal" gap="2" wrap>
+                  <Pill
+                    pillKey="tag"
+                    pillKeyLabel="tag"
+                    pillValue={selectedImageVersion.imageTag}
+                    pillValueLabel={selectedImageVersion.imageTag}
+                  />
+                  <Pill
+                    pillKey="repository"
+                    pillKeyLabel="repository"
+                    pillValue={selectedImageVersion.imageRepository}
+                    pillValueLabel={selectedImageVersion.imageRepository}
+                  />
+                  <Pill
+                    pillKey="version"
+                    pillKeyLabel="version"
+                    pillValue={selectedImageVersion.imageVersion}
+                    pillValueLabel={selectedImageVersion.imageVersion}
+                  />
+                </Stack>
+              </Stack>
+
+              {/* Issues Count Row */}
+              <Stack gap="2" direction="horizontal">
+                <Label text="Number of Issues: " />
+                <Stack direction="horizontal" gap="4" alignment="center">
+                  <Stack direction="horizontal" gap="2" alignment="center">
+                    <span>Critical:</span>
+                    <Badge
+                      icon="danger"
+                      text={`${selectedImageVersion.issueCounts?.critical || 0}`}
+                      variant={selectedImageVersion.issueCounts?.critical > 0 ? "danger" : "default"}
+                    />
+                  </Stack>
+                  <Stack direction="horizontal" gap="2" alignment="center">
+                    <span>High:</span>
+                    <Badge
+                      icon="warning"
+                      text={`${selectedImageVersion.issueCounts?.high || 0}`}
+                      variant={selectedImageVersion.issueCounts?.high > 0 ? "warning" : "default"}
+                    />
+                  </Stack>
+                  <Stack direction="horizontal" gap="2" alignment="center">
+                    <span>Low:</span>
+                    <span>{selectedImageVersion.issueCounts?.low || 0}</span>
+                  </Stack>
+                </Stack>
+              </Stack>
+
+              {/* Occurrences Section */}
+              <Stack gap="2" direction="vertical">
+                <Stack gap="2" direction="horizontal" alignment="center">
+                  <Label text="Image Instances: " />
+                  <a
+                    href="#"
+                    onClick={(e) =>  {
+                      e.stopPropagation()
+                      setShowOccurrences(!showOccurrences)
+                    }}
+                    className="hover:underline text-sm"
+                  >
+                    {showOccurrences ? "Hide Occurrences" : "Show Occurrences"}
+                  </a>
+                </Stack>
+                {showOccurrences && (
+                  <Stack gap="4" direction="vertical" className="pl-4">
+                    {/* TODO: Add list of image instances details here after being available from API*/}
+                    <span className="text-theme-light">List of image instances with details will be displayed here</span>
+                  </Stack>
+                )}
+              </Stack>
+            </Stack>
+          </Stack>
+        )}
       </Stack>
     </MessagesProvider>
   )
 }
+
+

--- a/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
+++ b/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { ContentHeading, Stack, Badge, Pill, Label } from "@cloudoperators/juno-ui-components"
-import { ServiceImageVersions } from "../common/ServiceImageVersions"
+import { ServiceImageVersions, ServiceImageVersion } from "../common/ServiceImageVersions"
+import { ImageVersionDetailsPanel } from "../common/ImageVersionDetailsPanel/ImageVersionDetailsPanel"
 import { MessagesProvider, Messages } from "@cloudoperators/juno-messages-provider"
 import { useStore } from "../../../store/StoreProvider"
 import { SelectServiceDetailsPayload, UserView } from "../../../store/StoreProvider/types"
@@ -13,17 +14,23 @@ import { Breadcrumb } from "../../common/Breadcrumb"
 
 export const ServiceDetails = () => {
   const { selectedView } = useStore()
-  const [showOccurrences, setShowOccurrences] = useState(false)
+  const [selectedImageVersion, setSelectedImageVersion] = useState<ServiceImageVersion | null>(null)
 
   const selectedService =
     selectedView.viewId === UserView.ServiceDetails
       ? (selectedView as SelectServiceDetailsPayload).params.service
       : undefined
 
-  const selectedImageVersion =
+  const selectedImageVersionFromStore =
     selectedView.viewId === UserView.ServiceDetails
       ? (selectedView as SelectServiceDetailsPayload).params.imageVersion
       : undefined
+
+  useEffect(() => {
+    if (selectedImageVersionFromStore) {
+      setSelectedImageVersion(selectedImageVersionFromStore)
+    }
+  }, [selectedImageVersionFromStore])
 
   if (typeof selectedService === "undefined") {
     return null
@@ -64,7 +71,6 @@ export const ServiceDetails = () => {
             <Stack gap="2" direction="horizontal">
               <Label text="Number of Issues: " />
               <Stack direction="horizontal" gap="4" alignment="center">
-                {/* <span>{totalIssues}</span> */}
                 <Stack direction="horizontal" gap="2" alignment="center">
                   <span>Critical:</span>
                   <Badge
@@ -115,132 +121,14 @@ export const ServiceDetails = () => {
           <ServiceImageVersions
             service={selectedService}
             onVersionSelect={(version) => {
-              // This will be handled by the store through the ServiceImageVersions component
+              setSelectedImageVersion(version)
             }}
           />
         </Stack>
 
-        {/* Selected Image Version Details Section */}
+        {/* Image Version Details Panel */}
         {selectedImageVersion && (
-          <Stack gap="6" direction="vertical" className="w-full">
-            <ContentHeading>Image {selectedImageVersion.imageRepository} Information</ContentHeading>
-            <Stack gap="4" direction="vertical">
-              {/* Component Details Row */}
-              <Stack gap="2" direction="horizontal">
-                <Label text="Image Details: " />
-                <Stack direction="horizontal" gap="2" wrap>
-                  <Pill
-                    pillKey="tag"
-                    pillKeyLabel="tag"
-                    pillValue={selectedImageVersion.imageTag}
-                    pillValueLabel={selectedImageVersion.imageTag}
-                  />
-                  <Pill
-                    pillKey="repository"
-                    pillKeyLabel="repository"
-                    pillValue={selectedImageVersion.imageRepository}
-                    pillValueLabel={selectedImageVersion.imageRepository}
-                  />
-                  <Pill
-                    pillKey="version"
-                    pillKeyLabel="version"
-                    pillValue={selectedImageVersion.imageVersion}
-                    pillValueLabel={selectedImageVersion.imageVersion}
-                  />
-                </Stack>
-              </Stack>
-
-              {/* Issues Count Row */}
-              <Stack gap="2" direction="horizontal">
-                <Label text="Number of Issues: " />
-                <Stack direction="horizontal" gap="4" alignment="center">
-                  <Stack direction="horizontal" gap="2" alignment="center">
-                    <span>Critical:</span>
-                    <Badge
-                      icon="danger"
-                      text={`${selectedImageVersion.issueCounts?.critical || 0}`}
-                      variant={selectedImageVersion.issueCounts?.critical > 0 ? "danger" : "default"}
-                    />
-                  </Stack>
-                  <Stack direction="horizontal" gap="2" alignment="center">
-                    <span>High:</span>
-                    <Badge
-                      icon="warning"
-                      text={`${selectedImageVersion.issueCounts?.high || 0}`}
-                      variant={selectedImageVersion.issueCounts?.high > 0 ? "warning" : "default"}
-                    />
-                  </Stack>
-                  <Stack direction="horizontal" gap="2" alignment="center">
-                    <span>Low:</span>
-                    <span>{selectedImageVersion.issueCounts?.low || 0}</span>
-                  </Stack>
-                </Stack>
-              </Stack>
-
-              {/* Occurrences Section */}
-              <Stack gap="2" direction="vertical">
-                <Stack gap="2" direction="horizontal" alignment="center">
-                  <Label text="Image Instances: " />
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault()
-                      setShowOccurrences(!showOccurrences)
-                    }}
-                    className="hover:underline text-sm"
-                  >
-                    {showOccurrences ? "Hide Occurrences" : "Show Occurrences"} (
-                    {selectedImageVersion.componentInstances?.totalCount || 0})
-                  </a>
-                </Stack>
-                {showOccurrences && (
-                  <Stack gap="4" direction="vertical" className="pl-4">
-                    {selectedImageVersion.componentInstances &&
-                    selectedImageVersion.componentInstances.edges.length > 0 ? (
-                      <Stack gap="2" direction="vertical">
-                        {selectedImageVersion.componentInstances.edges.map((edge) => (
-                          <Stack key={`${edge?.node?.ccrn}-${edge?.node?.id}`} gap="2" direction="horizontal" wrap>
-                            <Pill
-                              pillKey="region"
-                              pillKeyLabel="region"
-                              pillValue={edge?.node?.region || ""}
-                              pillValueLabel={edge?.node?.region || ""}
-                            />
-                            <Pill
-                              pillKey="cluster"
-                              pillKeyLabel="cluster"
-                              pillValue={edge?.node?.cluster || ""}
-                              pillValueLabel={edge?.node?.cluster || ""}
-                            />
-                            <Pill
-                              pillKey="namespace"
-                              pillKeyLabel="namespace"
-                              pillValue={edge?.node?.namespace || ""}
-                              pillValueLabel={edge?.node?.namespace || ""}
-                            />
-                            <Pill
-                              pillKey="domain"
-                              pillKeyLabel="domain"
-                              pillValue={edge?.node?.domain || ""}
-                              pillValueLabel={edge?.node?.domain || ""}
-                            />
-                            <Pill
-                              pillKey="project"
-                              pillKeyLabel="project"
-                              pillValue={edge?.node?.project || ""}
-                              pillValueLabel={edge?.node?.project || ""}
-                            />
-                          </Stack>
-                        ))}
-                      </Stack>
-                    ) : (
-                      <span className="text-theme-light">No image instances found</span>
-                    )}
-                  </Stack>
-                )}
-              </Stack>
-            </Stack>
-          </Stack>
+          <ImageVersionDetailsPanel imageVersion={selectedImageVersion} onClose={() => setSelectedImageVersion(null)} />
         )}
       </Stack>
     </MessagesProvider>

--- a/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
+++ b/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect } from "react"
+import React, { useState } from "react"
 import { ContentHeading, Stack, Badge, Pill, Label } from "@cloudoperators/juno-ui-components"
 import { ServiceImageVersions, ServiceImageVersion } from "../common/ServiceImageVersions"
 import { ImageVersionDetailsPanel } from "../common/ImageVersionDetailsPanel/ImageVersionDetailsPanel"
@@ -14,23 +14,16 @@ import { Breadcrumb } from "../../common/Breadcrumb"
 
 export const ServiceDetails = () => {
   const { selectedView } = useStore()
-  const [selectedImageVersion, setSelectedImageVersion] = useState<ServiceImageVersion | null>(null)
-
   const selectedService =
     selectedView.viewId === UserView.ServiceDetails
       ? (selectedView as SelectServiceDetailsPayload).params.service
       : undefined
 
-  const selectedImageVersionFromStore =
+  const [selectedImageVersion, setSelectedImageVersion] = useState<ServiceImageVersion | null>(
     selectedView.viewId === UserView.ServiceDetails
-      ? (selectedView as SelectServiceDetailsPayload).params.imageVersion
-      : undefined
-
-  useEffect(() => {
-    if (selectedImageVersionFromStore) {
-      setSelectedImageVersion(selectedImageVersionFromStore)
-    }
-  }, [selectedImageVersionFromStore])
+      ? (selectedView as SelectServiceDetailsPayload).params.imageVersion || null
+      : null
+  )
 
   if (typeof selectedService === "undefined") {
     return null

--- a/apps/heureka/src/components/Services/ServicePanel/ServicePanel.test.tsx
+++ b/apps/heureka/src/components/Services/ServicePanel/ServicePanel.test.tsx
@@ -49,7 +49,7 @@ describe("ServicePanel", () => {
     expect(await screen.findByText("Test-service Overview")).toBeInTheDocument()
 
     // Check if table headers are rendered
-    expect(await screen.findByText("Image Name")).toBeInTheDocument()
+    expect(await screen.findByText("Image Repository")).toBeInTheDocument()
     expect(await screen.findByText("Tag")).toBeInTheDocument()
     expect(await screen.findByText("Critical")).toBeInTheDocument()
     expect(await screen.findByText("High")).toBeInTheDocument()

--- a/apps/heureka/src/components/Services/ServicePanel/ServicePanel.tsx
+++ b/apps/heureka/src/components/Services/ServicePanel/ServicePanel.tsx
@@ -18,7 +18,7 @@ export const ServicePanel = ({ service, onClose }: ServicePanelProps) => (
   <Panel heading={`${capitalizeFirstLetter(service.name)} Overview`} opened={true} onClose={onClose} size="large">
     <PanelBody>
       <Stack className="w-full">
-        <ServiceImageVersions service={service} showDetailsButtons />
+        <ServiceImageVersions service={service} showFullTable />
       </Stack>
     </PanelBody>
   </Panel>

--- a/apps/heureka/src/components/Services/ServicesList/ServicesList.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServicesList.tsx
@@ -68,7 +68,7 @@ export const ServicesList = ({ filterSettings }: ServiceListProps) => {
           <DataGridHeadCell>Service details</DataGridHeadCell>
           <DataGridHeadCell>No. Components</DataGridHeadCell>
           <DataGridHeadCell>Service owners</DataGridHeadCell>
-          <DataGridHeadCell>Actions</DataGridHeadCell>
+          <DataGridHeadCell></DataGridHeadCell>
         </DataGridRow>
         {
           /* if request is in flight */

--- a/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionDetailsPanel.tsx
+++ b/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionDetailsPanel.tsx
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from "react"
+import { Panel, PanelBody, Stack, ContentHeading, Badge, Pill, Label } from "@cloudoperators/juno-ui-components"
+import { ServiceImageVersion } from "../ServiceImageVersions"
+
+type ImageVersionDetailsPanelProps = {
+  imageVersion: ServiceImageVersion
+  onClose: () => void
+}
+
+export const ImageVersionDetailsPanel = ({ imageVersion, onClose }: ImageVersionDetailsPanelProps) => {
+  const [showOccurrences, setShowOccurrences] = useState(false)
+
+  return (
+    <Panel heading={`Image ${imageVersion.imageRepository} Information`} opened={true} onClose={onClose} size="large">
+      <PanelBody>
+        <Stack gap="6" direction="vertical" className="w-full">
+          <Stack gap="4" direction="vertical">
+            {/* Component Details Row */}
+            <Stack gap="2" direction="horizontal">
+              <Label text="Image Details: " />
+              <Stack direction="horizontal" gap="2" wrap>
+                <Pill
+                  pillKey="tag"
+                  pillKeyLabel="tag"
+                  pillValue={imageVersion.imageTag}
+                  pillValueLabel={imageVersion.imageTag}
+                />
+                <Pill
+                  pillKey="repository"
+                  pillKeyLabel="repository"
+                  pillValue={imageVersion.imageRepository}
+                  pillValueLabel={imageVersion.imageRepository}
+                />
+                <Pill
+                  pillKey="version"
+                  pillKeyLabel="version"
+                  pillValue={imageVersion.imageVersion}
+                  pillValueLabel={imageVersion.imageVersion}
+                />
+              </Stack>
+            </Stack>
+
+            {/* Issues Count Row */}
+            <Stack gap="2" direction="horizontal">
+              <Label text="Number of Issues: " />
+              <Stack direction="horizontal" gap="4" alignment="center">
+                <Stack direction="horizontal" gap="2" alignment="center">
+                  <span>Critical:</span>
+                  <Badge
+                    icon="danger"
+                    text={`${imageVersion.issueCounts?.critical || 0}`}
+                    variant={imageVersion.issueCounts?.critical > 0 ? "danger" : "default"}
+                  />
+                </Stack>
+                <Stack direction="horizontal" gap="2" alignment="center">
+                  <span>High:</span>
+                  <Badge
+                    icon="warning"
+                    text={`${imageVersion.issueCounts?.high || 0}`}
+                    variant={imageVersion.issueCounts?.high > 0 ? "warning" : "default"}
+                  />
+                </Stack>
+                <Stack direction="horizontal" gap="2" alignment="center">
+                  <span>Low:</span>
+                  <span>{imageVersion.issueCounts?.low || 0}</span>
+                </Stack>
+              </Stack>
+            </Stack>
+
+            {/* Occurrences Section */}
+            <Stack gap="2" direction="vertical">
+              <Stack gap="2" direction="horizontal" alignment="center">
+                <Label text="Image Instances: " />
+                <a
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    setShowOccurrences(!showOccurrences)
+                  }}
+                  className="hover:underline text-sm"
+                >
+                  {showOccurrences ? "Hide Occurrences" : "Show Occurrences"} (
+                  {imageVersion.componentInstances?.totalCount || 0})
+                </a>
+              </Stack>
+              {showOccurrences && (
+                <Stack gap="4" direction="vertical" className="pl-4">
+                  {imageVersion.componentInstances && imageVersion.componentInstances.edges.length > 0 ? (
+                    <Stack gap="2" direction="vertical">
+                      {imageVersion.componentInstances.edges.map((edge) => (
+                        <Stack key={`${edge?.node?.ccrn}-${edge?.node?.id}`} gap="2" direction="vertical">
+                          <span>Region: {edge?.node?.region || "-"}</span>
+                          <span>Cluster: {edge?.node?.cluster || "-"}</span>
+                          <span>Namespace: {edge?.node?.namespace || "-"}</span>
+                          <span>Domain: {edge?.node?.domain || "-"}</span>
+                          <span>Project: {edge?.node?.project || "-"}</span>
+                        </Stack>
+                      ))}
+                    </Stack>
+                  ) : (
+                    <span className="text-theme-light">No image instances found</span>
+                  )}
+                </Stack>
+              )}
+            </Stack>
+          </Stack>
+        </Stack>
+      </PanelBody>
+    </Panel>
+  )
+}

--- a/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionDetailsPanel.tsx
+++ b/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionDetailsPanel.tsx
@@ -94,11 +94,11 @@ export const ImageVersionDetailsPanel = ({ imageVersion, onClose }: ImageVersion
                     <Stack gap="2" direction="vertical">
                       {imageVersion.componentInstances.edges.map((edge) => (
                         <Stack key={`${edge?.node?.ccrn}-${edge?.node?.id}`} gap="2" direction="vertical">
-                          <span>Region: {edge?.node?.region || "-"}</span>
-                          <span>Cluster: {edge?.node?.cluster || "-"}</span>
-                          <span>Namespace: {edge?.node?.namespace || "-"}</span>
-                          <span>Domain: {edge?.node?.domain || "-"}</span>
-                          <span>Project: {edge?.node?.project || "-"}</span>
+                          <span>{edge?.node?.region || "-"}</span>
+                          <span>{edge?.node?.cluster || "-"}</span>
+                          <span>{edge?.node?.namespace || "-"}</span>
+                          <span>{edge?.node?.pod || "-"}</span>
+                          <span>{edge?.node?.container || "-"}</span>
                         </Stack>
                       ))}
                     </Stack>

--- a/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/index.ts
+++ b/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/index.ts
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./ImageVersionDetailsPanel"

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -107,90 +107,90 @@ export const ServiceImageVersions = ({ service, showDetailsButtons, onVersionSel
           <ContentHeading>Service Image Versions ({totalCount})</ContentHeading>
         )}
       </Stack>
-        <DataGrid columns={columnCount}>
-          <DataGridRow>
-            <DataGridHeadCell>Image Repository</DataGridHeadCell>
-            <DataGridHeadCell>Tag</DataGridHeadCell>
-            <DataGridHeadCell>Critical</DataGridHeadCell>
-            <DataGridHeadCell>High</DataGridHeadCell>
-            <DataGridHeadCell>Medium</DataGridHeadCell>
-            <DataGridHeadCell>Low</DataGridHeadCell>
-            {showDetailsButtons && <DataGridHeadCell>Actions</DataGridHeadCell>}
-          </DataGridRow>
-          {loading ? (
-            <EmptyDataGridRow colSpan={columnCount}>Loading...</EmptyDataGridRow>
-          ) : imageVersions?.length === 0 && !error ? (
-            <EmptyDataGridRow colSpan={columnCount}>No image versions available.</EmptyDataGridRow>
-          ) : (
-            formattedImageVersions.map((version, index) => (
-              <DataGridRow 
-                key={index} 
-                onClick={() => {
-                  onVersionSelect?.(version)
-                  selectImageVersion({
-                    service,
-                    imageVersion: version,
-                  })
-                }}
-                className={`cursor-pointer ${onVersionSelect ? "active" : ""}`}
-              >
-                <DataGridCell className="service-image-versions-cell">
-                  <Stack gap="1" direction="vertical">
-                    <Stack gap="0.5" direction="vertical">
-                      <span>{version.imageRepository}</span>
-                      <span className="text-sm text-theme-light">{version.imageVersion}</span>
-                    </Stack>
-                    <Stack gap="1" alignment="center">
-                      <a
-                        href={`https://${version.imageName}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:underline text-sm"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <Stack gap="1.5" alignment="center">
-                          <Icon icon="openInNew" size="16" color="jn-global-text" />
-                          <span>Image registery</span>
-                        </Stack>
-                      </a>
-                    </Stack>
+      <DataGrid columns={columnCount}>
+        <DataGridRow>
+          <DataGridHeadCell>Image Repository</DataGridHeadCell>
+          <DataGridHeadCell>Tag</DataGridHeadCell>
+          <DataGridHeadCell>Critical</DataGridHeadCell>
+          <DataGridHeadCell>High</DataGridHeadCell>
+          <DataGridHeadCell>Medium</DataGridHeadCell>
+          <DataGridHeadCell>Low</DataGridHeadCell>
+          {showDetailsButtons && <DataGridHeadCell>Actions</DataGridHeadCell>}
+        </DataGridRow>
+        {loading ? (
+          <EmptyDataGridRow colSpan={columnCount}>Loading...</EmptyDataGridRow>
+        ) : imageVersions?.length === 0 && !error ? (
+          <EmptyDataGridRow colSpan={columnCount}>No image versions available.</EmptyDataGridRow>
+        ) : (
+          formattedImageVersions.map((version, index) => (
+            <DataGridRow
+              key={index}
+              onClick={() => {
+                onVersionSelect?.(version)
+                selectImageVersion({
+                  service,
+                  imageVersion: version,
+                })
+              }}
+              className={`cursor-pointer ${onVersionSelect ? "active" : ""}`}
+            >
+              <DataGridCell className="service-image-versions-cell">
+                <Stack gap="1" direction="vertical">
+                  <Stack gap="0.5" direction="vertical">
+                    <span>{version.imageRepository}</span>
+                    <span className="text-sm text-theme-light">{version.imageVersion}</span>
                   </Stack>
-                </DataGridCell>
-                <DataGridCell className="service-image-versions-cell">{version.imageTag}</DataGridCell>
-                <DataGridCell>
-                  {version.issueCounts.critical ? (
-                    <Badge icon text={version.issueCounts.critical.toString()} variant="danger" />
-                  ) : (
-                    "-"
-                  )}
-                </DataGridCell>
-                <DataGridCell>
-                  {version.issueCounts.high ? (
-                    <Badge icon text={version.issueCounts.high.toString()} variant="warning" />
-                  ) : (
-                    "-"
-                  )}
-                </DataGridCell>
-                <DataGridCell>{version.issueCounts.medium || "-"}</DataGridCell>
-                <DataGridCell>{version.issueCounts.low || "-"}</DataGridCell>
-                {showDetailsButtons && (
-                  <DataGridCell>
-                    <Button
-                      label="Show Details"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        showServiceDetails({
-                          service,
-                          imageVersion: version,
-                        })
-                      }}
-                    />
-                  </DataGridCell>
+                  <Stack gap="1" alignment="center">
+                    <a
+                      href={`https://${version.imageName}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:underline text-sm"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <Stack gap="1.5" alignment="center">
+                        <Icon icon="openInNew" size="16" color="jn-global-text" />
+                        <span>Image registery</span>
+                      </Stack>
+                    </a>
+                  </Stack>
+                </Stack>
+              </DataGridCell>
+              <DataGridCell className="service-image-versions-cell">{version.imageTag}</DataGridCell>
+              <DataGridCell>
+                {version.issueCounts.critical ? (
+                  <Badge icon text={version.issueCounts.critical.toString()} variant="danger" />
+                ) : (
+                  "-"
                 )}
-              </DataGridRow>
-            ))
-          )}
-        </DataGrid>
+              </DataGridCell>
+              <DataGridCell>
+                {version.issueCounts.high ? (
+                  <Badge icon text={version.issueCounts.high.toString()} variant="warning" />
+                ) : (
+                  "-"
+                )}
+              </DataGridCell>
+              <DataGridCell>{version.issueCounts.medium || "-"}</DataGridCell>
+              <DataGridCell>{version.issueCounts.low || "-"}</DataGridCell>
+              {showDetailsButtons && (
+                <DataGridCell>
+                  <Button
+                    label="Show Details"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      showServiceDetails({
+                        service,
+                        imageVersion: version,
+                      })
+                    }}
+                  />
+                </DataGridCell>
+              )}
+            </DataGridRow>
+          ))
+        )}
+      </DataGrid>
       {totalNumberOfPages > 1 && (
         <Stack distribution="end">
           <Pagination

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -22,6 +22,16 @@ import { useDispatch } from "../../../../store/StoreProvider"
 import { ActionType, UserView } from "../../../../store/StoreProvider/types"
 import { ServiceType } from "../../Services"
 
+export type ComponentInstance = {
+  id: string
+  ccrn?: string | null
+  region?: string | null
+  cluster?: string | null
+  namespace?: string | null
+  domain?: string | null
+  project?: string | null
+}
+
 export type ServiceImageVersion = {
   imageName: string
   imageVersion: string
@@ -36,15 +46,21 @@ export type ServiceImageVersion = {
   }
   serviceName: string
   totalCount?: number
+  componentInstances?: {
+    totalCount: number
+    edges: Array<{
+      node: ComponentInstance
+    } | null>
+  }
 }
 
 type ServiceImageVersionsProps = {
   service: ServiceType
-  showDetailsButtons?: boolean
+  showFullTable?: boolean
   onVersionSelect?: (version: ServiceImageVersion) => void
 }
 
-export const ServiceImageVersions = ({ service, showDetailsButtons, onVersionSelect }: ServiceImageVersionsProps) => {
+export const ServiceImageVersions = ({ service, showFullTable, onVersionSelect }: ServiceImageVersionsProps) => {
   const dispatch = useDispatch()
   const { name: serviceName } = service
   const { loading, imageVersions, error, totalNumberOfPages, currentPage, goToPage, totalCount } =
@@ -60,9 +76,15 @@ export const ServiceImageVersions = ({ service, showDetailsButtons, onVersionSel
     imageRepository: version.repository,
     issueCounts: version.issueCounts,
     serviceName,
+    componentInstances: version.componentInstances
+      ? {
+          totalCount: version.componentInstances.totalCount,
+          edges: version.componentInstances.edges,
+        }
+      : undefined,
   }))
 
-  const columnCount = showDetailsButtons ? 7 : 6
+  const columnCount = 7
 
   const showServiceDetails = useCallback(
     ({ service, imageVersion }: { service: ServiceType; imageVersion?: ServiceImageVersion }) => {
@@ -96,7 +118,7 @@ export const ServiceImageVersions = ({ service, showDetailsButtons, onVersionSel
   return (
     <Stack gap="4" direction="vertical" className="w-full">
       <Stack distribution="between" alignment="center" className="w-full">
-        {showDetailsButtons ? (
+        {showFullTable ? (
           <>
             <span>{totalCount} image versions in service</span>
             <Button variant="primary" size="small" onClick={() => showServiceDetails({ service })}>
@@ -115,7 +137,7 @@ export const ServiceImageVersions = ({ service, showDetailsButtons, onVersionSel
           <DataGridHeadCell>High</DataGridHeadCell>
           <DataGridHeadCell>Medium</DataGridHeadCell>
           <DataGridHeadCell>Low</DataGridHeadCell>
-          {showDetailsButtons && <DataGridHeadCell>Actions</DataGridHeadCell>}
+          <DataGridHeadCell></DataGridHeadCell>
         </DataGridRow>
         {loading ? (
           <EmptyDataGridRow colSpan={columnCount}>Loading...</EmptyDataGridRow>
@@ -173,20 +195,18 @@ export const ServiceImageVersions = ({ service, showDetailsButtons, onVersionSel
               </DataGridCell>
               <DataGridCell>{version.issueCounts.medium || "-"}</DataGridCell>
               <DataGridCell>{version.issueCounts.low || "-"}</DataGridCell>
-              {showDetailsButtons && (
-                <DataGridCell>
-                  <Button
-                    label="Show Details"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      showServiceDetails({
-                        service,
-                        imageVersion: version,
-                      })
-                    }}
-                  />
-                </DataGridCell>
-              )}
+              <DataGridCell>
+                <Button
+                  label="Show Details"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    showServiceDetails({
+                      service,
+                      imageVersion: version,
+                    })
+                  }}
+                />
+              </DataGridCell>
             </DataGridRow>
           ))
         )}

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -24,12 +24,19 @@ import { ServiceType } from "../../Services"
 
 export type ComponentInstance = {
   id: string
-  ccrn?: string | null
-  region?: string | null
-  cluster?: string | null
-  namespace?: string | null
-  domain?: string | null
-  project?: string | null
+  ccrn?: string | ""
+  region?: string | ""
+  cluster?: string | ""
+  namespace?: string | ""
+  pod?: string | ""
+  container?: string | ""
+}
+
+export type ComponentInstancesConnection = {
+  totalCount: number
+  edges: Array<{
+    node: ComponentInstance
+  } | null>
 }
 
 export type ServiceImageVersion = {
@@ -46,12 +53,7 @@ export type ServiceImageVersion = {
   }
   serviceName: string
   totalCount?: number
-  componentInstances?: {
-    totalCount: number
-    edges: Array<{
-      node: ComponentInstance
-    } | null>
-  }
+  componentInstances?: ComponentInstancesConnection
 }
 
 type ServiceImageVersionsProps = {
@@ -97,7 +99,7 @@ export const ServiceImageVersions = ({ service, showFullTable, onVersionSelect }
         },
       })
     },
-    []
+    [dispatch]
   )
 
   const showServiceDetails = useCallback(
@@ -204,17 +206,19 @@ export const ServiceImageVersions = ({ service, showFullTable, onVersionSelect }
               <DataGridCell>{version.issueCounts.medium || "-"}</DataGridCell>
               <DataGridCell>{version.issueCounts.low || "-"}</DataGridCell>
               <DataGridCell>
-                <Button
-                  size="small"
-                  label="Show Details"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    showServiceDetails({
-                      service,
-                      imageVersion: version,
-                    })
-                  }}
-                />
+                {showFullTable && (
+                  <Button
+                    size="small"
+                    label="Show Details"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      showServiceDetails({
+                        service,
+                        imageVersion: version,
+                      })
+                    }}
+                  />
+                )}
               </DataGridCell>
             </DataGridRow>
           ))

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -86,8 +86,29 @@ export const ServiceImageVersions = ({ service, showFullTable, onVersionSelect }
 
   const columnCount = 7
 
+  const selectImageVersion = useCallback(
+    ({ service, imageVersion }: { service: ServiceType; imageVersion: ServiceImageVersion }) => {
+      dispatch({
+        type: ActionType.SelectImageVersion,
+        payload: {
+          service,
+          imageVersion,
+          showPanel: true,
+        },
+      })
+    },
+    []
+  )
+
   const showServiceDetails = useCallback(
     ({ service, imageVersion }: { service: ServiceType; imageVersion?: ServiceImageVersion }) => {
+      if (imageVersion) {
+        onVersionSelect?.(imageVersion)
+        selectImageVersion({
+          service,
+          imageVersion,
+        })
+      }
       dispatch({
         type: ActionType.SelectView,
         payload: {
@@ -99,20 +120,7 @@ export const ServiceImageVersions = ({ service, showFullTable, onVersionSelect }
         },
       })
     },
-    []
-  )
-
-  const selectImageVersion = useCallback(
-    ({ service, imageVersion }: { service: ServiceType; imageVersion: ServiceImageVersion }) => {
-      dispatch({
-        type: ActionType.SelectImageVersion,
-        payload: {
-          service,
-          imageVersion,
-        },
-      })
-    },
-    []
+    [onVersionSelect, selectImageVersion]
   )
 
   return (
@@ -197,6 +205,7 @@ export const ServiceImageVersions = ({ service, showFullTable, onVersionSelect }
               <DataGridCell>{version.issueCounts.low || "-"}</DataGridCell>
               <DataGridCell>
                 <Button
+                  size="small"
                   label="Show Details"
                   onClick={(e) => {
                     e.stopPropagation()

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -122,7 +122,7 @@ export const ServiceImageVersions = ({ service, showFullTable, onVersionSelect }
         },
       })
     },
-    [onVersionSelect, selectImageVersion]
+    [onVersionSelect, selectImageVersion, dispatch]
   )
 
   return (

--- a/apps/heureka/src/components/Services/useFetchServiceImageVersions.ts
+++ b/apps/heureka/src/components/Services/useFetchServiceImageVersions.ts
@@ -8,6 +8,7 @@ import { isNil } from "lodash"
 import {
   Page,
   ComponentVersionOrderByField,
+  ComponentInstanceOrderByField,
   OrderDirection,
   useGetServiceImageVersionsLazyQuery,
 } from "../../generated/graphql"
@@ -40,6 +41,20 @@ export const useFetchServiceImageVersions = ({ serviceCcrn, pageSize = 10 }: Use
               direction: OrderDirection.Desc,
             },
           ],
+          // Add component instances ordering and filtering
+          orderByCi: [
+            {
+              by: ComponentInstanceOrderByField.Cluster,
+              direction: OrderDirection.Asc,
+            },
+            {
+              by: ComponentInstanceOrderByField.Namespace,
+              direction: OrderDirection.Asc,
+            },
+          ],
+          filterCi: {
+            serviceCcrn: [serviceCcrn],
+          },
         },
         fetchPolicy: "network-only",
       }),

--- a/apps/heureka/src/components/Services/utils.ts
+++ b/apps/heureka/src/components/Services/utils.ts
@@ -13,6 +13,7 @@ import {
   ServiceEdge,
   ServiceFilter,
   IssueMatchConnection,
+  ComponentInstanceConnection,
   GetServiceImageVersionsQuery,
 } from "../../generated/graphql"
 import { ServiceType } from "./Services"
@@ -143,6 +144,7 @@ type ServiceImageVersion = {
   repository: string
   ccrn: string
   issueCounts: IssuesCountsType
+  componentInstances?: ComponentInstanceConnection | null
 }
 
 type NormalizedServiceImageVersions = {
@@ -175,6 +177,7 @@ export const getNormalizedImageVersionsData = (
               low: 0,
               none: 0,
             },
+            componentInstances: edge?.node?.componentInstances,
           })
         ),
 })

--- a/apps/heureka/src/components/Services/utils.ts
+++ b/apps/heureka/src/components/Services/utils.ts
@@ -140,6 +140,7 @@ export const getActiveServiceFilter = (filterSettings: FilterSettings): ServiceF
 type ServiceImageVersion = {
   version: string
   tag: string
+  repository: string
   ccrn: string
   issueCounts: IssuesCountsType
 }
@@ -165,6 +166,7 @@ export const getNormalizedImageVersionsData = (
           (edge): ServiceImageVersion => ({
             version: edge?.node?.version || "",
             tag: edge?.node?.tag || "",
+            repository: edge?.node?.repository || "",
             ccrn: edge?.node?.component?.ccrn || "",
             issueCounts: edge?.node?.issueCounts || {
               critical: 0,

--- a/apps/heureka/src/components/common/Breadcrumb/Breadcrumb.tsx
+++ b/apps/heureka/src/components/common/Breadcrumb/Breadcrumb.tsx
@@ -26,7 +26,10 @@ export const Breadcrumb = () => {
     <BreadcrumbContainer className="mb-6">
       <BreadcrumbItem icon="home" label="Services" onClick={() => handleClick(UserView.Services)} />
       {selectedView.viewId === UserView.ServiceDetails && (
-        <BreadcrumbItem label={capitalizeFirstLetter((selectedView.params as ServiceDetailViewParams).service.name)} />
+        <BreadcrumbItem
+          label={capitalizeFirstLetter((selectedView.params as ServiceDetailViewParams).service.name)}
+          disabled
+        />
       )}
     </BreadcrumbContainer>
   )

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -194,12 +194,14 @@ export type ComponentInstance = Node & {
   cluster?: Maybe<Scalars["String"]["output"]>
   componentVersion?: Maybe<ComponentVersion>
   componentVersionId?: Maybe<Scalars["String"]["output"]>
+  container?: Maybe<Scalars["String"]["output"]>
   count?: Maybe<Scalars["Int"]["output"]>
   domain?: Maybe<Scalars["String"]["output"]>
   id: Scalars["ID"]["output"]
   issueMatches?: Maybe<IssueMatchConnection>
   metadata?: Maybe<Metadata>
   namespace?: Maybe<Scalars["String"]["output"]>
+  pod?: Maybe<Scalars["String"]["output"]>
   project?: Maybe<Scalars["String"]["output"]>
   region?: Maybe<Scalars["String"]["output"]>
   service?: Maybe<Service>
@@ -229,8 +231,10 @@ export type ComponentInstanceFilter = {
   ccrn?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   cluster?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   componentVersionDigest?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
+  container?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   domain?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   namespace?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
+  pod?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   project?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   region?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   search?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
@@ -243,8 +247,10 @@ export type ComponentInstanceFilterValue = {
   __typename?: "ComponentInstanceFilterValue"
   ccrn?: Maybe<FilterItem>
   cluster?: Maybe<FilterItem>
+  container?: Maybe<FilterItem>
   domain?: Maybe<FilterItem>
   namespace?: Maybe<FilterItem>
+  pod?: Maybe<FilterItem>
   project?: Maybe<FilterItem>
   region?: Maybe<FilterItem>
   serviceCcrn?: Maybe<FilterItem>
@@ -259,11 +265,19 @@ export type ComponentInstanceFilterValueClusterArgs = {
   filter?: InputMaybe<ComponentInstanceFilter>
 }
 
+export type ComponentInstanceFilterValueContainerArgs = {
+  filter?: InputMaybe<ComponentInstanceFilter>
+}
+
 export type ComponentInstanceFilterValueDomainArgs = {
   filter?: InputMaybe<ComponentInstanceFilter>
 }
 
 export type ComponentInstanceFilterValueNamespaceArgs = {
+  filter?: InputMaybe<ComponentInstanceFilter>
+}
+
+export type ComponentInstanceFilterValuePodArgs = {
   filter?: InputMaybe<ComponentInstanceFilter>
 }
 
@@ -287,9 +301,11 @@ export type ComponentInstanceInput = {
   ccrn?: InputMaybe<Scalars["String"]["input"]>
   cluster?: InputMaybe<Scalars["String"]["input"]>
   componentVersionId?: InputMaybe<Scalars["String"]["input"]>
+  container?: InputMaybe<Scalars["String"]["input"]>
   count?: InputMaybe<Scalars["Int"]["input"]>
   domain?: InputMaybe<Scalars["String"]["input"]>
   namespace?: InputMaybe<Scalars["String"]["input"]>
+  pod?: InputMaybe<Scalars["String"]["input"]>
   project?: InputMaybe<Scalars["String"]["input"]>
   region?: InputMaybe<Scalars["String"]["input"]>
   serviceId?: InputMaybe<Scalars["String"]["input"]>
@@ -303,8 +319,10 @@ export type ComponentInstanceOrderBy = {
 export enum ComponentInstanceOrderByField {
   Ccrn = "ccrn",
   Cluster = "cluster",
+  Container = "container",
   Domain = "domain",
   Namespace = "namespace",
+  Pod = "pod",
   Project = "project",
   Region = "region",
 }
@@ -1609,8 +1627,8 @@ export type GetServiceImageVersionsQuery = {
               region?: string | null
               cluster?: string | null
               namespace?: string | null
-              domain?: string | null
-              project?: string | null
+              pod?: string | null
+              container?: string | null
             }
           } | null>
           pageInfo?: {
@@ -1769,8 +1787,8 @@ export const GetServiceImageVersionsDocument = gql`
                 region
                 cluster
                 namespace
-                domain
-                project
+                pod
+                container
               }
             }
             pageInfo {

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -92,6 +92,7 @@ export type Cvss = {
   __typename?: "CVSS"
   base?: Maybe<CvssBase>
   environmental?: Maybe<CvssEnvironmental>
+  externalUrl?: Maybe<Scalars["String"]["output"]>
   temporal?: Maybe<CvssTemporal>
   vector?: Maybe<Scalars["String"]["output"]>
 }
@@ -227,6 +228,7 @@ export type ComponentInstanceEdge = Edge & {
 export type ComponentInstanceFilter = {
   ccrn?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   cluster?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
+  componentVersionDigest?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   domain?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   namespace?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   project?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
@@ -772,6 +774,7 @@ export enum IssueTypes {
 export type IssueVariant = Node & {
   __typename?: "IssueVariant"
   description?: Maybe<Scalars["String"]["output"]>
+  externalUrl?: Maybe<Scalars["String"]["output"]>
   id: Scalars["ID"]["output"]
   issue?: Maybe<Issue>
   issueId?: Maybe<Scalars["String"]["output"]>
@@ -803,6 +806,7 @@ export type IssueVariantFilter = {
 
 export type IssueVariantInput = {
   description?: InputMaybe<Scalars["String"]["input"]>
+  externalUrl?: InputMaybe<Scalars["String"]["input"]>
   issueId?: InputMaybe<Scalars["String"]["input"]>
   issueRepositoryId?: InputMaybe<Scalars["String"]["input"]>
   secondaryName?: InputMaybe<Scalars["String"]["input"]>
@@ -1609,6 +1613,11 @@ export type GetServiceImageVersionsQuery = {
               project?: string | null
             }
           } | null>
+          pageInfo?: {
+            __typename?: "PageInfo"
+            pageNumber?: number | null
+            pages?: Array<{ __typename?: "Page"; after?: string | null; pageNumber?: number | null } | null> | null
+          } | null
         } | null
       }
     } | null>
@@ -1762,6 +1771,13 @@ export const GetServiceImageVersionsDocument = gql`
                 namespace
                 domain
                 project
+              }
+            }
+            pageInfo {
+              pageNumber
+              pages {
+                after
+                pageNumber
               }
             }
           }

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -240,11 +240,36 @@ export type ComponentInstanceFilter = {
 export type ComponentInstanceFilterValue = {
   __typename?: "ComponentInstanceFilterValue"
   ccrn?: Maybe<FilterItem>
+  cluster?: Maybe<FilterItem>
+  domain?: Maybe<FilterItem>
+  namespace?: Maybe<FilterItem>
+  project?: Maybe<FilterItem>
+  region?: Maybe<FilterItem>
   serviceCcrn?: Maybe<FilterItem>
   supportGroupCcrn?: Maybe<FilterItem>
 }
 
 export type ComponentInstanceFilterValueCcrnArgs = {
+  filter?: InputMaybe<ComponentInstanceFilter>
+}
+
+export type ComponentInstanceFilterValueClusterArgs = {
+  filter?: InputMaybe<ComponentInstanceFilter>
+}
+
+export type ComponentInstanceFilterValueDomainArgs = {
+  filter?: InputMaybe<ComponentInstanceFilter>
+}
+
+export type ComponentInstanceFilterValueNamespaceArgs = {
+  filter?: InputMaybe<ComponentInstanceFilter>
+}
+
+export type ComponentInstanceFilterValueProjectArgs = {
+  filter?: InputMaybe<ComponentInstanceFilter>
+}
+
+export type ComponentInstanceFilterValueRegionArgs = {
   filter?: InputMaybe<ComponentInstanceFilter>
 }
 
@@ -459,6 +484,7 @@ export type IssueIssueMatchesArgs = {
   after?: InputMaybe<Scalars["String"]["input"]>
   filter?: InputMaybe<IssueMatchFilter>
   first?: InputMaybe<Scalars["Int"]["input"]>
+  orderBy?: InputMaybe<Array<InputMaybe<IssueMatchOrderBy>>>
 }
 
 export type IssueIssueVariantsArgs = {
@@ -1548,6 +1574,7 @@ export type GetServiceImageVersionsQuery = {
       node: {
         __typename?: "ComponentVersion"
         tag?: string | null
+        repository?: string | null
         version?: string | null
         issueCounts?: {
           __typename?: "SeverityCounts"
@@ -1685,6 +1712,7 @@ export const GetServiceImageVersionsDocument = gql`
       edges {
         node {
           tag
+          repository
           version
           issueCounts {
             critical

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -283,8 +283,13 @@ export type ComponentInstanceFilterValueSupportGroupCcrnArgs = {
 
 export type ComponentInstanceInput = {
   ccrn?: InputMaybe<Scalars["String"]["input"]>
+  cluster?: InputMaybe<Scalars["String"]["input"]>
   componentVersionId?: InputMaybe<Scalars["String"]["input"]>
   count?: InputMaybe<Scalars["Int"]["input"]>
+  domain?: InputMaybe<Scalars["String"]["input"]>
+  namespace?: InputMaybe<Scalars["String"]["input"]>
+  project?: InputMaybe<Scalars["String"]["input"]>
+  region?: InputMaybe<Scalars["String"]["input"]>
   serviceId?: InputMaybe<Scalars["String"]["input"]>
 }
 
@@ -325,6 +330,7 @@ export type ComponentVersion = Node & {
 
 export type ComponentVersionComponentInstancesArgs = {
   after?: InputMaybe<Scalars["String"]["input"]>
+  filter?: InputMaybe<ComponentInstanceFilter>
   first?: InputMaybe<Scalars["Int"]["input"]>
   orderBy?: InputMaybe<Array<InputMaybe<ComponentInstanceOrderBy>>>
 }
@@ -1562,6 +1568,8 @@ export type GetServiceImageVersionsQueryVariables = Exact<{
   first?: InputMaybe<Scalars["Int"]["input"]>
   after?: InputMaybe<Scalars["String"]["input"]>
   orderBy?: InputMaybe<Array<InputMaybe<ComponentVersionOrderBy>> | InputMaybe<ComponentVersionOrderBy>>
+  orderByCi?: InputMaybe<Array<InputMaybe<ComponentInstanceOrderBy>> | InputMaybe<ComponentInstanceOrderBy>>
+  filterCi?: InputMaybe<ComponentInstanceFilter>
 }>
 
 export type GetServiceImageVersionsQuery = {
@@ -1585,6 +1593,23 @@ export type GetServiceImageVersionsQuery = {
           none: number
         } | null
         component?: { __typename?: "Component"; ccrn?: string | null } | null
+        componentInstances?: {
+          __typename?: "ComponentInstanceConnection"
+          totalCount: number
+          edges: Array<{
+            __typename?: "ComponentInstanceEdge"
+            node: {
+              __typename?: "ComponentInstance"
+              id: string
+              ccrn?: string | null
+              region?: string | null
+              cluster?: string | null
+              namespace?: string | null
+              domain?: string | null
+              project?: string | null
+            }
+          } | null>
+        } | null
       }
     } | null>
     pageInfo?: {
@@ -1707,6 +1732,8 @@ export const GetServiceImageVersionsDocument = gql`
     $first: Int
     $after: String
     $orderBy: [ComponentVersionOrderBy]
+    $orderByCi: [ComponentInstanceOrderBy]
+    $filterCi: ComponentInstanceFilter
   ) {
     ComponentVersions(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
       edges {
@@ -1723,6 +1750,20 @@ export const GetServiceImageVersionsDocument = gql`
           }
           component {
             ccrn
+          }
+          componentInstances(filter: $filterCi, orderBy: $orderByCi) {
+            totalCount
+            edges {
+              node {
+                id
+                ccrn
+                region
+                cluster
+                namespace
+                domain
+                project
+              }
+            }
           }
         }
       }
@@ -1754,6 +1795,8 @@ export const GetServiceImageVersionsDocument = gql`
  *      first: // value for 'first'
  *      after: // value for 'after'
  *      orderBy: // value for 'orderBy'
+ *      orderByCi: // value for 'orderByCi'
+ *      filterCi: // value for 'filterCi'
  *   },
  * });
  */

--- a/apps/heureka/src/graphql/Services/getServiceImageVersions.graphql
+++ b/apps/heureka/src/graphql/Services/getServiceImageVersions.graphql
@@ -6,6 +6,8 @@ query GetServiceImageVersions(
   $first: Int
   $after: String
   $orderBy: [ComponentVersionOrderBy]
+  $orderByCi:[ComponentInstanceOrderBy]
+  $filterCi: ComponentInstanceFilter
 ) {
   ComponentVersions(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
     edges {
@@ -22,6 +24,20 @@ query GetServiceImageVersions(
         }
         component {
           ccrn
+        }
+        componentInstances(filter:$filterCi, orderBy:$orderByCi) {
+          totalCount
+          edges {
+            node {
+              id
+              ccrn
+              region
+              cluster
+              namespace
+              domain
+              project
+            }
+          }
         }
       }
     }

--- a/apps/heureka/src/graphql/Services/getServiceImageVersions.graphql
+++ b/apps/heureka/src/graphql/Services/getServiceImageVersions.graphql
@@ -11,6 +11,7 @@ query GetServiceImageVersions(
     edges {
       node {
         tag
+        repository
         version
         issueCounts {
           critical

--- a/apps/heureka/src/graphql/Services/getServiceImageVersions.graphql
+++ b/apps/heureka/src/graphql/Services/getServiceImageVersions.graphql
@@ -38,6 +38,13 @@ query GetServiceImageVersions(
               project
             }
           }
+          pageInfo {
+      pageNumber
+      pages {
+        after
+        pageNumber
+      }
+    }
         }
       }
     }

--- a/apps/heureka/src/graphql/Services/getServiceImageVersions.graphql
+++ b/apps/heureka/src/graphql/Services/getServiceImageVersions.graphql
@@ -34,8 +34,8 @@ query GetServiceImageVersions(
               region
               cluster
               namespace
-              domain
-              project
+              pod
+              container
             }
           }
           pageInfo {

--- a/apps/heureka/src/store/StoreProvider/stateReducer.ts
+++ b/apps/heureka/src/store/StoreProvider/stateReducer.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Action, ActionType, State } from "./types"
+import { Action, ActionType, State, UserView } from "./types"
 
 /*
  * draft is a mutable copy of the current state which guarantees that our reducer is pure
@@ -15,6 +15,13 @@ export const servicesReducer = (draft: State, action: Action) => {
       draft.selectedView = {
         viewId: action.payload?.viewId,
         params: action.payload.params,
+      }
+      return
+    }
+    case ActionType.SelectImageVersion: {
+      draft.selectedView = {
+        viewId: UserView.ServiceDetails,
+        params: action.payload,
       }
       return
     }

--- a/apps/heureka/src/store/StoreProvider/types.ts
+++ b/apps/heureka/src/store/StoreProvider/types.ts
@@ -4,17 +4,12 @@
  */
 
 import { InitialFilters } from "../../App"
-import { ServiceImageVersion } from "../../components/Services/common/ServiceImageVersions"
+import {
+  ServiceImageVersion,
+  ComponentInstance,
+  ComponentInstancesConnection,
+} from "../../components/Services/common/ServiceImageVersions"
 import { ServiceType } from "../../components/Services/Services"
-
-export type ComponentInstance = {
-  ccrn?: string | null
-  region?: string | null
-  cluster?: string | null
-  namespace?: string | null
-  domain?: string | null
-  project?: string | null
-}
 
 export enum UserView {
   Services = "services",
@@ -30,12 +25,7 @@ export enum ActionType {
 export type ServiceDetailViewParams = {
   service: ServiceType
   imageVersion?: ServiceImageVersion & {
-    componentInstances?: {
-      totalCount: number
-      edges: Array<{
-        node: ComponentInstance
-      } | null>
-    }
+    componentInstances?: ComponentInstancesConnection
   }
 }
 

--- a/apps/heureka/src/store/StoreProvider/types.ts
+++ b/apps/heureka/src/store/StoreProvider/types.ts
@@ -7,6 +7,15 @@ import { InitialFilters } from "../../App"
 import { ServiceImageVersion } from "../../components/Services/common/ServiceImageVersions"
 import { ServiceType } from "../../components/Services/Services"
 
+export type ComponentInstance = {
+  ccrn?: string | null
+  region?: string | null
+  cluster?: string | null
+  namespace?: string | null
+  domain?: string | null
+  project?: string | null
+}
+
 export enum UserView {
   Services = "services",
   ServiceDetails = "service_details",
@@ -20,7 +29,14 @@ export enum ActionType {
 
 export type ServiceDetailViewParams = {
   service: ServiceType
-  imageVersion?: ServiceImageVersion
+  imageVersion?: ServiceImageVersion & {
+    componentInstances?: {
+      totalCount: number
+      edges: Array<{
+        node: ComponentInstance
+      } | null>
+    }
+  }
 }
 
 export type UserViewParams = ServiceDetailViewParams // | ParamsForOtherViews

--- a/apps/heureka/src/store/StoreProvider/types.ts
+++ b/apps/heureka/src/store/StoreProvider/types.ts
@@ -55,7 +55,9 @@ export type SelectUserViewAction = {
 
 export type SelectImageVersionAction = {
   type: ActionType.SelectImageVersion
-  payload: ServiceDetailViewParams
+  payload: ServiceDetailViewParams & {
+    showPanel?: boolean
+  }
 }
 
 export type Action = SelectUserViewAction | SelectImageVersionAction

--- a/apps/heureka/src/store/StoreProvider/types.ts
+++ b/apps/heureka/src/store/StoreProvider/types.ts
@@ -15,6 +15,7 @@ export enum UserView {
 export enum ActionType {
   SelectView = "select_view",
   SelectServiceComponent = "select_service_component",
+  SelectImageVersion = "select_image_version",
 }
 
 export type ServiceDetailViewParams = {
@@ -36,7 +37,12 @@ export type SelectUserViewAction = {
   payload: SelectServiceDetailsPayload | SelectUserViewActionPayload
 }
 
-export type Action = SelectUserViewAction
+export type SelectImageVersionAction = {
+  type: ActionType.SelectImageVersion
+  payload: ServiceDetailViewParams
+}
+
+export type Action = SelectUserViewAction | SelectImageVersionAction
 
 export type State = {
   selectedView: SelectServiceDetailsPayload | SelectUserViewActionPayload


### PR DESCRIPTION
# Summary

This PR adds a third section to the service details page, which displays detailed information about a selected image version. The image version can be selected in two ways:

Directly within the service details page from the image version table, which then reveals the third section with detailed information about the selected image version.

From the panel, where selecting an image version updates the service details page to display the detailed information of that image version, along with the first two sections—one containing service details and the other listing all related image versions for that service.

# Changes Made

- Extended the ServiceDetails component to display detailed information about the selected image version.
- Updated store types and reducers to support selecting an image version action type and updating the store with the selected version.
- Enhanced the ServiceImageVersion component to make rows clickable when displayed within the service details page.
- Replaced `Image Name` with repository in the ServiceImageVersion table, as the image name was too long. Renamed the column to `Image Repository` and adjusted the tests accordingly. This change is reflected in both the service overview panel and the service details page.

# Related Issues

- Issue 1: [link to issue](https://github.com/cloudoperators/juno/issues/799)

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
