### PR TITLE
chore(ci): add .nojekyll to fix GitHub Pages 404 for files starting with underscores

### DIFF
--- a/.github/workflows/deploy-github-pages.yaml
+++ b/.github/workflows/deploy-github-pages.yaml
@@ -52,6 +52,9 @@ jobs:
       - name: Build storybook
         run: pnpm --filter @cloudoperators/juno-ui-components build-storybook
 
+      - name: Add .nojekyll
+        run: echo > packages/ui-components/storybook-static/.nojekyll
+
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 #v4.7.3
         with:

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-To include Juno UI components as a dev dependency in your app install with pnpm:
+To add Juno UI components to your app as a development dependency, install them using pnpm:
 
 ```bash
 pnpm add @cloudoperators/juno-ui-components


### PR DESCRIPTION
# Summary

GitHub Pages was returning 404 errors for files starting with an underscore (e.g. heureka with file based routing in the pr-preview) due to Jekyll ignoring them by default.
To resolve this, I added an empty .nojekyll file to the root of the gh-pages branch. This disables Jekyll processing and ensures all files are served correctly. To keep the file allways in the root of gh-pages we need to create it on the fly when deploying story-book to github-pages.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Add empty .nojekyll

# Related Issues

- #957

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
