### PR TITLE
chore(heureka): cleanup imageversions types

### DIFF
--- a/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
+++ b/apps/heureka/src/components/Services/ServiceDetails/ServiceDetails.tsx
@@ -5,12 +5,13 @@
 
 import React, { useState } from "react"
 import { ContentHeading, Stack, Badge, Pill, Label } from "@cloudoperators/juno-ui-components"
-import { ServiceImageVersions, ServiceImageVersion } from "../common/ServiceImageVersions"
+import { ServiceImageVersions } from "../common/ServiceImageVersions"
 import { ImageVersionDetailsPanel } from "../common/ImageVersionDetailsPanel/ImageVersionDetailsPanel"
 import { MessagesProvider, Messages } from "@cloudoperators/juno-messages-provider"
 import { useStore } from "../../../store/StoreProvider"
 import { SelectServiceDetailsPayload, UserView } from "../../../store/StoreProvider/types"
 import { Breadcrumb } from "../../common/Breadcrumb"
+import { ServiceImageVersion } from "../utils"
 
 export const ServiceDetails = () => {
   const { selectedView } = useStore()

--- a/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionDetailsPanel.tsx
+++ b/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionDetailsPanel.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from "react"
 import { Panel, PanelBody, Stack, ContentHeading, Badge, Pill, Label } from "@cloudoperators/juno-ui-components"
-import { ServiceImageVersion } from "../ServiceImageVersions"
+import { ServiceImageVersion } from "../../utils"
 
 type ImageVersionDetailsPanelProps = {
   imageVersion: ServiceImageVersion
@@ -16,7 +16,7 @@ export const ImageVersionDetailsPanel = ({ imageVersion, onClose }: ImageVersion
   const [showOccurrences, setShowOccurrences] = useState(false)
 
   return (
-    <Panel heading={`Image ${imageVersion.imageRepository} Information`} opened={true} onClose={onClose} size="large">
+    <Panel heading={`Image ${imageVersion.repository} Information`} opened={true} onClose={onClose} size="large">
       <PanelBody>
         <Stack gap="6" direction="vertical" className="w-full">
           <Stack gap="4" direction="vertical">
@@ -24,23 +24,18 @@ export const ImageVersionDetailsPanel = ({ imageVersion, onClose }: ImageVersion
             <Stack gap="2" direction="horizontal">
               <Label text="Image Details: " />
               <Stack direction="horizontal" gap="2" wrap>
-                <Pill
-                  pillKey="tag"
-                  pillKeyLabel="tag"
-                  pillValue={imageVersion.imageTag}
-                  pillValueLabel={imageVersion.imageTag}
-                />
+                <Pill pillKey="tag" pillKeyLabel="tag" pillValue={imageVersion.tag} pillValueLabel={imageVersion.tag} />
                 <Pill
                   pillKey="repository"
                   pillKeyLabel="repository"
-                  pillValue={imageVersion.imageRepository}
-                  pillValueLabel={imageVersion.imageRepository}
+                  pillValue={imageVersion.repository}
+                  pillValueLabel={imageVersion.repository}
                 />
                 <Pill
                   pillKey="version"
                   pillKeyLabel="version"
-                  pillValue={imageVersion.imageVersion}
-                  pillValueLabel={imageVersion.imageVersion}
+                  pillValue={imageVersion.version}
+                  pillValueLabel={imageVersion.version}
                 />
               </Stack>
             </Stack>
@@ -85,20 +80,20 @@ export const ImageVersionDetailsPanel = ({ imageVersion, onClose }: ImageVersion
                   className="hover:underline text-sm"
                 >
                   {showOccurrences ? "Hide Occurrences" : "Show Occurrences"} (
-                  {imageVersion.componentInstances?.totalCount || 0})
+                  {imageVersion.componetInstancesCount || 0})
                 </a>
               </Stack>
               {showOccurrences && (
                 <Stack gap="4" direction="vertical" className="pl-4">
-                  {imageVersion.componentInstances && imageVersion.componentInstances.edges.length > 0 ? (
+                  {imageVersion.componentInstances && imageVersion.componentInstances.length > 0 ? (
                     <Stack gap="2" direction="vertical">
-                      {imageVersion.componentInstances.edges.map((edge) => (
-                        <Stack key={`${edge?.node?.ccrn}-${edge?.node?.id}`} gap="2" direction="vertical">
-                          <span>{edge?.node?.region || "-"}</span>
-                          <span>{edge?.node?.cluster || "-"}</span>
-                          <span>{edge?.node?.namespace || "-"}</span>
-                          <span>{edge?.node?.pod || "-"}</span>
-                          <span>{edge?.node?.container || "-"}</span>
+                      {imageVersion.componentInstances.map((componentInstance) => (
+                        <Stack key={`${componentInstance?.ccrn}-${componentInstance?.id}`} gap="2" direction="vertical">
+                          <span>{componentInstance?.region || "-"}</span>
+                          <span>{componentInstance?.cluster || "-"}</span>
+                          <span>{componentInstance?.namespace || "-"}</span>
+                          <span>{componentInstance?.pod || "-"}</span>
+                          <span>{componentInstance?.container || "-"}</span>
                         </Stack>
                       ))}
                     </Stack>

--- a/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionDetailsPanel.tsx
+++ b/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionDetailsPanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react"
-import { Panel, PanelBody, Stack, ContentHeading, Badge, Pill, Label } from "@cloudoperators/juno-ui-components"
+import { Panel, PanelBody, Stack, Badge, Pill, Label } from "@cloudoperators/juno-ui-components"
 import { ServiceImageVersion } from "../../utils"
 
 type ImageVersionDetailsPanelProps = {

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -19,40 +19,7 @@ import { useDispatch } from "../../../../store/StoreProvider"
 import { ActionType, UserView } from "../../../../store/StoreProvider/types"
 import { ServiceType } from "../../Services"
 import ServiceImageVersionsItem from "./ServiceImageVersionsItem"
-
-export type ComponentInstance = {
-  id: string
-  ccrn?: string | ""
-  region?: string | ""
-  cluster?: string | ""
-  namespace?: string | ""
-  pod?: string | ""
-  container?: string | ""
-}
-
-export type ComponentInstancesConnection = {
-  totalCount: number
-  edges: Array<{
-    node: ComponentInstance
-  } | null>
-}
-
-export type ServiceImageVersion = {
-  imageName: string
-  imageVersion: string
-  imageTag: string
-  imageRepository: string
-  issueCounts: {
-    critical: number
-    high: number
-    medium: number
-    low: number
-    none: number
-  }
-  serviceName: string
-  totalCount?: number
-  componentInstances?: ComponentInstancesConnection
-}
+import { ServiceImageVersion } from "../../utils"
 
 type ServiceImageVersionsProps = {
   service: ServiceType
@@ -60,6 +27,8 @@ type ServiceImageVersionsProps = {
   selectedImageVersion?: ServiceImageVersion | null
   onVersionSelect?: (version: ServiceImageVersion) => void
 }
+
+const COLUMN_COUNT = 7
 
 export const ServiceImageVersions = ({
   service,
@@ -74,23 +43,6 @@ export const ServiceImageVersions = ({
       serviceCcrn: serviceName || "",
       pageSize: 10,
     })
-
-  const formattedImageVersions = imageVersions.map((version) => ({
-    imageName: version.ccrn,
-    imageVersion: version.version,
-    imageTag: version.tag,
-    imageRepository: version.repository,
-    issueCounts: version.issueCounts,
-    serviceName,
-    componentInstances: version.componentInstances
-      ? {
-          totalCount: version.componentInstances.totalCount,
-          edges: version.componentInstances.edges,
-        }
-      : undefined,
-  }))
-
-  const columnCount = 7
 
   const selectImageVersion = useCallback(
     ({ service, imageVersion }: { service: ServiceType; imageVersion: ServiceImageVersion }) => {
@@ -144,7 +96,7 @@ export const ServiceImageVersions = ({
         )}
       </Stack>
       <div className="datagrid-hover">
-        <DataGrid columns={columnCount}>
+        <DataGrid columns={COLUMN_COUNT}>
           <DataGridRow>
             <DataGridHeadCell>Image Repository</DataGridHeadCell>
             <DataGridHeadCell>Tag</DataGridHeadCell>
@@ -155,28 +107,28 @@ export const ServiceImageVersions = ({
             <DataGridHeadCell></DataGridHeadCell>
           </DataGridRow>
           {loading ? (
-            <EmptyDataGridRow colSpan={columnCount}>Loading...</EmptyDataGridRow>
+            <EmptyDataGridRow colSpan={COLUMN_COUNT}>Loading...</EmptyDataGridRow>
           ) : imageVersions?.length === 0 && !error ? (
-            <EmptyDataGridRow colSpan={columnCount}>No image versions available.</EmptyDataGridRow>
+            <EmptyDataGridRow colSpan={COLUMN_COUNT}>No image versions available.</EmptyDataGridRow>
           ) : (
-            formattedImageVersions.map((version, index) => (
+            imageVersions.map((imageVersion, index) => (
               <ServiceImageVersionsItem
                 key={index}
-                version={version}
-                selected={selectedImageVersion?.imageVersion === version.imageVersion}
+                version={imageVersion}
+                selected={selectedImageVersion?.version === imageVersion.version}
                 displayDetailsButton={showFullTable || false}
                 onItemClick={() => {
-                  onVersionSelect?.(version)
+                  onVersionSelect?.(imageVersion)
                   selectImageVersion({
                     service,
-                    imageVersion: version,
+                    imageVersion: imageVersion,
                   })
                 }}
                 onDetailClick={(event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
                   event.stopPropagation()
                   showServiceDetails({
                     service,
-                    imageVersion: version,
+                    imageVersion: imageVersion,
                   })
                 }}
               />

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
@@ -32,7 +32,7 @@ const ServiceImageVersionsItem = ({
           </Stack>
           <Stack gap="1" alignment="center">
             <a
-              href={`https://${version.imageName}`}
+              href={`https://${version.ccrn}`}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:underline text-sm"

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react"
-import { ServiceImageVersion } from "./ServiceImageVersions"
+import { ServiceImageVersion } from "../../utils"
 import { DataGridRow, DataGridCell, Button, Badge, Icon, Stack } from "@cloudoperators/juno-ui-components"
 
 type ServiceImageVersionsItemProps = {
@@ -27,8 +27,8 @@ const ServiceImageVersionsItem = ({
       <DataGridCell className="service-image-versions-cell">
         <Stack gap="1" direction="vertical">
           <Stack gap="0.5" direction="vertical">
-            <span>{version.imageRepository}</span>
-            <span className="text-sm text-theme-light">{version.imageVersion}</span>
+            <span>{version.repository}</span>
+            <span className="text-sm text-theme-light">{version.version}</span>
           </Stack>
           <Stack gap="1" alignment="center">
             <a
@@ -46,7 +46,7 @@ const ServiceImageVersionsItem = ({
           </Stack>
         </Stack>
       </DataGridCell>
-      <DataGridCell className="service-image-versions-cell">{version.imageTag}</DataGridCell>
+      <DataGridCell className="service-image-versions-cell">{version.tag}</DataGridCell>
       <DataGridCell>
         {version.issueCounts.critical ? (
           <Badge icon text={version.issueCounts.critical.toString()} variant="danger" />

--- a/apps/heureka/src/components/Services/utils.ts
+++ b/apps/heureka/src/components/Services/utils.ts
@@ -13,7 +13,6 @@ import {
   ServiceEdge,
   ServiceFilter,
   IssueMatchConnection,
-  ComponentInstanceConnection,
   GetServiceImageVersionsQuery,
 } from "../../generated/graphql"
 import { ServiceType } from "./Services"
@@ -138,13 +137,24 @@ export const getActiveServiceFilter = (filterSettings: FilterSettings): ServiceF
     }, {}),
 })
 
-type ServiceImageVersion = {
+type ComponentInstance = {
+  id: string
+  ccrn?: string | ""
+  region?: string | ""
+  cluster?: string | ""
+  namespace?: string | ""
+  pod?: string | ""
+  container?: string | ""
+}
+
+export type ServiceImageVersion = {
   version: string
   tag: string
   repository: string
   ccrn: string
   issueCounts: IssuesCountsType
-  componentInstances?: ComponentInstanceConnection | null
+  componetInstancesCount: number
+  componentInstances?: ComponentInstance[]
 }
 
 type NormalizedServiceImageVersions = {
@@ -177,7 +187,19 @@ export const getNormalizedImageVersionsData = (
               low: 0,
               none: 0,
             },
-            componentInstances: edge?.node?.componentInstances,
+            componetInstancesCount: edge?.node?.componentInstances?.totalCount ?? 0,
+            componentInstances:
+              edge?.node?.componentInstances?.edges
+                ?.filter((edge) => edge?.node) // Remove null edges
+                .map((edge) => ({
+                  id: edge!.node.id,
+                  ccrn: edge!.node.ccrn ?? "",
+                  region: edge!.node.region ?? "",
+                  cluster: edge!.node.cluster ?? "",
+                  namespace: edge!.node.namespace ?? "",
+                  pod: edge!.node.pod ?? "",
+                  container: edge!.node.container ?? "",
+                })) ?? [],
           })
         ),
 })

--- a/apps/heureka/src/store/StoreProvider/types.ts
+++ b/apps/heureka/src/store/StoreProvider/types.ts
@@ -4,12 +4,8 @@
  */
 
 import { InitialFilters } from "../../App"
-import {
-  ServiceImageVersion,
-  ComponentInstance,
-  ComponentInstancesConnection,
-} from "../../components/Services/common/ServiceImageVersions"
 import { ServiceType } from "../../components/Services/Services"
+import { ServiceImageVersion } from "../../components/Services/utils"
 
 export enum UserView {
   Services = "services",
@@ -24,9 +20,7 @@ export enum ActionType {
 
 export type ServiceDetailViewParams = {
   service: ServiceType
-  imageVersion?: ServiceImageVersion & {
-    componentInstances?: ComponentInstancesConnection
-  }
+  imageVersion?: ServiceImageVersion
 }
 
 export type UserViewParams = ServiceDetailViewParams // | ParamsForOtherViews


### PR DESCRIPTION
# Summary

Cleaned up image version types by removing duplicates and unnecessary mappings that caused confusion. Now, only the essential types are created during fetching and reused throughout the application.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Unified types
- Normalised ComponentInstance to own types because of simplicity

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npx turbo dev --filter @cloudoperators/juno-app-heureka`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
