### PR TITLE
feat(ui): disable in-built confirm and cancel buttons

### DIFF
--- a/.changeset/stale-towns-win.md
+++ b/.changeset/stale-towns-win.md
@@ -3,5 +3,5 @@
 "@cloudoperators/juno-app-example": minor
 ---
 
-Allow Buttons to be Disabled in Modal and ModalFooter Juno UI Components and update Example App to use this feature.
+Allow Buttons to be Disabled in Modal and ModalFooter Juno UI Components.
 [Issue #1010](https://github.com/cloudoperators/juno/issues/1010)

--- a/.changeset/stale-towns-win.md
+++ b/.changeset/stale-towns-win.md
@@ -1,0 +1,7 @@
+---
+"@cloudoperators/juno-ui-components": minor
+"@cloudoperators/juno-app-example": minor
+---
+
+Allow Buttons to be Disabled in Modal and ModalFooter Juno UI Components and update Example App to use this feature.
+[Issue #1010](https://github.com/cloudoperators/juno/issues/1010)

--- a/apps/example/src/components/metrics/MetricsBox.tsx
+++ b/apps/example/src/components/metrics/MetricsBox.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react"
-import { Modal, Badge, Button, ModalFooter, ButtonRow, Icon, Spinner, Box } from "@cloudoperators/juno-ui-components"
+import { Modal, Badge, Icon, Spinner, Box } from "@cloudoperators/juno-ui-components"
 
 import { Peak } from "../../mocks/db"
 import useUIStore from "../../store/useUIStore"
@@ -139,21 +139,13 @@ const PeakModal: React.FC<{
 }> = ({ peakDetails, modalVisible, onClose, onOpenDetail }) =>
   modalVisible && peakDetails ? (
     <Modal
-      open={modalVisible}
-      onCancel={onClose}
-      closeable
       title={`Details for ${peakDetails.name}, ${peakDetails.countries}`}
+      open={modalVisible}
+      closeable
+      confirmButtonLabel="Open Detail Page"
+      onConfirm={onOpenDetail}
+      onCancel={onClose}
       size="large"
-      modalFooter={
-        <ModalFooter className="flex justify-end">
-          <ButtonRow>
-            <Button onClick={onClose} label={"Cancel"} />
-            <Button variant="primary" onClick={onOpenDetail}>
-              Open Detail Page
-            </Button>
-          </ButtonRow>
-        </ModalFooter>
-      }
     >
       <div className="flex flex-col space-y-3">
         <div className="flex items-center space-x-2">

--- a/apps/example/src/components/peaks/list/CreatePeakModal.tsx
+++ b/apps/example/src/components/peaks/list/CreatePeakModal.tsx
@@ -14,7 +14,7 @@ interface CreatePeakModalProps {
 }
 
 const CreatePeakModal: React.FC<CreatePeakModalProps> = ({ isOpen, title, onClose }) => (
-  <Modal title={title} open={isOpen} modalFooter={undefined} size="large" closeable={false}>
+  <Modal title={title} open={isOpen} size="large" closeable={false}>
     <PeakForm closeCallback={onClose} />
   </Modal>
 )

--- a/packages/ui-components/src/components/Modal/Modal.component.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.component.tsx
@@ -82,25 +82,27 @@ By default, the modal will close (i.e. set its `open` state to false) once the u
 To make the modal less intrusive and effectively un-modal it, pass `closeOnBackdropClick`. This will close the modal when the user clicks the modal backdrop.
 */
 export const Modal: React.FC<ModalProps> = ({
-  ariaLabel,
-  cancelButtonIcon,
-  cancelButtonLabel = "",
-  confirmButtonIcon,
-  confirmButtonLabel = "",
-  children,
-  closeable = true,
-  closeOnBackdropClick = false,
-  closeOnEsc = true,
-  heading = "",
-  initialFocus,
-  modalFooter,
-  onConfirm,
-  onCancel,
-  open = false,
-  size = "small",
   title = "",
+  heading = "",
+  ariaLabel,
+  initialFocus,
+  open = false,
+  closeable = true,
+  closeOnEsc = true,
+  closeOnBackdropClick = false,
+  size = "small",
   unpad = false,
   className = "",
+  children,
+  modalFooter,
+  confirmButtonLabel = "",
+  cancelButtonLabel = "",
+  confirmButtonIcon,
+  cancelButtonIcon,
+  disableConfirmButton = false,
+  disableCancelButton = false,
+  onConfirm,
+  onCancel,
   ...props
 }) => {
   const uniqueId = () => "juno-modal-" + useId()
@@ -208,6 +210,8 @@ export const Modal: React.FC<ModalProps> = ({
                       cancelButtonLabel={cancelButtonLabel}
                       confirmButtonIcon={confirmButtonIcon}
                       cancelButtonIcon={cancelButtonIcon}
+                      disableConfirmButton={disableConfirmButton}
+                      disableCancelButton={disableCancelButton}
                       onConfirm={onConfirm ? handleConfirmClick : undefined}
                       onCancel={handleCancelClick}
                     />
@@ -225,14 +229,32 @@ export const Modal: React.FC<ModalProps> = ({
 type ModalSize = "small" | "large"
 
 export interface ModalProps extends Omit<React.HTMLProps<HTMLDivElement>, "size"> {
-  /** The aria-label of the modal. Use only if the modal does NOT have a `title` or `heading`.  */
-  ariaLabel?: string
   /** The title of the modal. This will be rendering as the heading of the modal, and the modal's `arial-labelledby` attribute will reference the title/heading element. If the modal does not have `title` or `heading`, use `ariaLabel` to provide an accessible name for the modal. */
   title?: string
   /** Also the title of the modal, just for API flexibility. If both `title` and `heading` are passed, `title` will win. */
   heading?: string
+  /** The aria-label of the modal. Use only if the modal does NOT have a `title` or `heading`.  */
+  ariaLabel?: string
+  /** By default, the first element in the tab order of the Modal content will be focussed. To specify an element to be focussed when the modal opens, pass an element, DOM node, or selector string. */
+  initialFocus?: HTMLElement | SVGElement | string
+  /** Whether the modal will be open */
+  open?: boolean
+  /** Whether the modal can be closed using an "X"-Button at the top right. Defaults to true. */
+  closeable?: boolean
+  /** Whether the modal should be closed when the backdrop is clicked. Essentially 'un-modals' the modal. */
+  closeOnEsc?: boolean
   /** The Modal size */
+  closeOnBackdropClick?: boolean
+  /** Whether the modal can be closed by hitting the ESC key */
   size?: ModalSize
+  /** Pass to remove default padding from the content area of the modal */
+  unpad?: boolean
+  /** Custom className to add to the modal */
+  className?: string
+  /** The children of the modal. These will be rendered as the modal content. To render custom buttons at the bottom, see `modalFooter` below.*/
+  children?: React.ReactNode
+  /** Optional. Pass a `<ModalFooter />` component with custom content as required. Will default to using the `<ModalFooter/>` component internally. */
+  modalFooter?: React.ReactElement
   /** Pass a label to render a confirm button and a Cancel button */
   confirmButtonLabel?: string
   /** Pass a label for the cancel button. Defaults to "Cancel" */
@@ -241,27 +263,13 @@ export interface ModalProps extends Omit<React.HTMLProps<HTMLDivElement>, "size"
   confirmButtonIcon?: KnownIcons
   /** Pass an icon name to show on the cancelling button */
   cancelButtonIcon?: KnownIcons
-  /** Whether the modal will be open */
-  open?: boolean
-  /** The children of the modal. These will be rendered as the modal content. To render custom buttons at the bottom, see `modalFooter` below.*/
-  children?: React.ReactNode
-  /** Optional. Pass a `<ModalFooter />` component with custom content as required. Will default to using the `<ModalFooter/>` component internally. */
-  modalFooter?: React.ReactElement
-  /** Whether the modal can be closed using an "X"-Button at the top right. Defaults to true. */
-  closeable?: boolean
-  /** Pass to remove default padding from the content area of the modal */
-  unpad?: boolean
-  /** Custom className to add to the modal */
-  className?: string
+  /** Determines whether the confirm action button should be disabled */
+  disableConfirmButton?: boolean
+  /** Determines whether the cancel action button should be disabled */
+  disableCancelButton?: boolean
   /** A handler to execute once the modal is confirmed by clicking the confrim button if exists. Note that we do not close the modal automatically. */
   onConfirm?: React.MouseEventHandler<HTMLElement>
   /** A handler to execute once the modal is cancelled or dismissed using the x-Close button,  Cancel-button or pressing ESC */
   // eslint-disable-next-line no-unused-vars
   onCancel?: (event: React.MouseEvent<HTMLElement> | KeyboardEvent) => void
-  /** Whether the modal should be closed when the backdrop is clicked. Essentially 'un-modals' the modal. */
-  closeOnBackdropClick?: boolean
-  /** Whether the modal can be closed by hitting the ESC key */
-  closeOnEsc?: boolean
-  /** By default, the first element in the tab order of the Modal content will be focussed. To specify an element to be focussed when the modal opens, pass an element, DOM node, or selector string. */
-  initialFocus?: HTMLElement | SVGElement | string
 }

--- a/packages/ui-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.stories.tsx
@@ -89,6 +89,17 @@ export const SimpleConfirmDialog: Story = {
   },
 }
 
+export const SimpleConfirmDialogWithDisabledButtons: Story = {
+  render: Template,
+  args: {
+    children: <p>Are you sure you want to proceed?</p>,
+    cancelButtonLabel: "Cancel",
+    confirmButtonLabel: "Yes, Proceed",
+    disableConfirmButton: true,
+    disableCancelButton: true,
+  },
+}
+
 export const AutoFocusDialog: Story = {
   render: Template,
   args: {

--- a/packages/ui-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.stories.tsx
@@ -77,6 +77,8 @@ export const Default: Story = {
   render: Template,
   args: {
     children: <p>A default modal.</p>,
+    disableConfirmButton: false,
+    disableCancelButton: false,
   },
 }
 

--- a/packages/ui-components/src/components/Modal/Modal.test.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.test.tsx
@@ -351,4 +351,38 @@ describe("Modal", () => {
     )
     expect(screen.getByRole("dialog")).toHaveAttribute("name", "My little Modal")
   })
+
+  test("renders a disabled confirm action button and ensures onConfirm is not triggered", async () => {
+    await waitFor(() =>
+      render(
+        <PortalProvider>
+          <Modal open onConfirm={mockOnConfirm} confirmButtonLabel="Proceed" disableConfirmButton />
+        </PortalProvider>
+      )
+    )
+
+    const confirmButton = screen.getByRole("button", { name: "Proceed" })
+    expect(confirmButton).toBeInTheDocument()
+    expect(confirmButton).toHaveAttribute("disabled")
+
+    await waitFor(() => userEvent.click(confirmButton))
+    expect(mockOnConfirm).not.toHaveBeenCalled()
+  })
+
+  test("renders a disabled cancel action button and ensures onCancel is not triggered", async () => {
+    await waitFor(() =>
+      render(
+        <PortalProvider>
+          <Modal open onCancel={mockOnCancel} cancelButtonLabel="Cancel" disableCancelButton />
+        </PortalProvider>
+      )
+    )
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" })
+    expect(cancelButton).toBeInTheDocument()
+    expect(cancelButton).toHaveAttribute("disabled")
+
+    await waitFor(() => userEvent.click(cancelButton))
+    expect(mockOnCancel).not.toHaveBeenCalled()
+  })
 })

--- a/packages/ui-components/src/components/ModalFooter/ModalFooter.component.tsx
+++ b/packages/ui-components/src/components/ModalFooter/ModalFooter.component.tsx
@@ -30,14 +30,16 @@ Can alternatively render all custom children as passed.
 */
 
 export const ModalFooter: React.FC<ModalFooterProps> = ({
+  className = "",
   children,
   confirmButtonLabel = "",
   cancelButtonLabel = "",
   confirmButtonIcon,
   cancelButtonIcon,
+  disableConfirmButton = false,
+  disableCancelButton = false,
   onConfirm,
   onCancel,
-  className = "",
   ...props
 }) => {
   const handleConfirmClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -61,11 +63,13 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
             variant="primary"
             label={confirmButtonLabel || "Confirm"}
             icon={confirmButtonIcon || undefined}
+            disabled={disableConfirmButton}
             onClick={handleConfirmClick}
           />
           <Button
             variant="subdued"
             label={cancelButtonLabel || "Cancel"}
+            disabled={disableCancelButton}
             icon={cancelButtonIcon || undefined}
             onClick={handleCancelClick}
           />
@@ -74,9 +78,10 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
         <ButtonRow>
           <Button
             variant="subdued"
-            onClick={handleCancelClick}
             label={cancelButtonLabel || "Close"}
+            disabled={disableCancelButton}
             icon={cancelButtonIcon || undefined}
+            onClick={handleCancelClick}
           />
         </ButtonRow>
       )}
@@ -85,6 +90,8 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({
 }
 
 export interface ModalFooterProps extends React.HTMLProps<HTMLDivElement> {
+  /** A custom className. Useful to configure flex items alignment when passing custom content as children. */
+  className?: string
   /** Custom children to render. */
   children?: React.ReactNode
   /** The label for the Confirm-button. When passed, the component will render a Confirm button and a cancel button, otherwise the component will ONLY render a Close-Button. */
@@ -95,8 +102,10 @@ export interface ModalFooterProps extends React.HTMLProps<HTMLDivElement> {
   confirmButtonIcon?: KnownIcons
   /** Pass an icon name to show on the cancelling button */
   cancelButtonIcon?: KnownIcons
-  /** A custom className. Useful to configure flex items alignment when passing custom content as children. */
-  className?: string
+  /** Determines whether the confirm action button should be disabled */
+  disableConfirmButton?: boolean
+  /** Determines whether the cancel action button should be disabled */
+  disableCancelButton?: boolean
   /** Handler to execute once the confirming button is clicked */
   onConfirm?: React.MouseEventHandler<HTMLElement>
   /** Handler to execute once the cancelling button is clicked */

--- a/packages/ui-components/src/components/ModalFooter/ModalFooter.stories.tsx
+++ b/packages/ui-components/src/components/ModalFooter/ModalFooter.stories.tsx
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   render: Template,
-  args: {},
+  args: { disableConfirmButton: false, disableCancelButton: false },
 }
 
 export const Configure: Story = {

--- a/packages/ui-components/src/components/ModalFooter/ModalFooter.stories.tsx
+++ b/packages/ui-components/src/components/ModalFooter/ModalFooter.stories.tsx
@@ -45,6 +45,16 @@ export const Configure: Story = {
   },
 }
 
+export const ConfigureWithDisabledButtons: Story = {
+  render: Template,
+  args: {
+    confirmButtonLabel: "Confirm Action",
+    cancelButtonLabel: "Cancel Action",
+    disableConfirmButton: true,
+    disableCancelButton: true,
+  },
+}
+
 export const Custom: Story = {
   render: Template,
   args: {

--- a/packages/ui-components/src/components/ModalFooter/ModalFooter.test.tsx
+++ b/packages/ui-components/src/components/ModalFooter/ModalFooter.test.tsx
@@ -78,4 +78,58 @@ describe("ModalFooter", () => {
     render(<ModalFooter data-testid="my-modal-footer" name="My little ModalFooter" />)
     expect(screen.getByTestId("my-modal-footer")).toHaveAttribute("name", "My little ModalFooter")
   })
+
+  describe("Disabled Button Tests", () => {
+    test("renders a disabled confirm action button when disableConfirmButton is true and ensures onConfirm isn't triggered", () => {
+      const onClickSpy = vi.fn()
+      render(<ModalFooter confirmButtonLabel="Confirm" onConfirm={onClickSpy} disableConfirmButton />)
+
+      const confirmButton = screen.getByRole("button", { name: "Confirm" })
+      expect(confirmButton).toBeInTheDocument()
+      expect(confirmButton).toHaveAttribute("disabled")
+
+      act(() => confirmButton.click())
+      expect(onClickSpy).not.toHaveBeenCalled()
+    })
+
+    test("renders a disabled cancel action button when disableCancelButton is true and ensures onCancel isn't triggered", () => {
+      const onClickSpy = vi.fn()
+      render(<ModalFooter cancelButtonLabel="Cancel" onCancel={onClickSpy} disableCancelButton />)
+
+      const cancelButton = screen.getByRole("button", { name: "Cancel" })
+      expect(cancelButton).toBeInTheDocument()
+      expect(cancelButton).toHaveAttribute("disabled")
+
+      act(() => cancelButton.click())
+      expect(onClickSpy).not.toHaveBeenCalled()
+    })
+
+    test("renders disabled confirm and cancel buttons and ensures onConfirm and onCancel aren't triggered", () => {
+      const onConfirmSpy = vi.fn()
+      const onCancelSpy = vi.fn()
+
+      render(
+        <ModalFooter
+          confirmButtonLabel="Confirm"
+          cancelButtonLabel="Cancel"
+          onConfirm={onConfirmSpy}
+          onCancel={onCancelSpy}
+          disableConfirmButton
+          disableCancelButton
+        />
+      )
+
+      const confirmButton = screen.getByRole("button", { name: "Confirm" })
+      expect(confirmButton).toBeInTheDocument()
+      expect(confirmButton).toHaveAttribute("disabled")
+      act(() => confirmButton.click())
+      expect(onConfirmSpy).not.toHaveBeenCalled()
+
+      const cancelButton = screen.getByRole("button", { name: "Cancel" })
+      expect(cancelButton).toBeInTheDocument()
+      expect(cancelButton).toHaveAttribute("disabled")
+      act(() => cancelButton.click())
+      expect(onCancelSpy).not.toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
# Summary

Issue: https://github.com/cloudoperators/juno/issues/1010

- Added `disableConfirmButton` and `disableCancelButton` props to `Modal` and `ModalFooter` so users can disable these in-built buttons during invalid input states or asynchronous operations.

# Changes Made

- Fulfilled all ACs.
  - This solution isn't applicable to Example App's current use cases. However, `MetricsBox` was updated to use `Modal`'s in-built confirmation props, instead of custom buttons.
- Logically grouped and ordered existing component props.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
