### PR TITLE
fix(heureka): fixes the issue of missing current filters when using service pagination

### DIFF
--- a/.changeset/two-squids-brake.md
+++ b/.changeset/two-squids-brake.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+---
+
+Fixes the issue of missing current filters when using service

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -459,6 +459,7 @@ export type IssueIssueMatchesArgs = {
   after?: InputMaybe<Scalars["String"]["input"]>
   filter?: InputMaybe<IssueMatchFilter>
   first?: InputMaybe<Scalars["Int"]["input"]>
+  orderBy?: InputMaybe<Array<InputMaybe<IssueMatchOrderBy>>>
 }
 
 export type IssueIssueVariantsArgs = {


### PR DESCRIPTION
# Summary

Fixes the issue of missing current filters when using service pagination and clarifies code by setting default options directly in `useLazyQuery`, allowing customization within the query function. This eliminates one `useCallback`, making the code clearer and more concise.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- useFetchServices

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npx turbo dev --filter @cloudoperators/juno-app-heureka`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
