### PR TITLE
fix(heureka): removes unnecessary fields from getServices to improve performance

### DIFF
--- a/.changeset/rich-otters-agree.md
+++ b/.changeset/rich-otters-agree.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+fix(heureka): removes unnecessary fields from getServices to improve performance

--- a/apps/heureka/src/components/Services/ServicesList/ServicePanel.test.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServicePanel.test.tsx
@@ -25,7 +25,6 @@ const mockService: ServiceType = {
   serviceDetails: {
     supportGroups: ["group1", "group2"],
   },
-  components: 3,
   remediationDate: "2024-01-01",
   serviceOwners: ["owner1", "owner2"],
 }

--- a/apps/heureka/src/components/Services/ServicesList/index.test.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/index.test.tsx
@@ -41,7 +41,6 @@ const renderServicesList = () => ({
               serviceDetails: {
                 supportGroups: [],
               },
-              components: 0,
               remediationDate: "",
               serviceOwners: [],
             },

--- a/apps/heureka/src/components/Services/utils.ts
+++ b/apps/heureka/src/components/Services/utils.ts
@@ -65,7 +65,6 @@ export const getNormalizedData = (data: GetServicesQuery | undefined): Normalize
               serviceDetails: {
                 supportGroups: getSupportGroups(edge),
               },
-              components: node?.objectMetadata?.componentInstanceCount || 0,
               serviceOwners: getServiceOwners(edge),
               issuesCount: {
                 critical: node?.issueCounts?.critical || 0,

--- a/apps/heureka/src/components/types.ts
+++ b/apps/heureka/src/components/types.ts
@@ -20,7 +20,6 @@ export type ServiceType = {
   serviceDetails: {
     supportGroups: string[]
   }
-  components: number
   remediationDate: string
   serviceOwners: string[]
 }

--- a/apps/heureka/src/graphql/Services/getServices.graphql
+++ b/apps/heureka/src/graphql/Services/getServices.graphql
@@ -20,10 +20,6 @@ query GetServices(
       node {
         id
         ccrn
-        objectMetadata {
-          componentInstanceCount
-          issueMatchCount
-        }
         owners {
           edges {
             node {

--- a/apps/heureka/src/mocks/fixtures/services.ts
+++ b/apps/heureka/src/mocks/fixtures/services.ts
@@ -13,11 +13,6 @@ export const mockServices: Partial<GetServicesQueryResult> = {
           node: {
             id: "1",
             ccrn: "alpha",
-            objectMetadata: {
-              componentInstanceCount: 5,
-              issueMatchCount: 2,
-              __typename: "ServiceMetadata",
-            },
             owners: {
               edges: [],
               __typename: "UserConnection",
@@ -43,11 +38,6 @@ export const mockServices: Partial<GetServicesQueryResult> = {
           node: {
             id: "2",
             ccrn: "beta",
-            objectMetadata: {
-              componentInstanceCount: 10,
-              issueMatchCount: 5,
-              __typename: "ServiceMetadata",
-            },
             owners: {
               edges: [],
               __typename: "UserConnection",
@@ -73,11 +63,6 @@ export const mockServices: Partial<GetServicesQueryResult> = {
           node: {
             id: "3",
             ccrn: "gamma",
-            objectMetadata: {
-              componentInstanceCount: 0,
-              issueMatchCount: 0,
-              __typename: "ServiceMetadata",
-            },
             owners: {
               edges: [],
               __typename: "UserConnection",


### PR DESCRIPTION
# Summary

The `objectMetadata` fields are unused in the application and are leftover data that negatively impact API performance. Since they are expensive to compute and not displayed in the UI, we need to remove them.

# Changes Made

- getServices query is updated to remove `objectMetadata`


# Related Issues

No issue is created, reported by API colleagues.

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
