### PR TITLE
fix(ui): fix DateTimePicker light mode colors

### DIFF
--- a/packages/ui-components/src/components/DateTimePicker/datetimepicker.scss
+++ b/packages/ui-components/src/components/DateTimePicker/datetimepicker.scss
@@ -172,8 +172,8 @@
 }
 .flatpickr-months .flatpickr-month {
   background: var(--color-datepicker-calendar-bg);
-  color: #fff;
-  fill: #fff;
+  color: var(--color-text-highest);
+  fill: var(--color-text-highest);
   height: 34px;
   line-height: 1;
   text-align: center;
@@ -201,8 +201,8 @@
   height: 34px;
   padding: 10px;
   z-index: 3;
-  color: #fff;
-  fill: #fff;
+  color: var(--color-text-highest);
+  fill: var(--color-text-highest);
 }
 .flatpickr-months .flatpickr-prev-month.flatpickr-disabled,
 .flatpickr-months .flatpickr-next-month.flatpickr-disabled {
@@ -246,11 +246,11 @@
       /*rtl:end:ignore*/
 .flatpickr-months .flatpickr-prev-month:hover,
 .flatpickr-months .flatpickr-next-month:hover {
-  color: #eee;
+  color: var(--color-background-lvl-5);
 }
 .flatpickr-months .flatpickr-prev-month:hover svg,
 .flatpickr-months .flatpickr-next-month:hover svg {
-  fill: #f64747;
+  fill: var(--color-accent);
 }
 .flatpickr-months .flatpickr-prev-month svg,
 .flatpickr-months .flatpickr-next-month svg {
@@ -296,10 +296,10 @@
   box-sizing: border-box;
 }
 .numInputWrapper span:hover {
-  background: rgba(192, 187, 167, 0.1);
+  background: rgba(var(--color-background-lvl-5-raw), 0.1);
 }
 .numInputWrapper span:active {
-  background: rgba(192, 187, 167, 0.2);
+  background: rgba(var(--color-background-lvl-5-raw), 0.2);
 }
 .numInputWrapper span:after {
   display: block;
@@ -313,7 +313,7 @@
 .numInputWrapper span.arrowUp:after {
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  border-bottom: 4px solid rgba(255, 255, 255, 0.6);
+  border-bottom: 4px solid rgba(var(--color-text-highest-raw), 0.6);
   top: 26%;
 }
 .numInputWrapper span.arrowDown {
@@ -322,7 +322,7 @@
 .numInputWrapper span.arrowDown:after {
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  border-top: 4px solid rgba(255, 255, 255, 0.6);
+  border-top: 4px solid rgba(var(--color-text-highest-raw), 0.6);
   top: 40%;
 }
 .numInputWrapper span svg {
@@ -330,10 +330,10 @@
   height: auto;
 }
 .numInputWrapper span svg path {
-  fill: rgba(255, 255, 255, 0.5);
+  fill: rgba(var(--color-text-highest-raw), 0.5);
 }
 .numInputWrapper:hover {
-  background: rgba(192, 187, 167, 0.05);
+  background: rgba(var(--color-background-lvl-5-raw), 0.05);
 }
 .numInputWrapper:hover span {
   opacity: 1;
@@ -363,7 +363,7 @@
   padding: 0;
 }
 .flatpickr-current-month span.cur-month:hover {
-  background: rgba(192, 187, 167, 0.05);
+  background: rgba(var(--color-background-lvl-5-raw), 0.05);
 }
 .flatpickr-current-month .numInputWrapper {
   width: 6ch;
@@ -371,10 +371,10 @@
   display: inline-block;
 }
 .flatpickr-current-month .numInputWrapper span.arrowUp:after {
-  border-bottom-color: #fff;
+  border-bottom-color: var(--color-text-highest);
 }
 .flatpickr-current-month .numInputWrapper span.arrowDown:after {
-  border-top-color: #fff;
+  border-top-color: var(--color-text-highest);
 }
 .flatpickr-current-month input.cur-year {
   background: transparent;
@@ -403,7 +403,7 @@
 .flatpickr-current-month input.cur-year[disabled],
 .flatpickr-current-month input.cur-year[disabled]:hover {
   font-size: 100%;
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(var(--color-text-highest-raw), 0.5);
   background: transparent;
   pointer-events: none;
 }
@@ -434,10 +434,10 @@
   outline: none;
 }
 .flatpickr-current-month .flatpickr-monthDropdown-months:hover {
-  background: rgba(192, 187, 167, 0.05);
+  background: rgba(var(--color-background-lvl-5-raw), 0.05);
 }
 .flatpickr-current-month .flatpickr-monthDropdown-months .flatpickr-monthDropdown-month {
-  background-color: #3f4458;
+  background-color: var(--color-background-lvl-5);
   outline: none;
   padding: 0;
 }
@@ -469,7 +469,6 @@
 span.flatpickr-weekday {
   cursor: default;
   font-size: 90%;
-  // background: #3f4458;
   color: var(--color-text-default);
   line-height: 1;
   margin: 0;
@@ -568,8 +567,8 @@ span.flatpickr-weekday {
 .flatpickr-day.nextMonthDay:focus {
   cursor: pointer;
   outline: 0;
-  background: #646c8c;
-  border-color: #646c8c;
+  background: var(--color-background-lvl-5);
+  border-color: var(--color-background-lvl-5);
 }
 .flatpickr-day.today {
   border-color: var(--color-text-default);
@@ -577,7 +576,7 @@ span.flatpickr-weekday {
 .flatpickr-day.today:hover,
 .flatpickr-day.today:focus {
   border-color: var(--color-text-default);
-  background: #eee;
+  background: var(--color-background-lvl-5);
   color: var(--color-text-default);
 }
 .flatpickr-day.selected,
@@ -598,10 +597,10 @@ span.flatpickr-weekday {
 .flatpickr-day.selected.nextMonthDay,
 .flatpickr-day.startRange.nextMonthDay,
 .flatpickr-day.endRange.nextMonthDay {
-  background: var(--color-accent);
+  background: rgba(var(--color-accent-raw), 0.3);
   -webkit-box-shadow: none;
   box-shadow: none;
-  color: #fff;
+  color: var(--color-text-highest);
   border-color: var(--color-accent);
 }
 .flatpickr-day.selected.startRange,
@@ -641,7 +640,7 @@ span.flatpickr-weekday {
 .flatpickr-day.notAllowed,
 .flatpickr-day.notAllowed.prevMonthDay,
 .flatpickr-day.notAllowed.nextMonthDay {
-  color: rgba(255, 255, 255, 0.3);
+  color: rgba(var(--color-text-highest-raw), 0.3);
   background: transparent;
   border-color: transparent;
   cursor: default;
@@ -649,7 +648,7 @@ span.flatpickr-weekday {
 .flatpickr-day.flatpickr-disabled,
 .flatpickr-day.flatpickr-disabled:hover {
   cursor: not-allowed;
-  color: rgba(255, 255, 255, 0.1);
+  color: rgba(var(--color-text-highest-raw), 0.1);
 }
 .flatpickr-day.week.selected {
   border-radius: 0;
@@ -684,7 +683,7 @@ span.flatpickr-weekday {
   display: block;
   width: 100%;
   max-width: none;
-  color: rgba(255, 255, 255, 0.3);
+  color: rgba(var(--color-text-highest-raw), 0.3);
   background: transparent;
   cursor: default;
   border: none;
@@ -782,7 +781,7 @@ span.flatpickr-weekday {
   height: inherit;
   float: left;
   line-height: inherit;
-  color: rgba(255, 255, 255, 0.95);
+  color: rgba(var(--color-text-highest-raw), 0.95);
   font-weight: bold;
   width: 2%;
   -webkit-user-select: none;
@@ -804,7 +803,7 @@ span.flatpickr-weekday {
 .flatpickr-time .flatpickr-am-pm:hover,
 .flatpickr-time input:focus,
 .flatpickr-time .flatpickr-am-pm:focus {
-  background: #6a7395;
+  background: var(--color-background-lvl-5);
 }
 .flatpickr-input[readonly] {
   cursor: pointer;


### PR DESCRIPTION
# Summary

The DateTimePicker component doesn't look good in light mode. 

The reason is that since DateTimePicker is still in WiP mode  many colors were still hardcoded instead of using the proper theme-aware colors which change when switching between light and dark mode.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Replaced most hard-coded colors with theme-aware equivalents

# Related Issues

- Issue 1: #916 

# Screenshots (if applicable)
![Screenshot 2025-04-28 at 17 30 10](https://github.com/user-attachments/assets/04ad9e87-ad2c-4fcc-a93a-2e68cd20aaf3)

# Testing Instructions

1. Check the DateTimePicker component in storybook, switch between light and dark mode

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
