### PR TITLE
chore(ci): fixes renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "assigneesFromCodeOwners": true,
   "extends": ["config:best-practices"],
-  "enabledManagers": ["pnpm", "github-actions"],
+  "enabledManagers": ["npm", "github-actions"],
   "includePaths": ["packages/ui-components/**", ".github/workflows/**"],
   "updateLockFiles": true,
   "rangeStrategy": "update-lockfile",
@@ -20,8 +20,7 @@
       "matchFileNames": ["packages/ui-components/**"],
       "matchUpdateTypes": ["minor", "patch"],
       "minimumReleaseAge": "7 days",
-      "schedule": "every weekend",
-      "rangeStrategy": "pin"
+      "schedule": "every weekend"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
# Summary

Renovate was not running as expected, and no dependency update PRs were appearing. After investigating the issue, it was found that the Renovate configuration contained validation errors reported by the official validator tool:

```
INFO: Validating .github/renovate.json
ERROR: Found errors in configuration
  "file": ".github/renovate.json",
  "errors": [
    {
      "topic": "Configuration Error",
      "message": "The following managers configured in enabledManagers are not supported: \"pnpm\""
    },
    {
      "topic": "Configuration Error",
      "message": "packageRules[1]: packageRules cannot combine both matchUpdateTypes and rangeStrategy. Rule: {\"groupName\":\"dependencies for ui-components\",\"matchDatasources\":[\"npm\"],\"matchFileNames\":[\"packages/ui-components/**\"],\"matchUpdateTypes\":[\"minor\",\"patch\"],\"minimumReleaseAge\":\"7 days\",\"schedule\":[\"every weekend\"],\"rangeStrategy\":\"pin\"}"
    }
  ]
```

# Changes Made

<!-- List the changes that were made in this pull request. -->

- emoved the unsupported "pnpm" from enabledManagers
- Adjusted the conflicting packageRules to comply with Renovate’s configuration rules

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
