### PR TITLE
chore(ci): upgrade Docker Images to Node.js 22

### DIFF
--- a/apps/greenhouse/docker/Dockerfile
+++ b/apps/greenhouse/docker/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:20-alpine AS build
+FROM node:22-alpine AS build
 
 LABEL repository="https://github.com/cloudoperators/juno/tree/main/apps/greenhouse/docker/Dockerfile" 
 

--- a/apps/greenhouse/docker/README.md
+++ b/apps/greenhouse/docker/README.md
@@ -22,7 +22,7 @@ There are two primary methods to run the Greenhouse container:
 To provide a custom configuration file, mount your `appProps.json` via a Docker volume:
 
 ```bash
-docker run -v /path/to/your/appProps.json:/appProps.json -p 3010:80 greenhouse
+docker run -v /path/to/your/appProps.json:/appProps.json -p 8000:80 greenhouse
 ```
 
 #### Default appProps.json values:

--- a/apps/supernova/docker/Dockerfile
+++ b/apps/supernova/docker/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:20-alpine as build
+FROM node:22-alpine as build
 
 LABEL org.opencontainers.image.source=https://github.com/cloudoperators/juno/tree/main/apps/supernova
 LABEL org.opencontainers.image.description="This image contains a standalone runnable version of the Supernova alternative Alertmanager UI. For configuration options see the README here: https://github.com/cloudoperators/juno/tree/main/apps/supernova/docker"

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-alpine 
+FROM node:22-alpine 
 
 RUN npm i -g turbo
 RUN npm i -g pnpm

--- a/packages/k8s-client/docker/Dockerfile.dev
+++ b/packages/k8s-client/docker/Dockerfile.dev
@@ -2,4 +2,4 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM node:20-alpine 
+FROM node:22-alpine 


### PR DESCRIPTION
# Summary

Upgrade all project-related Docker images to use Node.js 22 as the base image to align with the development environment. This ensures consistency across local development, CI, and production, and helps avoid version discrepancies during builds and testing.

# Changes Made

- Changed base node alpine image to `node:22-alpine` for supernova, greenhouse and dev docker images for juno and k8s-client

# Related Issues

- #986

# Screenshots (if applicable)

![Screenshot 2025-06-16 at 12 00 37](https://github.com/user-attachments/assets/ba220fcc-a705-4fc9-97b0-0be0aad39f75)

![Screenshot 2025-06-16 at 12 01 30](https://github.com/user-attachments/assets/38483018-aff1-4713-8ca6-8c5622d7ade7)
![Screenshot 2025-06-16 at 12 11 39](https://github.com/user-attachments/assets/712a04fa-59de-4901-ae97-63fefa913535)
![Screenshot 2025-06-16 at 12 12 21](https://github.com/user-attachments/assets/b16efba4-905a-498c-8131-dbf8c663390f)

# Testing Instructions

1. Create the image for greenhouse and supernova
2. Run the image for greenhouse and supernova

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
