### PR TITLE
chore(ci): fix slack notification bz setting the webhook-type correctly

### DIFF
--- a/.github/workflows/shared-slack-notification.yaml
+++ b/.github/workflows/shared-slack-notification.yaml
@@ -61,6 +61,6 @@ jobs:
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           payload: ${{ env.FULL_PAYLOAD }}
+          webhook-type: incoming-webhook
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
# Summary

Fixes Slack notification action by correctly passing `webhook-type: incoming-webhook` as an input instead of an environment variable. It was likely never set correctly, but the recent action upgrade started enforcing it, causing the workflow to fail.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- shared-slack-notification workflow fixed

# Screenshots (if applicable)

<img width="1073" alt="Screenshot 2025-06-02 at 13 19 46" src="https://github.com/user-attachments/assets/02e21761-8602-48b6-b0fa-d81e8bc2be36" />

# Testing Instructions



# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
