### PR TITLE
feat(supernova): support absolute urls in playbook links

### DIFF
--- a/apps/supernova/src/components/alerts/shared/AlertLinks.tsx
+++ b/apps/supernova/src/components/alerts/shared/AlertLinks.tsx
@@ -24,7 +24,11 @@ const AlertLinks = ({ alert, className }: any) => {
       {alert?.labels?.playbook && (
         <a
           className="underline"
-          href={`https://operations.global.cloud.sap/${alert?.labels?.playbook}`}
+          href={
+            alert.labels.playbook.startsWith("http")
+              ? alert.labels.playbook
+              : `https://operations.global.cloud.sap/${alert.labels.playbook}`
+          }
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
Currently the link generator which creates clickable links to playbooks for alerts assumes the playbook label contains relative links. This PR enhances the link generator with a check whether the playbook label already contains an absolute url. In these cases that url will be used when generating the clickable link.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- add check for absolute links in playbook label
- absolute links aren't modified but taken as is as the `href` of the clickable link


# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
