### PR TITLE
feat(AlertLinks) support absolute urls

### DIFF
--- a/.changeset/fresh-islands-repair.md
+++ b/.changeset/fresh-islands-repair.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-supernova": patch
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+feat(AlertLinks) support absolute urls for playbook links.

--- a/apps/supernova/src/components/alerts/shared/AlertLinks.tsx
+++ b/apps/supernova/src/components/alerts/shared/AlertLinks.tsx
@@ -24,7 +24,11 @@ const AlertLinks = ({ alert, className }: any) => {
       {alert?.labels?.playbook && (
         <a
           className="underline"
-          href={`https://operations.global.cloud.sap/${alert?.labels?.playbook}`}
+          href={
+            alert.labels.playbook.startsWith("http")
+              ? alert.labels.playbook
+              : `https://operations.global.cloud.sap/${alert.labels.playbook}`
+          }
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
# Summary

Some Alerts contain absolute URLs redirecting to playbooks instead of relative urls

# Changes Made

```
href={
  alert.labels.playbook.startsWith("http")
    ? alert.labels.playbook
    : `https://operations.global.cloud.sap/${alert.labels.playbook}`
}
```

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 1: [link to issue]


# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
