### PR TITLE
fix(greenhouse): ensure nginx redirects to /index.html for unknown routes

### DIFF
--- a/.changeset/heavy-actors-retire.md
+++ b/.changeset/heavy-actors-retire.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+Update nginx.conf so the client side routing works.

--- a/apps/greenhouse/docker/nginx.conf
+++ b/apps/greenhouse/docker/nginx.conf
@@ -22,7 +22,7 @@ server {
         application/javascript mjs js;
     }
     
-    location / {
-        index index.html index.htm;
-    }
+	location / {
+		try_files $uri $uri/ /index.html;
+	}
 }


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->

This PR fixes the issue where when(greenhouse is) served via `nginx` web server client side routes like `/doop`,  `/heureka` do not work because these are unknown to the web server. So in case of unknown routes we need to serve `/index.html` so the client side router takes over the responsibility to render the correct page.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Changed `nginx.conf`
- 
# Related Issues

https://convergedcloud.slack.com/archives/C04Q0QM40KF/p1755700365206899

# Screenshots (if applicable)

N/A

# Testing Instructions

Most efficient way is to test it directly on QA after merge otherwise need to spin up nginx on local server with these configuration and verify it that works.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
