### PR TITLE
chore(ci): removes assigning renovate PRs to specific users

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "assigneesFromCodeOwners": true,
   "extends": ["config:best-practices"],
   "enabledManagers": ["npm", "github-actions"],
   "includePaths": ["packages/ui-components/**", ".github/workflows/**"],


### PR DESCRIPTION
# Summary

Renovate assigns PRs based on the .github/CODEOWNERS (assigneesFromCodeOwners) file. However, by default, it only assigns the last matching user or team from the CODEOWNERS pattern that applies to the changed file(s). To avoid incorrectly assigning a single user to Renovate PRs related to ui-components, especially when that person isn't the appropriate reviewer, the assigneesFromCodeOwners option is being removed. This leaves the PRs unassigned, allowing the relevant experts to either review them directly or assign themselves as needed.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Remove assigneesFromCodeOwners from renovate config

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `npx --yes --package renovate -- renovate-config-validator`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
