### PR TITLE
feat(heureka): updates types to resolve schema breaking change

### DIFF
--- a/.changeset/thick-needles-accept.md
+++ b/.changeset/thick-needles-accept.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+Updates types based on schema breaking changes to adjust severity filter type.

--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -54,7 +54,8 @@ header:
     - "**/*.sh"
     - "packages/ui-components/src/fonts/**"
     - "**/routeTree.gen.ts"
-    - .nvmrc 
+    - .nvmrc
+    - "**/codegen.ts"
 
   comment: on-failure
 

--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -55,7 +55,7 @@ header:
     - "packages/ui-components/src/fonts/**"
     - "**/routeTree.gen.ts"
     - .nvmrc
-    - "**/codegen.ts"
+    - "**/generated/**"
 
   comment: on-failure
 

--- a/apps/heureka/codegen.ts
+++ b/apps/heureka/codegen.ts
@@ -5,20 +5,6 @@
 
 import { CodegenConfig } from "@graphql-codegen/cli"
 import * as dotenv from "dotenv"
-import * as fs from "fs"
-import * as path from "path"
-import * as yaml from "js-yaml"
-
-// Load and parse the license config
-const licenseConfigPath = path.resolve(__dirname, "..", "..", ".github", "licenserc.yaml")
-const licenseYaml = fs.readFileSync(licenseConfigPath, "utf8")
-const licenseContent = (yaml.load(licenseYaml) as any)?.header?.license?.content?.trim() || ""
-
-// Format as a block comment
-const formattedLicenseHeader = `/*\n${licenseContent
-  .split("\n")
-  .map((line) => ` * ${line}`)
-  .join("\n")}\n */`
 
 // Load environment variables from .env file
 dotenv.config()
@@ -29,16 +15,7 @@ const config: CodegenConfig = {
 
   generates: {
     "src/generated/graphql.ts": {
-      plugins: [
-        "typescript",
-        "typescript-operations",
-        "typescript-react-apollo",
-        {
-          add: {
-            content: formattedLicenseHeader,
-          },
-        },
-      ],
+      plugins: ["typescript", "typescript-operations", "typescript-react-apollo"],
       config: {
         withHooks: false,
         withHOC: false,

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: [year] SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Juno contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: [year] SAP SE or an SAP affiliate company and Juno contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import { gql } from "@apollo/client"
 import * as Apollo from "@apollo/client"
 export type Maybe<T> = T | null

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -1,8 +1,7 @@
 /*
- * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-FileCopyrightText: [year] SAP SE or an SAP affiliate company and Juno contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { gql } from "@apollo/client"
 import * as Apollo from "@apollo/client"
 export type Maybe<T> = T | null
@@ -204,6 +203,7 @@ export type ComponentInstance = Node & {
   issueMatches?: Maybe<IssueMatchConnection>
   metadata?: Maybe<Metadata>
   namespace?: Maybe<Scalars["String"]["output"]>
+  parentId?: Maybe<Scalars["String"]["output"]>
   pod?: Maybe<Scalars["String"]["output"]>
   project?: Maybe<Scalars["String"]["output"]>
   region?: Maybe<Scalars["String"]["output"]>
@@ -239,6 +239,7 @@ export type ComponentInstanceFilter = {
   context?: InputMaybe<Array<InputMaybe<Scalars["Json"]["input"]>>>
   domain?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   namespace?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
+  parentId?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   pod?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   project?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   region?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
@@ -322,6 +323,7 @@ export type ComponentInstanceInput = {
   count?: InputMaybe<Scalars["Int"]["input"]>
   domain?: InputMaybe<Scalars["String"]["input"]>
   namespace?: InputMaybe<Scalars["String"]["input"]>
+  parentId?: InputMaybe<Scalars["String"]["input"]>
   pod?: InputMaybe<Scalars["String"]["input"]>
   project?: InputMaybe<Scalars["String"]["input"]>
   region?: InputMaybe<Scalars["String"]["input"]>
@@ -352,8 +354,11 @@ export enum ComponentInstanceTypes {
   DnsZone = "DnsZone",
   FloatingIp = "FloatingIp",
   Project = "Project",
+  ProjectConfiguration = "ProjectConfiguration",
   RbacPolicy = "RbacPolicy",
+  RecordSet = "RecordSet",
   SecurityGroup = "SecurityGroup",
+  SecurityGroupRule = "SecurityGroupRule",
   Server = "Server",
   Unknown = "Unknown",
   User = "User",
@@ -1614,6 +1619,7 @@ export type SupportGroupEdge = Edge & {
 }
 
 export type SupportGroupFilter = {
+  issueIds?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   state?: InputMaybe<Array<StateFilter>>
   supportGroupCcrn?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   userIds?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
@@ -1690,6 +1696,7 @@ export type Vulnerability = Node & {
   services?: Maybe<ServiceConnection>
   severity?: Maybe<SeverityValues>
   sourceUrl?: Maybe<Scalars["String"]["output"]>
+  supportGroups?: Maybe<SupportGroupConnection>
 }
 
 export type VulnerabilityServicesArgs = {
@@ -1697,8 +1704,14 @@ export type VulnerabilityServicesArgs = {
   first?: InputMaybe<Scalars["Int"]["input"]>
 }
 
+export type VulnerabilitySupportGroupsArgs = {
+  after?: InputMaybe<Scalars["String"]["input"]>
+  first?: InputMaybe<Scalars["Int"]["input"]>
+}
+
 export type VulnerabilityConnection = Connection & {
   __typename?: "VulnerabilityConnection"
+  counts?: Maybe<SeverityCounts>
   edges: Array<Maybe<VulnerabilityEdge>>
   pageInfo?: Maybe<PageInfo>
   totalCount: Scalars["Int"]["output"]
@@ -1712,12 +1725,14 @@ export type VulnerabilityEdge = Edge & {
 
 export type VulnerabilityFilter = {
   search?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
-  severity?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
+  service?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
+  severity?: InputMaybe<Array<InputMaybe<SeverityValues>>>
   supportGroup?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
 }
 
 export type VulnerabilityFilterValue = {
   __typename?: "VulnerabilityFilterValue"
+  service?: Maybe<FilterItem>
   severity?: Maybe<FilterItem>
   supportGroup?: Maybe<FilterItem>
 }
@@ -1941,6 +1956,8 @@ export type GetVulnerabilitiesQueryVariables = Exact<{
   filter?: InputMaybe<VulnerabilityFilter>
   first?: InputMaybe<Scalars["Int"]["input"]>
   after?: InputMaybe<Scalars["String"]["input"]>
+  firstServices?: InputMaybe<Scalars["Int"]["input"]>
+  afterServices?: InputMaybe<Scalars["String"]["input"]>
 }>
 
 export type GetVulnerabilitiesQuery = {
@@ -1964,6 +1981,11 @@ export type GetVulnerabilitiesQuery = {
             __typename?: "ServiceEdge"
             node: { __typename?: "Service"; ccrn?: string | null }
           } | null> | null
+          pageInfo?: {
+            __typename?: "PageInfo"
+            pageNumber?: number | null
+            pages?: Array<{ __typename?: "Page"; after?: string | null; pageNumber?: number | null } | null> | null
+          } | null
         } | null
       }
     } | null>
@@ -2200,7 +2222,13 @@ export const GetServicesDocument = gql`
 `
 export type GetServicesQueryResult = Apollo.QueryResult<GetServicesQuery, GetServicesQueryVariables>
 export const GetVulnerabilitiesDocument = gql`
-  query GetVulnerabilities($filter: VulnerabilityFilter, $first: Int, $after: String) {
+  query GetVulnerabilities(
+    $filter: VulnerabilityFilter
+    $first: Int
+    $after: String
+    $firstServices: Int
+    $afterServices: String
+  ) {
     Vulnerabilities(filter: $filter, first: $first, after: $after) {
       edges {
         node {
@@ -2209,11 +2237,18 @@ export const GetVulnerabilitiesDocument = gql`
           sourceUrl
           earliestTargetRemediationDate
           description
-          services {
+          services(first: $firstServices, after: $afterServices) {
             totalCount
             edges {
               node {
                 ccrn
+              }
+            }
+            pageInfo {
+              pageNumber
+              pages {
+                after
+                pageNumber
               }
             }
           }

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -1,8 +1,3 @@
-/*
- * SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Juno contributors
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { gql } from "@apollo/client"
 import * as Apollo from "@apollo/client"
 export type Maybe<T> = T | null


### PR DESCRIPTION
# Summary

This PR updates types based on announced schema breaking changes to change severity filter type. This change should be shipped to Greenhouse qa asap, since the schema changes are available in heureka endpoint for greenhouse qa.

# Changes Made

- graphql.ts is updated based on the latest schema change
- Autogenerated files (**/generated/** ) are now exlcuded from checking the license header

# Related Issues

- Issue 1: https://github.com/cloudoperators/heureka/issues/787

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
