### PR TITLE
fix(heureka): adds hover to all lists

### DIFF
--- a/.changeset/sweet-trees-design.md
+++ b/.changeset/sweet-trees-design.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+---
+
+Generalizes classes to highlight lists on hover and applies the class to all lists

--- a/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
+++ b/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
@@ -33,98 +33,96 @@ export const ServiceDetails = () => {
     <MessagesProvider>
       <Breadcrumb />
       <Messages />
-      <Stack gap="8" direction="vertical" className="overflow-auto w-full">
-        {/* Service Information Section */}
-        <Stack gap="6" direction="vertical" className="w-full">
-          <ContentHeading>Service {selectedService.name} Information</ContentHeading>
-          <Stack gap="4" direction="vertical">
-            {/* Service Details Row */}
-            <Stack gap="2" direction="horizontal">
-              <Label text="Service Details: " />
-              <Stack direction="horizontal" gap="2" wrap>
+
+      {/* Service Information Section */}
+      <Stack gap="6" direction="vertical" className="mb-6">
+        <ContentHeading>Service {selectedService.name} Information</ContentHeading>
+        <Stack gap="4" direction="vertical">
+          {/* Service Details Row */}
+          <Stack gap="2" direction="horizontal">
+            <Label text="Service Details: " />
+            <Stack direction="horizontal" gap="2" wrap>
+              <Pill
+                pillKey="service"
+                pillKeyLabel="service"
+                pillValue={selectedService.name}
+                pillValueLabel={selectedService.name}
+              />
+              {selectedService.serviceDetails?.supportGroups?.map((group) => (
                 <Pill
-                  pillKey="service"
-                  pillKeyLabel="service"
-                  pillValue={selectedService.name}
-                  pillValueLabel={selectedService.name}
+                  key={group}
+                  pillKey="support_group"
+                  pillKeyLabel="support_group"
+                  pillValue={group}
+                  pillValueLabel={group}
                 />
-                {selectedService.serviceDetails?.supportGroups?.map((group) => (
-                  <Pill
-                    key={group}
-                    pillKey="support_group"
-                    pillKeyLabel="support_group"
-                    pillValue={group}
-                    pillValueLabel={group}
-                  />
-                ))}
-              </Stack>
+              ))}
             </Stack>
+          </Stack>
 
-            {/* Issues Count Row */}
-            <Stack gap="2" direction="horizontal">
-              <Label text="Number of Issues: " />
-              <Stack direction="horizontal" gap="4" alignment="center">
-                <Stack direction="horizontal" gap="2" alignment="center">
-                  <span>Critical:</span>
-                  <Badge
-                    icon="danger"
-                    text={`${selectedService.issuesCount.critical}`}
-                    variant={selectedService.issuesCount.critical > 0 ? "danger" : "default"}
-                  />
-                </Stack>
-                <Stack direction="horizontal" gap="2" alignment="center">
-                  <span>High:</span>
-                  <Badge
-                    icon="warning"
-                    text={`${selectedService.issuesCount.high}`}
-                    variant={selectedService.issuesCount.high > 0 ? "warning" : "default"}
-                  />
-                </Stack>
-                <Stack direction="horizontal" gap="2" alignment="center">
-                  <span>Medium:</span>
-                  <span>{selectedService.issuesCount?.medium || 0}</span>
-                </Stack>
-                <Stack direction="horizontal" gap="2" alignment="center">
-                  <span>Low:</span>
-                  <span>{selectedService.issuesCount?.low || 0}</span>
-                </Stack>
-                <Stack direction="horizontal" gap="2" alignment="center">
-                  <span>None:</span>
-                  <span>{selectedService.issuesCount?.none || 0}</span>
-                </Stack>
+          {/* Issues Count Row */}
+          <Stack gap="2" direction="horizontal">
+            <Label text="Number of Issues: " />
+            <Stack direction="horizontal" gap="4" alignment="center">
+              <Stack direction="horizontal" gap="2" alignment="center">
+                <span>Critical:</span>
+                <Badge
+                  icon="danger"
+                  text={`${selectedService.issuesCount.critical}`}
+                  variant={selectedService.issuesCount.critical > 0 ? "danger" : "default"}
+                />
               </Stack>
-            </Stack>
-
-            {/* Owner Row */}
-            <Stack gap="2" direction="horizontal">
-              <Label text="Owner: " />
-              <Stack direction="horizontal" gap="2">
-                {selectedService.serviceOwners?.map((owner) => (
-                  <Pill key={owner} pillValue={owner}>
-                    {owner}
-                  </Pill>
-                ))}
+              <Stack direction="horizontal" gap="2" alignment="center">
+                <span>High:</span>
+                <Badge
+                  icon="warning"
+                  text={`${selectedService.issuesCount.high}`}
+                  variant={selectedService.issuesCount.high > 0 ? "warning" : "default"}
+                />
+              </Stack>
+              <Stack direction="horizontal" gap="2" alignment="center">
+                <span>Medium:</span>
+                <span>{selectedService.issuesCount?.medium || 0}</span>
+              </Stack>
+              <Stack direction="horizontal" gap="2" alignment="center">
+                <span>Low:</span>
+                <span>{selectedService.issuesCount?.low || 0}</span>
+              </Stack>
+              <Stack direction="horizontal" gap="2" alignment="center">
+                <span>None:</span>
+                <span>{selectedService.issuesCount?.none || 0}</span>
               </Stack>
             </Stack>
           </Stack>
-        </Stack>
 
-        {/* Image Versions Section */}
-        <Stack className="w-full">
-          <ServiceImageVersions
-            service={selectedService}
-            showFullTable={false}
-            onVersionSelect={(version) => {
-              setSelectedImageVersion(version)
-            }}
-          />
+          {/* Owner Row */}
+          <Stack gap="2" direction="horizontal">
+            <Label text="Owner: " />
+            <Stack direction="horizontal" gap="2">
+              {selectedService.serviceOwners?.map((owner) => (
+                <Pill key={owner} pillValue={owner}>
+                  {owner}
+                </Pill>
+              ))}
+            </Stack>
+          </Stack>
         </Stack>
-
-        {/* Image Version Details Panel */}
-        {selectedImageVersion && (
-          <ImageVersionDetailsPanel imageVersion={selectedImageVersion} onClose={() => setSelectedImageVersion(null)} />
-        )}
       </Stack>
+
+      {/* Image Versions Section */}
+      <ServiceImageVersions
+        service={selectedService}
+        showFullTable={false}
+        selectedImageVersion={selectedImageVersion}
+        onVersionSelect={(version) => {
+          setSelectedImageVersion(version)
+        }}
+      />
+
+      {/* Image Version Details Panel */}
+      {selectedImageVersion && (
+        <ImageVersionDetailsPanel imageVersion={selectedImageVersion} onClose={() => setSelectedImageVersion(null)} />
+      )}
     </MessagesProvider>
   )
 }

--- a/apps/heureka/src/components/Services/ServicesList/ServicesList.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServicesList.tsx
@@ -60,7 +60,7 @@ export const ServicesList = ({ filterSettings }: ServiceListProps) => {
   }, [error])
 
   return (
-    <div className="services">
+    <div className="datagrid-hover">
       <DataGrid minContentColumns={[5]} columns={COLUMN_SPAN}>
         <DataGridRow>
           <DataGridHeadCell>Service</DataGridHeadCell>

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -91,78 +91,80 @@ export const ServiceImageVersions = ({ service, showDetailsButtons }: ServiceIma
           <ContentHeading>Service Image Versions ({totalCount})</ContentHeading>
         )}
       </Stack>
-      <DataGrid columns={columnCount}>
-        <DataGridRow>
-          <DataGridHeadCell>Image Name</DataGridHeadCell>
-          <DataGridHeadCell>Tag</DataGridHeadCell>
-          <DataGridHeadCell>Critical</DataGridHeadCell>
-          <DataGridHeadCell>High</DataGridHeadCell>
-          <DataGridHeadCell>Medium</DataGridHeadCell>
-          <DataGridHeadCell>Low</DataGridHeadCell>
-          {showDetailsButtons && <DataGridHeadCell>Actions</DataGridHeadCell>}
-        </DataGridRow>
-        {loading ? (
-          <EmptyDataGridRow colSpan={columnCount}>Loading...</EmptyDataGridRow>
-        ) : imageVersions?.length === 0 && !error ? (
-          <EmptyDataGridRow colSpan={columnCount}>No image versions available.</EmptyDataGridRow>
-        ) : (
-          formattedImageVersions.map((version, index) => (
-            <DataGridRow key={index}>
-              <DataGridCell className="service-image-versions-cell">
-                <Stack gap="1" direction="vertical">
-                  <Stack gap="0.5" direction="vertical">
-                    <span>{version.imageName}</span>
-                    <span className="text-sm text-theme-light">{version.imageVersion}</span>
+      <div className="datagrid-hover">
+        <DataGrid columns={columnCount}>
+          <DataGridRow>
+            <DataGridHeadCell>Image Name</DataGridHeadCell>
+            <DataGridHeadCell>Tag</DataGridHeadCell>
+            <DataGridHeadCell>Critical</DataGridHeadCell>
+            <DataGridHeadCell>High</DataGridHeadCell>
+            <DataGridHeadCell>Medium</DataGridHeadCell>
+            <DataGridHeadCell>Low</DataGridHeadCell>
+            {showDetailsButtons && <DataGridHeadCell>Actions</DataGridHeadCell>}
+          </DataGridRow>
+          {loading ? (
+            <EmptyDataGridRow colSpan={columnCount}>Loading...</EmptyDataGridRow>
+          ) : imageVersions?.length === 0 && !error ? (
+            <EmptyDataGridRow colSpan={columnCount}>No image versions available.</EmptyDataGridRow>
+          ) : (
+            formattedImageVersions.map((version, index) => (
+              <DataGridRow key={index}>
+                <DataGridCell className="service-image-versions-cell">
+                  <Stack gap="1" direction="vertical">
+                    <Stack gap="0.5" direction="vertical">
+                      <span>{version.imageName}</span>
+                      <span className="text-sm text-theme-light">{version.imageVersion}</span>
+                    </Stack>
+                    <Stack gap="1" alignment="center">
+                      <a
+                        href={`https://${version.imageName}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:underline text-sm"
+                      >
+                        <Stack gap="1.5" alignment="center">
+                          <Icon icon="openInNew" size="16" color="jn-global-text" onClick={() => {}} />
+                          <span>Image registery</span>
+                        </Stack>
+                      </a>
+                    </Stack>
                   </Stack>
-                  <Stack gap="1" alignment="center">
-                    <a
-                      href={`https://${version.imageName}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="hover:underline text-sm"
-                    >
-                      <Stack gap="1.5" alignment="center">
-                        <Icon icon="openInNew" size="16" color="jn-global-text" onClick={() => {}} />
-                        <span>Image registery</span>
-                      </Stack>
-                    </a>
-                  </Stack>
-                </Stack>
-              </DataGridCell>
-              <DataGridCell className="service-image-versions-cell">{version.imageTag}</DataGridCell>
-              <DataGridCell>
-                {version.issueCounts.critical ? (
-                  <Badge icon text={version.issueCounts.critical.toString()} variant="danger" />
-                ) : (
-                  "-"
-                )}
-              </DataGridCell>
-              <DataGridCell>
-                {version.issueCounts.high ? (
-                  <Badge icon text={version.issueCounts.high.toString()} variant="warning" />
-                ) : (
-                  "-"
-                )}
-              </DataGridCell>
-              <DataGridCell>{version.issueCounts.medium || "-"}</DataGridCell>
-              <DataGridCell>{version.issueCounts.low || "-"}</DataGridCell>
-              {showDetailsButtons && (
-                <DataGridCell>
-                  <Button
-                    label="Show Details"
-                    onClick={() =>
-                      showServiceDetails({
-                        service,
-                        imageVersion: version,
-                      })
-                    }
-                  />
                 </DataGridCell>
-              )}
-            </DataGridRow>
-          ))
-        )}
-      </DataGrid>
+                <DataGridCell className="service-image-versions-cell">{version.imageTag}</DataGridCell>
+                <DataGridCell>
+                  {version.issueCounts.critical ? (
+                    <Badge icon text={version.issueCounts.critical.toString()} variant="danger" />
+                  ) : (
+                    "-"
+                  )}
+                </DataGridCell>
+                <DataGridCell>
+                  {version.issueCounts.high ? (
+                    <Badge icon text={version.issueCounts.high.toString()} variant="warning" />
+                  ) : (
+                    "-"
+                  )}
+                </DataGridCell>
+                <DataGridCell>{version.issueCounts.medium || "-"}</DataGridCell>
+                <DataGridCell>{version.issueCounts.low || "-"}</DataGridCell>
+                {showDetailsButtons && (
+                  <DataGridCell>
+                    <Button
+                      label="Show Details"
+                      onClick={() =>
+                        showServiceDetails({
+                          service,
+                          imageVersion: version,
+                        })
+                      }
+                    />
+                  </DataGridCell>
+                )}
+              </DataGridRow>
+            ))
+          )}
+        </DataGrid>
+      </div>
       {totalNumberOfPages > 1 && (
         <Stack distribution="end">
           <Pagination

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -21,6 +21,7 @@ import { useFetchServiceImageVersions } from "../../useFetchServiceImageVersions
 import { useDispatch } from "../../../../store/StoreProvider"
 import { ActionType, UserView } from "../../../../store/StoreProvider/types"
 import { ServiceType } from "../../Services"
+import ServiceImageVersionsItem from "./ServiceImageVersionsItem"
 
 export type ComponentInstance = {
   id: string
@@ -59,10 +60,16 @@ export type ServiceImageVersion = {
 type ServiceImageVersionsProps = {
   service: ServiceType
   showFullTable?: boolean
+  selectedImageVersion?: ServiceImageVersion | null
   onVersionSelect?: (version: ServiceImageVersion) => void
 }
 
-export const ServiceImageVersions = ({ service, showFullTable, onVersionSelect }: ServiceImageVersionsProps) => {
+export const ServiceImageVersions = ({
+  service,
+  selectedImageVersion,
+  showFullTable,
+  onVersionSelect,
+}: ServiceImageVersionsProps) => {
   const dispatch = useDispatch()
   const { name: serviceName } = service
   const { loading, imageVersions, error, totalNumberOfPages, currentPage, goToPage, totalCount } =
@@ -156,72 +163,26 @@ export const ServiceImageVersions = ({ service, showFullTable, onVersionSelect }
             <EmptyDataGridRow colSpan={columnCount}>No image versions available.</EmptyDataGridRow>
           ) : (
             formattedImageVersions.map((version, index) => (
-              <DataGridRow
+              <ServiceImageVersionsItem
                 key={index}
-                onClick={() => {
+                version={version}
+                selected={selectedImageVersion?.imageVersion === version.imageVersion}
+                displayDetailsButton={showFullTable || false}
+                onItemClick={() => {
                   onVersionSelect?.(version)
                   selectImageVersion({
                     service,
                     imageVersion: version,
                   })
                 }}
-                className={`cursor-pointer ${onVersionSelect ? "active" : ""}`}
-              >
-                <DataGridCell className="service-image-versions-cell">
-                  <Stack gap="1" direction="vertical">
-                    <Stack gap="0.5" direction="vertical">
-                      <span>{version.imageRepository}</span>
-                      <span className="text-sm text-theme-light">{version.imageVersion}</span>
-                    </Stack>
-                    <Stack gap="1" alignment="center">
-                      <a
-                        href={`https://${version.imageName}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:underline text-sm"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <Stack gap="1.5" alignment="center">
-                          <Icon icon="openInNew" size="16" color="jn-global-text" />
-                          <span>Image registery</span>
-                        </Stack>
-                      </a>
-                    </Stack>
-                  </Stack>
-                </DataGridCell>
-                <DataGridCell className="service-image-versions-cell">{version.imageTag}</DataGridCell>
-                <DataGridCell>
-                  {version.issueCounts.critical ? (
-                    <Badge icon text={version.issueCounts.critical.toString()} variant="danger" />
-                  ) : (
-                    "-"
-                  )}
-                </DataGridCell>
-                <DataGridCell>
-                  {version.issueCounts.high ? (
-                    <Badge icon text={version.issueCounts.high.toString()} variant="warning" />
-                  ) : (
-                    "-"
-                  )}
-                </DataGridCell>
-                <DataGridCell>{version.issueCounts.medium || "-"}</DataGridCell>
-                <DataGridCell>{version.issueCounts.low || "-"}</DataGridCell>
-                <DataGridCell>
-                  {showFullTable && (
-                    <Button
-                      size="small"
-                      label="Show Details"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        showServiceDetails({
-                          service,
-                          imageVersion: version,
-                        })
-                      }}
-                    />
-                  )}
-                </DataGridCell>
-              </DataGridRow>
+                onDetailClick={(e: React.MouseEvent<HTMLDivElement>) => {
+                  e.stopPropagation()
+                  showServiceDetails({
+                    service,
+                    imageVersion: version,
+                  })
+                }}
+              />
             ))
           )}
         </DataGrid>

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -7,11 +7,8 @@ import React, { useCallback } from "react"
 import {
   DataGrid,
   DataGridRow,
-  DataGridCell,
   DataGridHeadCell,
   Button,
-  Badge,
-  Icon,
   Stack,
   Pagination,
   ContentHeading,

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -175,8 +175,8 @@ export const ServiceImageVersions = ({
                     imageVersion: version,
                   })
                 }}
-                onDetailClick={(e: React.MouseEvent<HTMLDivElement>) => {
-                  e.stopPropagation()
+                onDetailClick={(event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+                  event.stopPropagation()
                   showServiceDetails({
                     service,
                     imageVersion: version,

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
@@ -6,7 +6,7 @@ type ServiceImageVersionsItemProps = {
   version: ServiceImageVersion
   selected: boolean
   displayDetailsButton: boolean
-  onItemClick: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>
+  onItemClick: React.MouseEventHandler<HTMLDivElement>
   onDetailClick: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>
 }
 

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
@@ -1,0 +1,64 @@
+import React from "react"
+import { ServiceImageVersion } from "./ServiceImageVersions"
+import { DataGridRow, DataGridCell, Button, Badge, Icon, Stack } from "@cloudoperators/juno-ui-components"
+
+type ServiceImageVersionsItemProps = {
+  version: ServiceImageVersion
+  selected: boolean
+  displayDetailsButton: boolean
+  onItemClick: () => void
+  onDetailClick: (e: React.MouseEvent<HTMLDivElement>) => void
+}
+
+const ServiceImageVersionsItem = ({
+  version,
+  selected = false,
+  displayDetailsButton = true,
+  onItemClick,
+  onDetailClick,
+}: ServiceImageVersionsItemProps) => {
+  return (
+    <DataGridRow onClick={onItemClick} className={`cursor-pointer ${selected ? "active" : ""}`}>
+      <DataGridCell className="service-image-versions-cell">
+        <Stack gap="1" direction="vertical">
+          <Stack gap="0.5" direction="vertical">
+            <span>{version.imageRepository}</span>
+            <span className="text-sm text-theme-light">{version.imageVersion}</span>
+          </Stack>
+          <Stack gap="1" alignment="center">
+            <a
+              href={`https://${version.imageName}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline text-sm"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Stack gap="1.5" alignment="center">
+                <Icon icon="openInNew" size="16" color="jn-global-text" />
+                <span>Image registery</span>
+              </Stack>
+            </a>
+          </Stack>
+        </Stack>
+      </DataGridCell>
+      <DataGridCell className="service-image-versions-cell">{version.imageTag}</DataGridCell>
+      <DataGridCell>
+        {version.issueCounts.critical ? (
+          <Badge icon text={version.issueCounts.critical.toString()} variant="danger" />
+        ) : (
+          "-"
+        )}
+      </DataGridCell>
+      <DataGridCell>
+        {version.issueCounts.high ? <Badge icon text={version.issueCounts.high.toString()} variant="warning" /> : "-"}
+      </DataGridCell>
+      <DataGridCell>{version.issueCounts.medium || "-"}</DataGridCell>
+      <DataGridCell>{version.issueCounts.low || "-"}</DataGridCell>
+      <DataGridCell>
+        {displayDetailsButton && <Button size="small" label="Show Details" onClick={onDetailClick} />}
+      </DataGridCell>
+    </DataGridRow>
+  )
+}
+
+export default ServiceImageVersionsItem

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from "react"
 import { ServiceImageVersion } from "./ServiceImageVersions"
 import { DataGridRow, DataGridCell, Button, Badge, Icon, Stack } from "@cloudoperators/juno-ui-components"

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
@@ -6,8 +6,8 @@ type ServiceImageVersionsItemProps = {
   version: ServiceImageVersion
   selected: boolean
   displayDetailsButton: boolean
-  onItemClick: () => void
-  onDetailClick: (e: React.MouseEvent<HTMLDivElement>) => void
+  onItemClick: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>
+  onDetailClick: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>
 }
 
 const ServiceImageVersionsItem = ({

--- a/apps/heureka/src/styles.scss
+++ b/apps/heureka/src/styles.scss
@@ -8,7 +8,7 @@
 
 // datagrid row hover style
 // REMOVE THIS ONCE DATAGRID COMPONENT SUPPORTS HOVER
-.services {
+.datagrid-hover {
   .juno-datagrid-row:hover {
     .juno-datagrid-cell {
       @apply bg-theme-background-lvl-1;


### PR DESCRIPTION
# Summary

Generalizes classes to highlight lists on hover and applies the class to all lists.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Added generic class to highlight datagrids
- Added the class to all existing lists
- Removed not necessary Stack components in ServiceDetails
- Removed also unnecessary classes `overflow-auto` and `w-full`
- Split ServiceImageVersions into two components to render independent the list items.

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npx turbo dev --filter @cloudoperators/juno-app-heureka`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
