### PR TITLE
chore(k8s): add cjs format to build

### DIFF
--- a/.changeset/giant-ghosts-yell.md
+++ b/.changeset/giant-ghosts-yell.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-k8s-client": patch
+---
+
+add support for common js

--- a/packages/k8s-client/package.json
+++ b/packages/k8s-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudoperators/juno-k8s-client",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "author": "UI-Team",
   "description": "JavaScript client for Kubernetes API",
   "main": "build/index.cjs.js",

--- a/packages/k8s-client/package.json
+++ b/packages/k8s-client/package.json
@@ -17,7 +17,7 @@
     "build/**",
     "LICENCE"
   ],
-  "type": "module",
+
   "scripts": {
     "test": "vitest run",
     "lint": "eslint",

--- a/packages/k8s-client/package.json
+++ b/packages/k8s-client/package.json
@@ -8,6 +8,7 @@
   "types": "build/index.d.ts",
   "exports": {
     ".": {
+      "types": "./build/index.d.ts",
       "import": "./build/index.es.js",
       "require": "./build/index.cjs.js"
     }

--- a/packages/k8s-client/package.json
+++ b/packages/k8s-client/package.json
@@ -1,11 +1,17 @@
 {
   "name": "@cloudoperators/juno-k8s-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "UI-Team",
   "description": "JavaScript client for Kubernetes API",
-  "main": "build/index.js",
-  "module": "build/index.js",
-  "types": "build/types/index.d.ts",
+  "main": "build/index.cjs.js",
+  "module": "build/index.es.js",
+  "types": "build/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./build/index.es.js",
+      "require": "./build/index.cjs.js"
+    }
+  },
   "files": [
     "build/**",
     "LICENCE"

--- a/packages/k8s-client/src/index.ts
+++ b/packages/k8s-client/src/index.ts
@@ -6,3 +6,4 @@
 export { createClient } from "./client"
 export type { RequestOptions } from "./client"
 export type { K8sApiError } from "./apiErrorHandler"
+export { ADDED, MODIFIED, DELETED, ERROR, Watch } from "./watch"

--- a/packages/k8s-client/src/index.ts
+++ b/packages/k8s-client/src/index.ts
@@ -5,3 +5,4 @@
 
 export { createClient } from "./client"
 export type { RequestOptions } from "./client"
+export type { K8sApiError } from "./apiErrorHandler"

--- a/packages/k8s-client/vite.config.ts
+++ b/packages/k8s-client/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
     lib: {
       entry: "src/index.ts", // or 'src/main.ts' if TypeScript
       name: "k8s-client", // Replace with your library's global name
-      formats: ["es"], // Output formats: ESM and CommonJS
-      fileName: () => `index.js`, // Output file names
+      formats: ["es", "cjs"], // Output formats: ESM and CommonJS
+      fileName: (format) => `index.${format}.js`, // Output file names
     },
     outDir: "build",
   },


### PR DESCRIPTION
This pull request (PR) introduces support for the CommonJS module format in our build process. This enhancement ensures better compatibility and interoperability with various JavaScript environments.

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npm i`
2. `npm run TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
