### PR TITLE
chore(ci): add pull-requests: write permission to PR preview workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -33,6 +33,7 @@ concurrency: deploy-pr-preview-${{ github.ref }}
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   DEPLOY_PATH: tmp

--- a/apps/carbon/README.md
+++ b/apps/carbon/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-**Carbon** This is an app that will replace the curent greenhouse app. For now use it as temporary app.
+**Carbon** This app is intended to replace the current Greenhouse app. For now, please use it as a temporary solution.
 
 ## What is inside?
 


### PR DESCRIPTION
# Summary

This PR fixes an issue where the PR preview workflow failed to post a comment with the preview link on the pull request.
Previously, the workflow ran without explicitly defined permissions (defaulting to full access). Due to recent security requirements (e.g. CodeQL), we now set explicit permissions. However, the pull-requests: write permission was missing, which prevented the workflow from commenting on the PR.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Add write permissions to the PR Prview Workflow

# Related Issues

- Same happened with hugo-documentation-templater: https://github.com/sapcc/hugo-documentation-templater/pull/46/files

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
