### PR TITLE
fix(heureka): ensure that filters can be added just once

### DIFF
--- a/.changeset/chubby-moose-travel.md
+++ b/.changeset/chubby-moose-travel.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+---
+
+fixes bug that the same filter could be applied multiple times

--- a/apps/heureka/src/components/common/Filters/index.tsx
+++ b/apps/heureka/src/components/common/Filters/index.tsx
@@ -29,18 +29,23 @@ export const Filters = ({ filters, filterSettings, onFilterChange, searchInputPl
     [filterSettings, onFilterChange]
   )
 
+  const handleFilterAdded = (filterToAdd: SelectedFilter) => {
+    // makes sure filters are just added once
+    const foundFilter = filterSettings.selectedFilters?.filter(
+      (filter) => filter.name === filterToAdd.name && filter.value === filterToAdd.value
+    )
+    if (!foundFilter || foundFilter.length == 0) {
+      onFilterChange({
+        ...filterSettings,
+        selectedFilters: filterSettings?.selectedFilters?.concat(filterToAdd),
+      })
+    }
+  }
+
   return (
     <Stack direction="vertical" gap="4" className="bg-theme-background-lvl-1 py-2 px-4 ">
       <InputGroup>
-        <FilterSelect
-          filters={filters}
-          onChange={(selectedFilter) => {
-            onFilterChange({
-              ...filterSettings,
-              selectedFilters: filterSettings?.selectedFilters?.concat(selectedFilter),
-            })
-          }}
-        />
+        <FilterSelect filters={filters} onChange={handleFilterAdded} />
         <Button
           label="Clear all"
           className="ml-4"

--- a/apps/heureka/src/components/common/Filters/index.tsx
+++ b/apps/heureka/src/components/common/Filters/index.tsx
@@ -17,17 +17,14 @@ export type FiltersProps = {
 }
 
 export const Filters = ({ filters, filterSettings, onFilterChange, searchInputPlaceholder }: FiltersProps) => {
-  const handleFilterDelete = useCallback(
-    (filterToRemove: SelectedFilter) => {
-      onFilterChange({
-        ...filterSettings,
-        selectedFilters: filterSettings.selectedFilters?.filter(
-          (filter) => !(filter.name === filterToRemove.name && filter.value === filterToRemove.value)
-        ),
-      })
-    },
-    [filterSettings, onFilterChange]
-  )
+  const handleFilterDelete = (filterToRemove: SelectedFilter) => {
+    onFilterChange({
+      ...filterSettings,
+      selectedFilters: filterSettings.selectedFilters?.filter(
+        (filter) => !(filter.name === filterToRemove.name && filter.value === filterToRemove.value)
+      ),
+    })
+  }
 
   const handleFilterAdded = (filterToAdd: SelectedFilter) => {
     // makes sure filters are just added once


### PR DESCRIPTION
# Summary

Ensures that filters can be just added once. 
Refactored useCallback

closes #974 

# Thoughts 

Even through i added my logic to the Filters component, if the State is given to multiple components from index there could be inconsistencies. I would prefer the logic near the state or in a separate file.

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
