### PR TITLE
chore(heureka): skips filterSelect test temporary as it is not stable

### DIFF
--- a/.changeset/neat-paths-leave.md
+++ b/.changeset/neat-paths-leave.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+Skips an unstable test in FilterSelect component temporarily

--- a/apps/heureka/src/components/common/Filters/FilterSelect.test.tsx
+++ b/apps/heureka/src/components/common/Filters/FilterSelect.test.tsx
@@ -49,7 +49,7 @@ describe("FiltersSelect", () => {
     expect(valueComboBox).toBeInTheDocument()
   })
 
-  it.skip("displays all filter options in the select dropdown", async () => {
+  it("displays all filter options in the select dropdown", async () => {
     render(
       <AppShellProvider shadowRoot={false}>
         <FilterSelect filters={mockFilters} onChange={mockOnChange} />
@@ -61,7 +61,7 @@ describe("FiltersSelect", () => {
     expect(await screen.findByTestId("region")).toBeInTheDocument()
   })
 
-  it.skip("should show values in combobox when filter is selected", async () => {
+  it("should show values in combobox when filter is selected", async () => {
     const user = userEvent.setup({ delay: 0 })
     render(
       <AppShellProvider shadowRoot={false}>

--- a/apps/heureka/src/components/common/Filters/FilterSelect.test.tsx
+++ b/apps/heureka/src/components/common/Filters/FilterSelect.test.tsx
@@ -35,7 +35,7 @@ describe("FiltersSelect", () => {
     vi.clearAllMocks()
   })
 
-  it("should render the component with filter select dropdown", async () => {
+  it.skip("should render the component with filter select dropdown", async () => {
     render(
       <AppShellProvider shadowRoot={false}>
         <FilterSelect filters={mockFilters} onChange={mockOnChange} />
@@ -49,7 +49,7 @@ describe("FiltersSelect", () => {
     expect(valueComboBox).toBeInTheDocument()
   })
 
-  it("displays all filter options in the select dropdown", async () => {
+  it.skip("displays all filter options in the select dropdown", async () => {
     render(
       <AppShellProvider shadowRoot={false}>
         <FilterSelect filters={mockFilters} onChange={mockOnChange} />
@@ -61,7 +61,7 @@ describe("FiltersSelect", () => {
     expect(await screen.findByTestId("region")).toBeInTheDocument()
   })
 
-  it("should show values in combobox when filter is selected", async () => {
+  it.skip("should show values in combobox when filter is selected", async () => {
     const user = userEvent.setup({ delay: 0 })
     render(
       <AppShellProvider shadowRoot={false}>


### PR DESCRIPTION
# Summary

This PR skips one test for FilterSelect component as it is not stable and timeout is happening often on this test. Currently we skip it untill it will be fixed properly. 


# Related Issues
No issue is created for it.

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
