### PR TITLE
chore(heureka): shows counts separate columns in lists

### DIFF
--- a/.changeset/silver-boxes-crash.md
+++ b/.changeset/silver-boxes-crash.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+Displays each count in a separate column within lists

--- a/apps/heureka/src/components/Services/ServicePanel/ServicePanel.test.tsx
+++ b/apps/heureka/src/components/Services/ServicePanel/ServicePanel.test.tsx
@@ -51,7 +51,6 @@ describe("ServicePanel", () => {
     // Check if table headers are rendered
     expect(await screen.findByText("Image Repository")).toBeInTheDocument()
     expect(await screen.findByText("Tag")).toBeInTheDocument()
-    expect(await screen.findByText("Issue Counts")).toBeInTheDocument()
   })
 
   // TODO: enable this test after having router

--- a/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
@@ -43,7 +43,7 @@ type ServiceListItemProps = {
 export const ServiceListItem = ({ item, selected, onItemClick, onServiceDetailClick }: ServiceListItemProps) => (
   <DataGridRow className={`cursor-pointer ${selected ? "active" : ""}`} onClick={onItemClick}>
     <DataGridCell>{item.name}</DataGridCell>
-    <DataGridCell>
+    <DataGridCell className="items-center">
       <SeverityCount
         count={item.issuesCount.critical}
         icon="danger"
@@ -51,10 +51,10 @@ export const ServiceListItem = ({ item, selected, onItemClick, onServiceDetailCl
         tooltipContent="Critical Issues"
       />
     </DataGridCell>
-    <DataGridCell>
+    <DataGridCell className="items-center">
       <SeverityCount count={item.issuesCount.high} icon="warning" variant="warning" tooltipContent="High Issues" />
     </DataGridCell>
-    <DataGridCell>
+    <DataGridCell className="items-center">
       <SeverityCount
         count={item.issuesCount.medium}
         icon="errorOutline"
@@ -62,10 +62,10 @@ export const ServiceListItem = ({ item, selected, onItemClick, onServiceDetailCl
         tooltipContent="Medium Issues"
       />
     </DataGridCell>
-    <DataGridCell>
+    <DataGridCell className="items-center">
       <SeverityCount count={item.issuesCount.low} icon="info" variant="info" tooltipContent="Low Issues" />
     </DataGridCell>
-    <DataGridCell>
+    <DataGridCell className="items-center">
       <SeverityCount count={item.issuesCount.none} icon="help" variant="default" tooltipContent="None Issues" />
     </DataGridCell>
     <DataGridCell>

--- a/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
@@ -6,8 +6,8 @@
 import React from "react"
 import { DataGridRow, DataGridCell, Pill, Badge, Stack, Button } from "@cloudoperators/juno-ui-components"
 import { ServiceType } from "../../Services"
-import { IssuesCountBadges } from "../../../common/IssuesCountBadges"
-
+// import { IssuesCountBadges } from "../../../common/IssuesCountBadges"
+import { SeverityCount } from "../../../common/IssuesCountBadges/IssuesCount"
 type ServiceDetailsLabel = {
   [key: string]: string
 }
@@ -44,9 +44,35 @@ type ServiceListItemProps = {
 export const ServiceListItem = ({ item, selected, onItemClick, onServiceDetailClick }: ServiceListItemProps) => (
   <DataGridRow className={`cursor-pointer ${selected ? "active" : ""}`} onClick={onItemClick}>
     <DataGridCell>{item.name}</DataGridCell>
-    <DataGridCell>
+    {/* <DataGridCell>
       <IssuesCountBadges counts={item.issuesCount} />
+    </DataGridCell> */}
+    <DataGridCell>
+      <SeverityCount
+        count={item.issuesCount.critical}
+        icon="danger"
+        variant="danger"
+        tooltipContent="Critical Issues"
+      />
     </DataGridCell>
+    <DataGridCell>
+      <SeverityCount count={item.issuesCount.high} icon="warning" variant="warning" tooltipContent="High Issues" />
+    </DataGridCell>
+    <DataGridCell>
+      <SeverityCount
+        count={item.issuesCount.medium}
+        icon="errorOutline"
+        variant="warning"
+        tooltipContent="Medium Issues"
+      />
+    </DataGridCell>
+    <DataGridCell>
+      <SeverityCount count={item.issuesCount.low} icon="info" variant="info" tooltipContent="Low Issues" />
+    </DataGridCell>
+    <DataGridCell>
+      <SeverityCount count={item.issuesCount.none} icon="help" variant="default" tooltipContent="None Issues" />
+    </DataGridCell>
+
     <DataGridCell>
       <ServiceDetails serviceDetails={item.serviceDetails} />
     </DataGridCell>

--- a/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
@@ -44,19 +44,29 @@ export const ServiceListItem = ({ item, selected, onItemClick, onServiceDetailCl
   <DataGridRow className={`cursor-pointer ${selected ? "active" : ""}`} onClick={onItemClick}>
     <DataGridCell>{item.name}</DataGridCell>
     <DataGridCell>
-    <SeverityCount count={item.issuesCount.critical} icon="danger" variant="danger" tooltipContent="Critical Issues" />
+      <SeverityCount
+        count={item.issuesCount.critical}
+        icon="danger"
+        variant="danger"
+        tooltipContent="Critical Issues"
+      />
     </DataGridCell>
     <DataGridCell>
-    <SeverityCount count={item.issuesCount.high} icon="warning" variant="warning" tooltipContent="High Issues" />
+      <SeverityCount count={item.issuesCount.high} icon="warning" variant="warning" tooltipContent="High Issues" />
     </DataGridCell>
     <DataGridCell>
-    <SeverityCount count={item.issuesCount.medium} icon="errorOutline" variant="warning" tooltipContent="Medium Issues" />
+      <SeverityCount
+        count={item.issuesCount.medium}
+        icon="errorOutline"
+        variant="warning"
+        tooltipContent="Medium Issues"
+      />
     </DataGridCell>
     <DataGridCell>
-    <SeverityCount count={item.issuesCount.low} icon="info" variant="info" tooltipContent="Low Issues" />
+      <SeverityCount count={item.issuesCount.low} icon="info" variant="info" tooltipContent="Low Issues" />
     </DataGridCell>
     <DataGridCell>
-    <SeverityCount count={item.issuesCount.none} icon="help" variant="default" tooltipContent="None Issues" />
+      <SeverityCount count={item.issuesCount.none} icon="help" variant="default" tooltipContent="None Issues" />
     </DataGridCell>
     <DataGridCell>
       <ServiceDetails serviceDetails={item.serviceDetails} />

--- a/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServiceListItem/ServiceListItem.tsx
@@ -6,7 +6,6 @@
 import React from "react"
 import { DataGridRow, DataGridCell, Pill, Badge, Stack, Button } from "@cloudoperators/juno-ui-components"
 import { ServiceType } from "../../Services"
-// import { IssuesCountBadges } from "../../../common/IssuesCountBadges"
 import { SeverityCount } from "../../../common/IssuesCountBadges/IssuesCount"
 type ServiceDetailsLabel = {
   [key: string]: string
@@ -44,35 +43,21 @@ type ServiceListItemProps = {
 export const ServiceListItem = ({ item, selected, onItemClick, onServiceDetailClick }: ServiceListItemProps) => (
   <DataGridRow className={`cursor-pointer ${selected ? "active" : ""}`} onClick={onItemClick}>
     <DataGridCell>{item.name}</DataGridCell>
-    {/* <DataGridCell>
-      <IssuesCountBadges counts={item.issuesCount} />
-    </DataGridCell> */}
     <DataGridCell>
-      <SeverityCount
-        count={item.issuesCount.critical}
-        icon="danger"
-        variant="danger"
-        tooltipContent="Critical Issues"
-      />
+    <SeverityCount count={item.issuesCount.critical} icon="danger" variant="danger" tooltipContent="Critical Issues" />
     </DataGridCell>
     <DataGridCell>
-      <SeverityCount count={item.issuesCount.high} icon="warning" variant="warning" tooltipContent="High Issues" />
+    <SeverityCount count={item.issuesCount.high} icon="warning" variant="warning" tooltipContent="High Issues" />
     </DataGridCell>
     <DataGridCell>
-      <SeverityCount
-        count={item.issuesCount.medium}
-        icon="errorOutline"
-        variant="warning"
-        tooltipContent="Medium Issues"
-      />
+    <SeverityCount count={item.issuesCount.medium} icon="errorOutline" variant="warning" tooltipContent="Medium Issues" />
     </DataGridCell>
     <DataGridCell>
-      <SeverityCount count={item.issuesCount.low} icon="info" variant="info" tooltipContent="Low Issues" />
+    <SeverityCount count={item.issuesCount.low} icon="info" variant="info" tooltipContent="Low Issues" />
     </DataGridCell>
     <DataGridCell>
-      <SeverityCount count={item.issuesCount.none} icon="help" variant="default" tooltipContent="None Issues" />
+    <SeverityCount count={item.issuesCount.none} icon="help" variant="default" tooltipContent="None Issues" />
     </DataGridCell>
-
     <DataGridCell>
       <ServiceDetails serviceDetails={item.serviceDetails} />
     </DataGridCell>

--- a/apps/heureka/src/components/Services/ServicesList/ServicesList.test.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServicesList.test.tsx
@@ -32,7 +32,6 @@ describe("ServicesList", () => {
 
     // Check for the presence of the service list headers
     expect(await screen.findByText("Service")).toBeInTheDocument()
-    expect(await screen.findByText("Issues count")).toBeInTheDocument()
     expect(await screen.findByText("Service details")).toBeInTheDocument()
   })
 

--- a/apps/heureka/src/components/Services/ServicesList/ServicesList.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServicesList.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useCallback, useEffect, useState } from "react"
-import { DataGrid, DataGridRow, DataGridHeadCell, Pagination, Stack } from "@cloudoperators/juno-ui-components"
+import { DataGrid, DataGridRow, DataGridHeadCell, Pagination, Stack, Spinner } from "@cloudoperators/juno-ui-components"
 import { ServiceListItem } from "./ServiceListItem"
 import { EmptyDataGridRow } from "../../common/EmptyDataGridRow/EmptyDataGridRow"
 import { useActions as useMessageActions } from "@cloudoperators/juno-messages-provider"
@@ -74,7 +74,14 @@ export const ServicesList = ({ filterSettings }: ServiceListProps) => {
         </DataGridRow>
         {
           /* if request is in flight */
-          loading && <EmptyDataGridRow colSpan={COLUMN_SPAN}>Loading...</EmptyDataGridRow>
+          loading && (
+            <EmptyDataGridRow colSpan={COLUMN_SPAN}>
+              <Stack gap="2" alignment="center">
+                <div>Loading</div>
+                <Spinner variant="primary"></Spinner>
+              </Stack>
+            </EmptyDataGridRow>
+          )
         }
 
         {

--- a/apps/heureka/src/components/Services/ServicesList/ServicesList.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServicesList.tsx
@@ -16,7 +16,7 @@ import { FilterSettings } from "../../common/Filters/types"
 import { useDispatch } from "../../../store/StoreProvider"
 import { ActionType, UserView } from "../../../store/StoreProvider/types"
 
-const COLUMN_SPAN = 4
+const COLUMN_SPAN = 8
 
 type ServiceListProps = {
   filterSettings: FilterSettings
@@ -61,10 +61,14 @@ export const ServicesList = ({ filterSettings }: ServiceListProps) => {
 
   return (
     <div className="datagrid-hover">
-      <DataGrid minContentColumns={[3]} columns={COLUMN_SPAN}>
+      <DataGrid minContentColumns={[1, 2, 3, 4, 5, 7]} columns={COLUMN_SPAN}>
         <DataGridRow>
           <DataGridHeadCell>Service</DataGridHeadCell>
-          <DataGridHeadCell>Issues count</DataGridHeadCell>
+          <DataGridHeadCell></DataGridHeadCell>
+          <DataGridHeadCell></DataGridHeadCell>
+          <DataGridHeadCell></DataGridHeadCell>
+          <DataGridHeadCell></DataGridHeadCell>
+          <DataGridHeadCell></DataGridHeadCell>
           <DataGridHeadCell>Service details</DataGridHeadCell>
           <DataGridHeadCell></DataGridHeadCell>
         </DataGridRow>

--- a/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionIssuesList.tsx
+++ b/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionIssuesList.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect } from "react"
-import { DataGrid, DataGridRow, DataGridHeadCell, Icon, Stack, Pagination } from "@cloudoperators/juno-ui-components"
+import { DataGrid, DataGridRow, DataGridHeadCell, Icon, Stack, Pagination, Spinner } from "@cloudoperators/juno-ui-components"
 import { EmptyDataGridRow } from "../../../common/EmptyDataGridRow/EmptyDataGridRow"
 import { useFetchServiceImageVersionIssues } from "../../useFetchServiceImageVersionIssues"
 import { ImageVersionIssueListItem } from "./ImageVersionIssueListItem"
@@ -52,9 +52,9 @@ export const ImageVersionIssuesList = ({ serviceCcrn, imageVersion }: ImageVersi
         </DataGridRow>
 
         {isLoading ? (
-          <EmptyDataGridRow colSpan={4}>Loading issues...</EmptyDataGridRow>
+          <EmptyDataGridRow colSpan={4}><Stack gap="2" alignment="center"><div>Loading issues</div><Spinner variant="primary"></Spinner></Stack></EmptyDataGridRow>
         ) : issues.length === 0 ? (
-          <EmptyDataGridRow colSpan={4}>No issues found.</EmptyDataGridRow>
+          <EmptyDataGridRow colSpan={4}>No issues found! 🚀</EmptyDataGridRow>
         ) : (
           !error && issues.map((issue, index) => <ImageVersionIssueListItem key={index} issue={issue} />)
         )}

--- a/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionIssuesList.tsx
+++ b/apps/heureka/src/components/Services/common/ImageVersionDetailsPanel/ImageVersionIssuesList.tsx
@@ -4,7 +4,15 @@
  */
 
 import React, { useEffect } from "react"
-import { DataGrid, DataGridRow, DataGridHeadCell, Icon, Stack, Pagination, Spinner } from "@cloudoperators/juno-ui-components"
+import {
+  DataGrid,
+  DataGridRow,
+  DataGridHeadCell,
+  Icon,
+  Stack,
+  Pagination,
+  Spinner,
+} from "@cloudoperators/juno-ui-components"
 import { EmptyDataGridRow } from "../../../common/EmptyDataGridRow/EmptyDataGridRow"
 import { useFetchServiceImageVersionIssues } from "../../useFetchServiceImageVersionIssues"
 import { ImageVersionIssueListItem } from "./ImageVersionIssueListItem"
@@ -52,7 +60,12 @@ export const ImageVersionIssuesList = ({ serviceCcrn, imageVersion }: ImageVersi
         </DataGridRow>
 
         {isLoading ? (
-          <EmptyDataGridRow colSpan={4}><Stack gap="2" alignment="center"><div>Loading issues</div><Spinner variant="primary"></Spinner></Stack></EmptyDataGridRow>
+          <EmptyDataGridRow colSpan={4}>
+            <Stack gap="2" alignment="center">
+              <div>Loading issues</div>
+              <Spinner variant="primary"></Spinner>
+            </Stack>
+          </EmptyDataGridRow>
         ) : issues.length === 0 ? (
           <EmptyDataGridRow colSpan={4}>No issues found! 🚀</EmptyDataGridRow>
         ) : (

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -29,7 +29,7 @@ type ServiceImageVersionsProps = {
   onVersionSelect?: (version: ServiceImageVersion) => void
 }
 
-const COLUMN_COUNT = 4
+const COLUMN_COUNT = 8
 
 export const ServiceImageVersions = ({
   service,
@@ -96,11 +96,15 @@ export const ServiceImageVersions = ({
       )}
 
       <div className="datagrid-hover">
-        <DataGrid columns={gridColumnCount}>
+        <DataGrid columns={gridColumnCount} minContentColumns={[2, 3, 4, 5]}>
           <DataGridRow>
             <DataGridHeadCell>Image Repository</DataGridHeadCell>
             <DataGridHeadCell>Tag</DataGridHeadCell>
-            <DataGridHeadCell>Issue Counts</DataGridHeadCell>
+            <DataGridHeadCell></DataGridHeadCell>
+            <DataGridHeadCell></DataGridHeadCell>
+            <DataGridHeadCell></DataGridHeadCell>
+            <DataGridHeadCell></DataGridHeadCell>
+            <DataGridHeadCell></DataGridHeadCell>
             {displayActions && <DataGridHeadCell></DataGridHeadCell>}
           </DataGridRow>
           {loading ? (

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersions.tsx
@@ -12,6 +12,7 @@ import {
   Stack,
   Pagination,
   DataGridToolbar,
+  Spinner,
 } from "@cloudoperators/juno-ui-components"
 import { EmptyDataGridRow } from "../../../common/EmptyDataGridRow/EmptyDataGridRow"
 import { useFetchServiceImageVersions } from "../../useFetchServiceImageVersions"
@@ -108,9 +109,14 @@ export const ServiceImageVersions = ({
             {displayActions && <DataGridHeadCell></DataGridHeadCell>}
           </DataGridRow>
           {loading ? (
-            <EmptyDataGridRow colSpan={gridColumnCount}>Loading...</EmptyDataGridRow>
+            <EmptyDataGridRow colSpan={gridColumnCount}>
+              <Stack gap="2" alignment="center">
+                <div>Loading</div>
+                <Spinner variant="primary"></Spinner>
+              </Stack>
+            </EmptyDataGridRow>
           ) : imageVersions?.length === 0 && !error ? (
-            <EmptyDataGridRow colSpan={gridColumnCount}>No image versions available.</EmptyDataGridRow>
+            <EmptyDataGridRow colSpan={gridColumnCount}>No images available.</EmptyDataGridRow>
           ) : (
             imageVersions.map((imageVersion, index) => (
               <ServiceImageVersionsItem

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
@@ -6,7 +6,7 @@
 import React from "react"
 import { ServiceImageVersion } from "../../utils"
 import { DataGridRow, DataGridCell, Button, Badge, Icon, Stack } from "@cloudoperators/juno-ui-components"
-import { IssuesCountBadges } from "../../../common/IssuesCountBadges"
+import { SeverityCount } from "../../../common/IssuesCountBadges/IssuesCount"
 
 type ServiceImageVersionsItemProps = {
   version: ServiceImageVersion
@@ -49,7 +49,29 @@ const ServiceImageVersionsItem = ({
       </DataGridCell>
       <DataGridCell className="service-image-versions-cell">{version.tag}</DataGridCell>
       <DataGridCell>
-        <IssuesCountBadges counts={version.issueCounts} />
+        <SeverityCount
+          count={version.issueCounts.critical}
+          icon="danger"
+          variant="danger"
+          tooltipContent="Critical Issues"
+        />
+      </DataGridCell>
+      <DataGridCell>
+        <SeverityCount count={version.issueCounts.high} icon="warning" variant="warning" tooltipContent="High Issues" />
+      </DataGridCell>
+      <DataGridCell>
+        <SeverityCount
+          count={version.issueCounts.medium}
+          icon="errorOutline"
+          variant="warning"
+          tooltipContent="Medium Issues"
+        />
+      </DataGridCell>
+      <DataGridCell>
+        <SeverityCount count={version.issueCounts.low} icon="info" variant="info" tooltipContent="Low Issues" />
+      </DataGridCell>
+      <DataGridCell>
+        <SeverityCount count={version.issueCounts.none} icon="help" variant="default" tooltipContent="None Issues" />
       </DataGridCell>
       {displayDetailsButton && (
         <DataGridCell>

--- a/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
+++ b/apps/heureka/src/components/Services/common/ServiceImageVersions/ServiceImageVersionsItem.tsx
@@ -41,14 +41,14 @@ const ServiceImageVersionsItem = ({
             >
               <Stack gap="1.5" alignment="center">
                 <Icon icon="openInNew" size="16" color="jn-global-text" />
-                <span>Image registery</span>
+                <span>Image registry</span>
               </Stack>
             </a>
           </Stack>
         </Stack>
       </DataGridCell>
       <DataGridCell className="service-image-versions-cell">{version.tag}</DataGridCell>
-      <DataGridCell>
+      <DataGridCell className="items-center">
         <SeverityCount
           count={version.issueCounts.critical}
           icon="danger"
@@ -56,10 +56,10 @@ const ServiceImageVersionsItem = ({
           tooltipContent="Critical Issues"
         />
       </DataGridCell>
-      <DataGridCell>
+      <DataGridCell className="items-center">
         <SeverityCount count={version.issueCounts.high} icon="warning" variant="warning" tooltipContent="High Issues" />
       </DataGridCell>
-      <DataGridCell>
+      <DataGridCell className="items-center">
         <SeverityCount
           count={version.issueCounts.medium}
           icon="errorOutline"
@@ -67,10 +67,10 @@ const ServiceImageVersionsItem = ({
           tooltipContent="Medium Issues"
         />
       </DataGridCell>
-      <DataGridCell>
+      <DataGridCell className="items-center">
         <SeverityCount count={version.issueCounts.low} icon="info" variant="info" tooltipContent="Low Issues" />
       </DataGridCell>
-      <DataGridCell>
+      <DataGridCell className="items-center">
         <SeverityCount count={version.issueCounts.none} icon="help" variant="default" tooltipContent="None Issues" />
       </DataGridCell>
       {displayDetailsButton && (

--- a/apps/heureka/src/components/common/IssuesCountBadges/IssuesCount.tsx
+++ b/apps/heureka/src/components/common/IssuesCountBadges/IssuesCount.tsx
@@ -25,7 +25,7 @@ export const SeverityCount = ({ count, icon, variant, tooltipContent }: Severity
         <TooltipContent>{tooltipContent}</TooltipContent>
       </Tooltip>
     ) : (
-      <span>-</span>
+      <span>&mdash;</span>
     )}
   </>
 )

--- a/apps/heureka/src/components/common/IssuesCountBadges/IssuesCount.tsx
+++ b/apps/heureka/src/components/common/IssuesCountBadges/IssuesCount.tsx
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from "react"
+import {
+  Badge,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  KnownIcons,
+  BadgeVariantType,
+} from "@cloudoperators/juno-ui-components"
+
+type SeverityCountProps = { count: number; icon: KnownIcons; variant: BadgeVariantType; tooltipContent: string }
+
+export const SeverityCount = ({ count, icon, variant, tooltipContent }: SeverityCountProps) => (
+  <>
+    {count > 0 ? (
+      <Tooltip triggerEvent="hover">
+        <TooltipTrigger>
+          <Badge icon={icon} text={count > 0 ? count.toString() : "-"} variant={count > 0 ? variant : "default"} />
+        </TooltipTrigger>
+        <TooltipContent>{tooltipContent}</TooltipContent>
+      </Tooltip>
+    ) : (
+      <span>-</span>
+    )}
+  </>
+)

--- a/apps/heureka/src/components/common/IssuesCountBadges/IssuesCountBadges.tsx
+++ b/apps/heureka/src/components/common/IssuesCountBadges/IssuesCountBadges.tsx
@@ -10,7 +10,6 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
-  Icon,
   KnownIcons,
   BadgeVariantType,
 } from "@cloudoperators/juno-ui-components"

--- a/apps/heureka/src/components/common/IssuesCountBadges/IssuesCountBadges.tsx
+++ b/apps/heureka/src/components/common/IssuesCountBadges/IssuesCountBadges.tsx
@@ -25,18 +25,23 @@ type ToolTipBadgeType = {
   text: string
   variant: BadgeVariantType
   tooltipContent: string
+  className?: string
 }
 
-const ToolTipBadge = ({ icon, text, variant, tooltipContent }: ToolTipBadgeType) => (
+const ToolTipBadge = ({ icon, text, variant, tooltipContent, className }: ToolTipBadgeType) => (
   <Tooltip triggerEvent="hover">
     <TooltipTrigger>
-      <Badge icon={icon} text={text} variant={variant} />
+      <Badge icon={icon} text={text} variant={variant} className={className} />
     </TooltipTrigger>
     <TooltipContent>{tooltipContent}</TooltipContent>
   </Tooltip>
 )
 
 export const IssuesCountBadges = ({ counts, displayMode = "all" }: IssuesCountBadgesProps) => {
+  if (counts.critical + counts.high + counts.medium + counts.low + counts.none === 0) {
+    return <div>No issues found! 🚀</div>
+  }
+
   return (
     <Stack gap="1">
       {"totalCount" in counts && (
@@ -50,12 +55,14 @@ export const IssuesCountBadges = ({ counts, displayMode = "all" }: IssuesCountBa
         text={`${counts.critical}`}
         variant={counts.critical > 0 ? "danger" : "default"}
         tooltipContent="Critical Issues"
+        className={`${counts.critical > 0 ? "" : "opacity-50"}`}
       />
       <ToolTipBadge
         icon="warning"
         text={`${counts.high}`}
         variant={counts.high > 0 ? "warning" : "default"}
         tooltipContent="High Issues"
+        className={`${counts.high > 0 ? "" : "opacity-50"}`}
       />
       {displayMode === "all" && (
         <>
@@ -64,14 +71,22 @@ export const IssuesCountBadges = ({ counts, displayMode = "all" }: IssuesCountBa
             text={`${counts.medium}`}
             variant={counts.medium > 0 ? "warning" : "default"}
             tooltipContent="Medium Issues"
+            className={`${counts.medium > 0 ? "" : "opacity-50"}`}
           />
           <ToolTipBadge
             icon="info"
             text={`${counts.low}`}
             variant={counts.low > 0 ? "info" : "default"}
             tooltipContent="Low Issues"
+            className={`${counts.low > 0 ? "" : "opacity-50"}`}
           />
-          <ToolTipBadge icon="help" text={`${counts.none}`} variant="default" tooltipContent="None Issues" />
+          <ToolTipBadge
+            icon="help"
+            text={`${counts.none}`}
+            variant="default"
+            tooltipContent="None Issues"
+            className={`${counts.none > 0 ? "" : "opacity-50"}`}
+          />
         </>
       )}
     </Stack>

--- a/apps/heureka/src/components/common/IssuesCountBadges/index.ts
+++ b/apps/heureka/src/components/common/IssuesCountBadges/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { IssuesCountBadges } from "./IssuesCountBadges"
+export { SeverityCount } from "./IssuesCount"


### PR DESCRIPTION
# Summary

The counts per severity are now displayed in separate columns with minimum widths to improve styling.

# Changes Made

- IssueCount component is added to display a badge with a respective icon and color per severity
- Services list and list item are adjusted to use this component
- Image versions list and list item are adjusted to use this component


# Related Issues

- Issue 1: [[link to issue](https://github.com/cloudoperators/juno/issues/622#issuecomment-2770697472)]

# Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/d56e0f29-70eb-459e-9691-69aa6b204066)


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
