### PR TITLE
fix(heureka): allow changing appProps.json url

### DIFF
--- a/.changeset/breezy-baths-switch.md
+++ b/.changeset/breezy-baths-switch.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+---
+
+Heureka static bundle now allows to change appProps.json URL based on the target environment.

--- a/.github/scripts/build-vite-app.sh
+++ b/.github/scripts/build-vite-app.sh
@@ -5,9 +5,10 @@ set -e
 entry_file=$(jq -r '.module // .main // .exports["."]' $PACKAGE_PATH/package.json)
 build_folder=$(dirname $entry_file)
 package_name=$(jq -r '.name' $PACKAGE_PATH/package.json)
+app_props_url=$PREVIEW_URL/$TARGET_FOLDER/appProps.json
 
 # Run build using turbo
-pnpx turbo run build:static --filter $package_name -- --base ./
+VITE_APP_PROPS_URL=$app_props_url pnpx turbo run build:static --filter $package_name -- --base ./
 
 # Copy build folder to deploy path
 mkdir -p "$DEPLOY_PATH/$TARGET_FOLDER"

--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -38,6 +38,7 @@ permissions:
 env:
   DEPLOY_PATH: tmp
   NODE_VERSION: "22.16.0"
+  PREVIEW_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}
 
 jobs:
   run-detect-changes:
@@ -117,6 +118,7 @@ jobs:
           PACKAGE_PATH: apps/heureka
           TARGET_FOLDER: heureka
           APP_PROPS_BASE64: ${{ secrets.HEUREKA_APP_PROPS_BASE64 }}
+          PREVIEW_URL: ${{ env.PREVIEW_URL }}
         continue-on-error: true
 
       - name: Build DOOP if changes detected

--- a/apps/heureka/index.html
+++ b/apps/heureka/index.html
@@ -30,8 +30,19 @@
   </head>
   <body>
     <script type="module">
-      // appProps are excluded from standalone build and should be generated from outside
-      fetch("./appProps.json")
+      /*
+       * The `VITE_APP_PROPS_URL` can vary depending on the deployment environment.
+       *
+       * Examples:
+       * - For a standard static build, this variable is typically undefined,
+       *   and the app expects `appProps.json` to be located at the server root "/".
+       * - For deployments like GitHub Pages, it can be set to a subdirectory path
+       *   (e.g., a pull request-specific folder) where the static build is hosted.
+       */
+
+      const { VITE_APP_PROPS_URL } = import.meta.env
+      const appPropsUrl = VITE_APP_PROPS_URL || "/appProps.json"
+      fetch(appPropsUrl)
         .then((res) => res.json())
         .catch((error) => {
           console.warn("No appProps found, using default props", error.message)


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->

This PR addresses the issue where `appProps.json` fetch was not working from a child route like `/services/:name` when page is refreshed. 

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Load `appProps.json` from supplied `VITE_APP_PROPS_URL` or load it from server root `/appProps.json`.
- Updated github pr-preview for Heureka by supplying correct url to `appProps.json`.

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 1: [link to issue]

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
