### PR TITLE
fix(heureka): remove no image version message

### DIFF
--- a/.changeset/weak-vans-cough.md
+++ b/.changeset/weak-vans-cough.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+---
+
+Remove unnecessary message in service detail page when there is no image version selected.

--- a/apps/heureka/src/components/Service/ImageVersionDetailsPanel/index.tsx
+++ b/apps/heureka/src/components/Service/ImageVersionDetailsPanel/index.tsx
@@ -37,7 +37,7 @@ export const ImageVersionDetailsPanel = ({ imageVersionsPromise }: ImageVersionD
   const imageVersion = imageVersions.find((version: ServiceImageVersion) => version.version === selectedImageVersion)
 
   if (!imageVersion) {
-    return <div>Image version not found</div>
+    return null
   }
 
   return (


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
If there is no image version selected instead of displaying `Image version not found` render nothing.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Remove unnecessary message

# Screenshots (if applicable)

## Before
<img width="1409" alt="Screenshot 2025-06-25 at 13 42 02" src="https://github.com/user-attachments/assets/5f873b7a-6b24-4dd0-bd18-3544c661c39f" />

## After
<img width="1510" alt="Screenshot 2025-06-25 at 13 40 57" src="https://github.com/user-attachments/assets/4081b279-8894-481f-afe6-06558eac3a3d" />

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
