### PR TITLE
chore(deps): upgrade license-checker-rseidelsohn to 4.4.2, fixing vulnerabilities

### DIFF
--- a/.changeset/lucky-cups-think.md
+++ b/.changeset/lucky-cups-think.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-config": patch
+---
+
+Upgraded license-checker-rseidelsohn to `4.4.2` (latest)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^24.0.3",
     "eslint": "^9.31.0",
     "husky": "^9.1.5",
-    "license-checker-rseidelsohn": "4.3.0",
+    "license-checker-rseidelsohn": "^4.4.2",
     "prettier": "^3.2.5",
     "turbo": "^2.0.3",
     "typescript": "^5.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^9.1.5
         version: 9.1.7
       license-checker-rseidelsohn:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: ^4.4.2
+        version: 4.4.2
       prettier:
         specifier: ^3.2.5
         version: 3.4.2
@@ -5955,8 +5955,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  license-checker-rseidelsohn@4.3.0:
-    resolution: {integrity: sha512-A2LQ+3kUIG1hCJ/hh4WUvPsyhooT7o5mFhNyTean0cqH3rZeB1ZUCthxlcdgWESSqx+3DLC6J/8ghbiWRYKdUA==}
+  license-checker-rseidelsohn@4.4.2:
+    resolution: {integrity: sha512-Sf8WaJhd2vELvCne+frS9AXqnY/vv591s2/nZcJDwTnoNgltG4mAmoenffVb8L2YPRYbxARLyrHJBC38AVfpuA==}
     engines: {node: '>=18', npm: '>=8'}
     hasBin: true
 
@@ -14461,7 +14461,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-checker-rseidelsohn@4.3.0:
+  license-checker-rseidelsohn@4.4.2:
     dependencies:
       chalk: 4.1.2
       debug: 4.4.1
@@ -16586,7 +16586,7 @@ snapshots:
   terser@5.39.2:
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.1
+      acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -17178,7 +17178,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.14.1
+      acorn: 8.15.0
       browserslist: 4.24.5
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.1
@@ -17210,7 +17210,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.14.1
+      acorn: 8.15.0
       browserslist: 4.24.5
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.1


### PR DESCRIPTION
# Summary

Upgrade `license-checker-rseidelsohn` to `4.4.2` (latest) to fix vulnerabilities linked below.

# Related Issues

- https://github.com/cloudoperators/juno/security/dependabot/92

# Testing Instructions

Ensure no breaking changes.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
