### PR TITLE
test(heureka): fix flaky tests

### DIFF
--- a/apps/heureka/src/components/Services/Services.test.tsx
+++ b/apps/heureka/src/components/Services/Services.test.tsx
@@ -65,6 +65,6 @@ const renderComponent = () => {
 describe("Services", () => {
   it("should render correctly", async () => {
     await act(async () => renderComponent())
-    expect(screen.getByText("alpha")).toBeInTheDocument()
+    expect(await screen.findByText("alpha")).toBeInTheDocument()
   })
 })

--- a/apps/heureka/src/components/Services/ServicesList/ServicePanel.test.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServicePanel.test.tsx
@@ -56,14 +56,14 @@ describe("ServicePanel", () => {
   it("should render correctly", async () => {
     await act(() => renderComponent())
     // expect that the panel has correct service name in the heading
-    expect(screen.getByText("Alpha Overview")).toBeInTheDocument()
+    expect(await screen.findByText("Alpha Overview")).toBeInTheDocument()
     // expect that the image version is displayed
     expect(await screen.findByText("repo1")).toBeInTheDocument()
   })
 
   it("should navigate to service details with no image version selected", async () => {
     const { user, router } = await act(() => renderComponent())
-    await user.click(screen.getByText("Full Details"))
+    await user.click(await screen.findByText("Full Details"))
     expect(router.state.location.href).toBe("/services/alpha")
   })
 

--- a/apps/heureka/src/components/Services/ServicesList/index.test.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/index.test.tsx
@@ -47,7 +47,7 @@ const renderComponent = () => {
 describe("ServicesList", () => {
   it("should render correctly", async () => {
     await act(() => renderComponent())
-    expect(screen.getByText("alpha")).toBeInTheDocument()
+    expect(await screen.findByText("alpha")).toBeInTheDocument()
   })
 
   it("should render service panel when clicking on a service", async () => {
@@ -61,7 +61,7 @@ describe("ServicesList", () => {
     expect(router.state.location.href).toBe("/services?service=alpha")
 
     // expect the service panel to be opened
-    expect(screen.getByText("Alpha Overview")).toBeInTheDocument()
+    expect(await screen.findByText("Alpha Overview")).toBeInTheDocument()
 
     // expect the image version to be displayed
     expect(await screen.findByText("repo1")).toBeInTheDocument()

--- a/apps/heureka/src/components/common/Filters/FilterSelect.test.tsx
+++ b/apps/heureka/src/components/common/Filters/FilterSelect.test.tsx
@@ -35,30 +35,30 @@ describe("FiltersSelect", () => {
     vi.clearAllMocks()
   })
 
-  it("should render the component with filter select dropdown", () => {
+  it("should render the component with filter select dropdown", async () => {
     render(
       <AppShellProvider shadowRoot={false}>
         <FilterSelect filters={mockFilters} onChange={mockOnChange} />
       </AppShellProvider>
     )
 
-    const filterSelect = screen.getByTestId("select-filterValue")
+    const filterSelect = await screen.findByTestId("select-filterValue")
     expect(filterSelect).toBeInTheDocument()
 
-    const valueComboBox = screen.getByTestId("combobox-filterValue")
+    const valueComboBox = await screen.findByTestId("combobox-filterValue")
     expect(valueComboBox).toBeInTheDocument()
   })
 
-  it("displays all filter options in the select dropdown", () => {
+  it("displays all filter options in the select dropdown", async () => {
     render(
       <AppShellProvider shadowRoot={false}>
         <FilterSelect filters={mockFilters} onChange={mockOnChange} />
       </AppShellProvider>
     )
 
-    expect(screen.getByTestId("category")).toBeInTheDocument()
-    expect(screen.getByTestId("status")).toBeInTheDocument()
-    expect(screen.getByTestId("region")).toBeInTheDocument()
+    expect(await screen.findByTestId("category")).toBeInTheDocument()
+    expect(await screen.findByTestId("status")).toBeInTheDocument()
+    expect(await screen.findByTestId("region")).toBeInTheDocument()
   })
 
   it("should show values in combobox when filter is selected", async () => {
@@ -69,15 +69,15 @@ describe("FiltersSelect", () => {
       </AppShellProvider>
     )
 
-    const filterSelect = screen.getByTestId("select-filterValue")
+    const filterSelect = await screen.findByTestId("select-filterValue")
     await user.click(filterSelect)
-    await user.click(screen.getByTestId("region"))
+    await user.click(await screen.findByTestId("region"))
 
-    const valueComboBox = screen.getByTestId("combobox-filterValue").getElementsByClassName("juno-combobox-toggle")[0]
-    await user.click(valueComboBox)
+    const valueComboBox = await screen.findByTestId("combobox-filterValue")
+    await user.click(valueComboBox.getElementsByClassName("juno-combobox-toggle")[0])
 
-    expect(screen.getByTestId("Asia")).toBeInTheDocument()
-    expect(screen.getByTestId("America")).toBeInTheDocument()
-    expect(screen.getByTestId("Europe")).toBeInTheDocument()
+    expect(await screen.findByTestId("Asia")).toBeInTheDocument()
+    expect(await screen.findByTestId("America")).toBeInTheDocument()
+    expect(await screen.findByTestId("Europe")).toBeInTheDocument()
   })
 })

--- a/apps/heureka/src/components/common/Filters/index.test.tsx
+++ b/apps/heureka/src/components/common/Filters/index.test.tsx
@@ -47,18 +47,20 @@ describe("Filters", () => {
     vi.clearAllMocks()
   })
 
-  it("renders the component with search, select and combobox", () => {
+  it("renders the component with search, select and combobox", async () => {
     renderShell({ filters, filterSettings, onFilterChange: vi.fn() })
-    expect(screen.getByTestId("select-filterValue")).toBeInTheDocument()
-    expect(screen.getByTestId("combobox-filterValue")).toBeInTheDocument()
-    expect(screen.getByTestId("searchbar")).toBeInTheDocument()
+    expect(await screen.findByTestId("select-filterValue")).toBeInTheDocument()
+    expect(await screen.findByTestId("combobox-filterValue")).toBeInTheDocument()
+    expect(await screen.findByTestId("searchbar")).toBeInTheDocument()
   })
 
   it("should allow filtering by text", async () => {
     const onFilterChangeSpy = vi.fn()
     const { user } = renderShell({ filters, filterSettings, onFilterChange: onFilterChangeSpy })
-    await user.type(screen.getByRole("searchbox"), "Europe")
-    await user.click(screen.getByRole("button", { name: "Search" }))
+    const searchbox = await screen.findByRole("searchbox")
+    await user.type(searchbox, "Europe")
+    const searchButton = await screen.findByRole("button", { name: "Search" })
+    await user.click(searchButton)
     expect(onFilterChangeSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         selectedFilters: [],
@@ -71,15 +73,16 @@ describe("Filters", () => {
     const onFilterChangeSpy = vi.fn()
     const { user } = renderShell({ filters, filterSettings, onFilterChange: onFilterChangeSpy })
 
-    const filterSelect = screen.getByTestId("select-filterValue")
+    const filterSelect = await screen.findByTestId("select-filterValue")
     await user.click(filterSelect)
-    await user.click(screen.getByTestId("region"))
+    await user.click(await screen.findByTestId("region"))
 
-    const valueComboBox = screen.getByTestId("combobox-filterValue").getElementsByClassName("juno-combobox-toggle")[0]
-    await user.click(valueComboBox)
+    const valueComboBox = await screen.findByTestId("combobox-filterValue")
 
-    expect(screen.getByTestId("Europe")).toBeInTheDocument()
-    await user.click(screen.getByTestId("Europe"))
+    await user.click(valueComboBox.getElementsByClassName("juno-combobox-toggle")[0])
+
+    expect(await screen.findByTestId("Europe")).toBeInTheDocument()
+    await user.click(await screen.findByTestId("Europe"))
 
     expect(onFilterChangeSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
This PR fixes failing tests because of the timeout. 

The issue seems to be that the apis, like `getByRole`, `getByTestId`, `getByText` are synchronous and expect elements to be rendered without waiting for them to be rendered, therefore replacing them with the asynchronous counterparts like `findByText`, `findByTestId`, `findByRole` waits for the element to appear in the DOM (up to the default timeout), making it robust against async rendering.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Used asynchronous `screen` APIs instead of the synchronous ones.

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 1: [link to issue]

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
