### PR TITLE
feat(greenhouse): propagates token to the Extensions

### DIFF
--- a/.changeset/gentle-walls-poke.md
+++ b/.changeset/gentle-walls-poke.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+Propagates authentication token to the extensions

--- a/apps/greenhouse/src/components/Extensions.tsx
+++ b/apps/greenhouse/src/components/Extensions.tsx
@@ -22,7 +22,7 @@ const CorePlugin = ({ config, auth }: any) => {
   )
 }
 
-const Extension = ({ config }: any) => {
+const Extension = ({ config, auth }: any) => {
   const holder = useRef()
 
   useEffect(() => {
@@ -47,7 +47,7 @@ const Extension = ({ config }: any) => {
 
     loadExtension()
       .then((app) => {
-        app.mount(holder.current, { props: { ...config.props, embedded: true } })
+        app.mount(holder.current, { props: { ...config.props, embedded: true, token: auth?.JWT } })
       })
       .catch((error) => {
         // @ts-expect-error TS(2532): Object is possibly 'undefined'.


### PR DESCRIPTION
# Summary

Propagates the authentication token as appProp to the extensions temporary so it can be used against the API.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Extension loader injects the token as appProp so it can be used to authenticate against the API.

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npx turbo dev --filter @cloudoperators/juno-app-greenhouse`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
