### PR TITLE
fix(doop): add unique id to items for stable ReactMarkdown rendering and fix inconsistent instance content

### DIFF
--- a/apps/doop/src/components/violations/ViolationDetailsList.tsx
+++ b/apps/doop/src/components/violations/ViolationDetailsList.tsx
@@ -24,9 +24,12 @@ const ViolationDetailsList = () => {
 
   const items = React.useMemo(() => {
     if (!detailsViolationGroup) return null
+    let uidCounter = 0
+
     // @ts-ignore
     return detailsViolationGroup.constraints.reduce((items: any, constraint: any) => {
       items.push({
+        id: `doc-${constraint.name}-${uidCounter++}`,
         type: "doc",
         title: constraint.name,
         severity: constraint.metadata.severity,
@@ -77,7 +80,7 @@ const ViolationDetailsList = () => {
                         <div className="info-box text-theme-high">
                           <h1 className="mb-4 mt-0 text-2xl">{capitalize(item.title)}</h1>
                           {item.data ? (
-                            <ReactMarkdown urlTransform={(href: any) => href.replace(/^\((.+)\)$/, "$1")}>
+                            <ReactMarkdown key={item.id} urlTransform={(href: any) => href.replace(/^\((.+)\)$/, "$1")}>
                               {item.data}
                             </ReactMarkdown>
                           ) : (

--- a/apps/doop/src/components/violations/ViolationDetailsOccurrences.tsx
+++ b/apps/doop/src/components/violations/ViolationDetailsOccurrences.tsx
@@ -42,9 +42,9 @@ const ViolationDetailsOccurrences = ({ violation }: any) => {
         </Collapsible>
       ) : (
         <div className="flex flex-wrap gap-2">
-          {violation.instances.map((instance: any, i: any) => (
+          {violation?.instances?.map((instance: any, i: any) => (
             <div key={i} className="text-sm text-theme-light">
-              {instance.cluster}:{instance.name}
+              {(instance?.cluster || "") + ":" + (instance?.name || "")}
             </div>
           ))}
         </div>


### PR DESCRIPTION
# Summary

Ensure stable rendering by adding unique ids to items for correct ReactMarkdown remounting and sanitizing instance values to prevent inconsistent DOM node structures. Fixes NotFoundError: `Failed to execute 'removeChild' on 'Node' errors caused by improper reuse of DOM nodes`

# Changes Made

**Added unique id to all items which uses ReactMarkdown**
- Each item now has a stable id (based on constraint.name, index, and a counter).
- Used as React key when rendering ReactMarkdown.
- Ensures that when the item changes, ReactMarkdown unmounts and remounts cleanly.

**Handled unsafe values in instance.cluster and instance.name**
- Some values were undefined, null, objects, or arrays.
- These now default to safe, displayable values using fallback logic (String(value), or "—").

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

-#959

# Screenshots (if applicable)

# Testing Instructions

1. Apply the Support Group filter (e.g., "containers") in the main list.
2. Click on a violation to open the detail panel.
3. While the panel is open, perform a search in the search bar (use a string that still shows results in the main list) like ingress.
4. With the panel still open, click on a different violation in the main list.
5. Repeat step 4 one or more times.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
