### PR TITLE
chore(greenhouse): clarifies that isMock, when set, takes precedence over token-based authentication

### DIFF
--- a/apps/greenhouse/README.md
+++ b/apps/greenhouse/README.md
@@ -48,5 +48,7 @@ These are the customizable application properties (appProps) that you can define
 - **currentHost** (required): `"URL TO ASSETS SERVER"`. This value is usually set by the Widget Loader. If the app is loaded via `import` or `importShim`, this parameter should be set.
 - **apiEndpoint** (required): `"URL TO K8S API"`. This value is necessary to communicate with the Kubernetes API.
 - **mockAuth**: true, false (default), or JSON (optional). Simulates mock authentication; allowed values include boolean, plain JSON objects. When enabled, the application receives a predefined mock token with attributes such as `iss`, `sub`, `aud`, `exp`, `iat`, `nonce`, `email`, `email_verified`, `groups`, `name`, and `preferred_username`. These attributes will be overridden if a JSON object is provided instead of a boolean. Additionally, the organization group will be overridden with the value specified in the URL.
-- **demoOrg** (optional): `"demo"`. If the organization name matches this value, the app will enter demo mode (mock authentication and demo org plugins).
+  **Important:** `mockAuth` takes precedence over both real and token-based authentication, regardless of the organization provided. If set, mock data will be used even when `demoOrg` and `demoUserToken` are defined.
+- **demoOrg** (optional): `"demo"`. If the organization name matches this value, the app will use the demo user token for authentication.
 - **demoUserToken** (optional): `"token for demo user"`. Used for authentication if `demoOrg` and `demoUserToken` are set, and the organization name matches `demoOrg`.
+  **Note:** This is ignored if `mockAuth` is set.


### PR DESCRIPTION
# Summary

This update clarifies the authentication behavior when isMock is set. Specifically, it documents that isMock takes precedence over token-based authentication, regardless of whether a demoUserToken or demoOrg is provided. This ensures developers are aware that mock authentication will override other methods if enabled. The clarification has been added to improve transparency and prevent confusion for the dev setup for the backend.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Greenhouse readme updated.

# Related Issues

- https://github.com/cloudoperators/greenhouse/pull/1049
- https://github.com/cloudoperators/greenhouse/issues/1048

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
