### PR TITLE
feat(heureka): creates a standalone component to display issue counts

### DIFF
--- a/apps/heureka/src/components/Services/ServicesList/IssuesCount.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/IssuesCount.tsx
@@ -8,6 +8,7 @@ import { Spinner, Stack, Badge } from "@cloudoperators/juno-ui-components"
 import { FilterSettings } from "../../common/Filters/types"
 import { useFetchServicesCounts } from "../useFetchServicesCounts"
 import { useActions as useMessageActions } from "@cloudoperators/juno-messages-provider"
+import { IssuesCountBadges } from "../../common/IssuesCountBadges"
 
 type StatusBarProps = {
   filterSettings: FilterSettings
@@ -32,13 +33,10 @@ const IssuesCount = ({ filterSettings }: StatusBarProps) => {
   return (
     <Stack className="status-bar bg-theme-background-lvl-1 py-1.5 px-4 my-px text-theme-light" alignment="center">
       <Stack gap="1">
-        <div className="font-bold">All issues:</div>
-        {!error && !loading && (
-          <>
-            <div className="font-bold mr-2">{counts.totalCount}</div>
-            <Badge icon="danger" text={`${counts.critical}`} variant={counts.critical > 0 ? "danger" : "default"} />
-            <Badge icon="warning" text={`${counts.high}`} variant={counts.high > 0 ? "warning" : "default"} />
-          </>
+        {!error && !loading ? (
+          <IssuesCountBadges counts={counts} displayMode="criticalHigh" />
+        ) : (
+          <div className="font-bold">All issues: --</div>
         )}
       </Stack>
       <Stack alignment="center" className="ml-auto">

--- a/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { DataGridRow, DataGridCell, Pill, Badge, Stack, Button } from "@cloudoperators/juno-ui-components"
 import { ServiceType } from "../../Services"
+import { IssuesCountBadges } from "../../../common/IssuesCountBadges"
 
 type ServiceDetailsLabel = {
   [key: string]: string
@@ -44,18 +45,7 @@ export const ServiceListItem = ({ item, selected, onItemClick, onServiceDetailCl
   <DataGridRow className={`cursor-pointer ${selected ? "active" : ""}`} onClick={onItemClick}>
     <DataGridCell>{item.name}</DataGridCell>
     <DataGridCell>
-      <Stack gap="1">
-        <Badge
-          icon="danger"
-          text={`${item.issuesCount.critical}`}
-          variant={item.issuesCount.critical > 0 ? "danger" : "default"}
-        />
-        <Badge
-          icon="warning"
-          text={`${item.issuesCount.high}`}
-          variant={item.issuesCount.critical > 0 ? "warning" : "default"}
-        />
-      </Stack>
+      <IssuesCountBadges counts={item.issuesCount} displayMode="criticalHigh" />
     </DataGridCell>
     <DataGridCell>
       <ServiceDetails serviceDetails={item.serviceDetails} />

--- a/apps/heureka/src/components/Services/useFetchServicesCounts.ts
+++ b/apps/heureka/src/components/Services/useFetchServicesCounts.ts
@@ -20,7 +20,7 @@ export type IssuesCountsType = {
   none: number
 }
 
-type IssuesCountsWithTotalCountType = IssuesCountsType & {
+export type IssuesCountsWithTotalCountType = IssuesCountsType & {
   totalCount: number
 }
 

--- a/apps/heureka/src/components/common/IssuesCountBadges/IssuesCountBadges.tsx
+++ b/apps/heureka/src/components/common/IssuesCountBadges/IssuesCountBadges.tsx
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from "react"
+import { Stack, Badge } from "@cloudoperators/juno-ui-components"
+import { IssuesCountsWithTotalCountType, IssuesCountsType } from "../../Services/useFetchServicesCounts"
+
+type IssuesCountBadgesProps = {
+  counts: IssuesCountsWithTotalCountType | IssuesCountsType
+  displayMode: "all" | "criticalHigh"
+}
+
+export const IssuesCountBadges = ({ counts, displayMode = "all" }: IssuesCountBadgesProps) => {
+  return (
+    <Stack gap="1">
+      {"totalCount" in counts && (
+        <>
+          <div className="font-bold">All issues:</div>
+          <div className="font-bold mr-2">{counts.totalCount}</div>
+        </>
+      )}
+      <Badge icon="danger" text={`${counts.critical}`} variant={counts.critical > 0 ? "danger" : "default"} />
+      <Badge icon="warning" text={`${counts.high}`} variant={counts.high > 0 ? "warning" : "default"} />
+      {displayMode === "all" && (
+        <>
+          <Badge icon="errorOutline" text={`${counts.medium}`} variant={counts.medium > 0 ? "warning" : "default"} />
+          <Badge icon="info" text={`${counts.low}`} variant={counts.low > 0 ? "info" : "default"} />
+          <Badge text={`${counts.none}`} variant="default" />
+        </>
+      )}
+    </Stack>
+  )
+}

--- a/apps/heureka/src/components/common/IssuesCountBadges/index.ts
+++ b/apps/heureka/src/components/common/IssuesCountBadges/index.ts
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { IssuesCountBadges } from "./IssuesCountBadges"


### PR DESCRIPTION
# Summary

Creates a standalone `IssuesCountBadges` component to display issue counts, supporting `IssuesCountsWithTotalCountType` or `IssuesCountsType` based on total count visibility, with a `displayMode` prop (`"all"` | `"criticalHigh"`) for filtering, defaulting to `"all"`.  

# Changes Made

<!-- List the changes that were made in this pull request. -->

- New component IssuesCountBadges
- ServicesList adapted
- ServicesListItem adapted

# Screenshots (if applicable)

![Screenshot 2025-04-01 at 12 11 35](https://github.com/user-attachments/assets/bc6d9f2a-fff3-4b1c-8735-c30e01245f9a)

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npx turbo dev --filter @cloudoperators/juno-app-heureka`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
