### PR TITLE
chore(heureka): closes image version details panel on reselect in Service Details page

### DIFF
--- a/.changeset/violet-parents-melt.md
+++ b/.changeset/violet-parents-melt.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+Closes image version details panel on reselect in Service Details page

--- a/apps/heureka/src/components/ServiceDetails/index.tsx
+++ b/apps/heureka/src/components/ServiceDetails/index.tsx
@@ -77,7 +77,7 @@ export const ServiceDetails = () => {
         displayActions={false}
         selectedImageVersion={selectedImageVersion}
         onVersionSelect={(version) => {
-          setSelectedImageVersion(version)
+          setSelectedImageVersion(selectedImageVersion?.version === version.version ? null : version)
         }}
       />
       {/* Image Version Details Panel */}


### PR DESCRIPTION
# Summary

This pull request improves the user experience on the Service Details page by ensuring that if an already selected image version is reselected, the corresponding details panel will now close automatically—matching the behavior on the Services List page.

# Changes Made

- Updated the serviceDetails component to handle image version reselection.

# Related Issues

- Issue 1: https://github.com/cloudoperators/juno/issues/887

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
