### PR TITLE
chore(ci): enhance Trivy Output Readability with Table Format (Dual Scan with Caching)

### DIFF
--- a/.github/workflows/build-push-greenhouse-image.yaml
+++ b/.github/workflows/build-push-greenhouse-image.yaml
@@ -141,6 +141,21 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"
 
+      - name: Trivy vulnerability scanner (table output)
+        id: table-trivy
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
+          TRIVY_FORMAT: "table"
+          TRIVY_OUTPUT: ""
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          format: "table"
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH,MEDIUM"
+          skip-setup-trivy: true
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         if: always()

--- a/.github/workflows/build-push-supernova-image.yaml
+++ b/.github/workflows/build-push-supernova-image.yaml
@@ -163,6 +163,21 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"
 
+      - name: Trivy vulnerability scanner (table output)
+        id: table-trivy
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
+          TRIVY_FORMAT: "table"
+          TRIVY_OUTPUT: ""
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          format: "table"
+          ignore-unfixed: true
+          severity: "CRITICAL,HIGH,MEDIUM"
+          skip-setup-trivy: true
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         if: always()


### PR DESCRIPTION
# Summary

This PR improves the readability of vulnerability scan results by adding a second Trivy scan using the table output format. This human-friendly format makes it easier for developers to quickly analyze findings directly in the GitHub Actions logs.

# Changes Made

- Added a second Trivy step that runs with format: table for clear, readable logs.
- Reuses cache from the prior Trivy scan to avoid redundant work.

# Related Issues

- #984

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
