### PR TITLE
chore(ci): add SHA tag to Greenhouse-UI Docker image

### DIFF
--- a/.github/workflows/build-push-greenhouse-image.yaml
+++ b/.github/workflows/build-push-greenhouse-image.yaml
@@ -91,6 +91,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{major}}.{{minor}}.{{patch}},value=${{ steps.read_version.outputs.IMAGE_VERSION }}
+            type=sha,enable=true,format=short,prefix=
           labels: |
             org.opencontainers.image.description=${{env.DESCRIPTION}}
             org.opencontainers.image.title=Greenhouse-UI


### PR DESCRIPTION
# Summary

Adds a Git SHA tag to the Greenhouse-UI Docker image metadata, enabling each published image to be directly traced back to its exact source commit.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Include the Git commit SHA as a tag when generating Docker tags for the Greenhouse-UI image in the CI workflow

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
