### PR TITLE
fix(juno): address issues from url refactoring topic

### DIFF
--- a/.changeset/eighty-parks-think.md
+++ b/.changeset/eighty-parks-think.md
@@ -1,5 +1,0 @@
----
-"@cloudoperators/juno-ui-components": minor
----
-
-Added `ToggleButton` and `SortButton` components.

--- a/.changeset/free-lights-mate.md
+++ b/.changeset/free-lights-mate.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-supernova": patch
+---
+
+- Selected alert in url state gets removed when panel closes.
+- Supernova now preserves the URL state of the currently opened page when navigating to another page and restores it back when that page is visited again.

--- a/.changeset/new-houses-find.md
+++ b/.changeset/new-houses-find.md
@@ -1,0 +1,7 @@
+---
+"@cloudoperators/juno-app-greenhouse": patch
+"@cloudoperators/juno-app-supernova": patch
+"@cloudoperators/juno-app-doop": patch
+---
+
+Addressed issues found while testing new client side routing and url state.

--- a/.changeset/new-houses-find.md
+++ b/.changeset/new-houses-find.md
@@ -1,7 +1,5 @@
 ---
 "@cloudoperators/juno-app-greenhouse": patch
-"@cloudoperators/juno-app-supernova": patch
-"@cloudoperators/juno-app-doop": patch
 ---
 
-Addressed issues found while testing new client side routing and url state.
+Greenhouse now preserves the URL state of the currently opened app when navigating to another app and restores it back when that app is visited again.

--- a/.changeset/pretty-eagles-kiss.md
+++ b/.changeset/pretty-eagles-kiss.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-doop": patch
+---
+
+Selected `violationGroup` is now persisted on URL state and removed from it when the panel is closed.

--- a/apps/doop/src/components/violations/ViolationDetails.tsx
+++ b/apps/doop/src/components/violations/ViolationDetails.tsx
@@ -9,8 +9,10 @@ import { useDataDetailsViolationGroupKind, useDataActions } from "../StoreProvid
 import HintLoading from "../shared/HintLoading"
 import ViolationDetailsList from "./ViolationDetailsList"
 import Filters from "../filters/Filters"
+import { useNavigate } from "@tanstack/react-router"
 
 const ViolationDetails = () => {
+  const navigate = useNavigate()
   const detailsViolationGroupKind = useDataDetailsViolationGroupKind()
   // @ts-expect-error - setDetailsViolationGroupKind is not defined
   const { setDetailsViolationGroupKind } = useDataActions()
@@ -31,6 +33,10 @@ const ViolationDetails = () => {
       heading={`Check: ${detailsViolationGroupKind}`}
       onClose={() => {
         setDetailsViolationGroupKind(null)
+        navigate({
+          to: "/violations",
+          search: (prev) => ({ ...prev, violationGroup: undefined }),
+        })
       }}
       opened={!!detailsViolationGroupKind}
       size="large"

--- a/apps/doop/src/components/violations/ViolationsListItem.tsx
+++ b/apps/doop/src/components/violations/ViolationsListItem.tsx
@@ -4,12 +4,17 @@
  */
 
 import React from "react"
+import { useNavigate, useSearch } from "@tanstack/react-router"
 import { Stack, Badge, DataGridRow, DataGridCell, Icon } from "@cloudoperators/juno-ui-components"
 import { useDataDetailsViolationGroupKind, useDataActions } from "../StoreProvider"
 import ViolationServicesCount from "./ViolationServicesCount"
 import ViolationSeverity from "./ViolationSeverity"
 
 const ViolationListItem = ({ item }: any) => {
+  const navigate = useNavigate()
+  const { violationGroup } = useSearch({
+    from: "/violations",
+  })
   const detailsViolationGroupKind = useDataDetailsViolationGroupKind()
   // @ts-expect-error TS(2339) FIXME: Property 'setDetailsViolationGroupKind' does not exist on type 'any'.
   const { setDetailsViolationGroupKind } = useDataActions()
@@ -17,11 +22,18 @@ const ViolationListItem = ({ item }: any) => {
   return (
     <DataGridRow
       className={`cursor-pointer ${detailsViolationGroupKind === item?.kind ? "active" : ""}`}
-      onClick={() =>
+      onClick={() => {
         detailsViolationGroupKind === item.kind
           ? setDetailsViolationGroupKind(null)
           : setDetailsViolationGroupKind(item?.kind)
-      }
+        navigate({
+          to: "/violations",
+          search: (prev) => ({
+            ...prev,
+            violationGroup: violationGroup !== item?.kind ? item?.kind : undefined,
+          }),
+        })
+      }}
     >
       <DataGridCell className="pl-0">
         <ViolationSeverity severities={item?.severities} className="pl-5" border />

--- a/apps/greenhouse/src/components/nav/PluginNav.tsx
+++ b/apps/greenhouse/src/components/nav/PluginNav.tsx
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react"
-import { useMatches, useNavigate } from "@tanstack/react-router"
+import React, { useRef } from "react"
+import { AnySchema, useMatches, useNavigate } from "@tanstack/react-router"
 import GreenhouseLogo from "../../assets/greenhouse_logo.svg?react"
 import SupernovaIcon from "../../assets/juno_supernova.svg?react"
 import DoopIcon from "../../assets/juno_doop.svg?react"
@@ -60,6 +60,7 @@ break-all
 `
 
 const PluginNav = () => {
+  const visitedApps = useRef<Record<string, AnySchema>>({})
   const appConfig = usePlugin().appConfig()
   const mngConfig = usePlugin().mngConfig()
   const navigate = useNavigate({ from: "/" })
@@ -69,8 +70,13 @@ const PluginNav = () => {
   const { data: authData, loggedIn, login, logout } = useAuth()
 
   const navigateToApp = (appId: string) => {
+    // save the url state of the current app
+    if (activeApp) {
+      visitedApps.current[activeApp] = matches[matches.length - 1].search
+    }
     navigate({
       to: `/${appId}`,
+      search: visitedApps.current[appId] ?? {}, // restore the url state of the target app
     })
   }
 

--- a/apps/greenhouse/src/components/nav/PluginNav.tsx
+++ b/apps/greenhouse/src/components/nav/PluginNav.tsx
@@ -70,7 +70,7 @@ const PluginNav = () => {
   const { data: authData, loggedIn, login, logout } = useAuth()
 
   const navigateToApp = (appId: string) => {
-    // save the url state of the current app
+    // Save the current app's URL state to restore it later
     if (activeApp) {
       visitedApps.current[activeApp] = matches[matches.length - 1].search
     }

--- a/apps/supernova/src/components/CustomAppShell.tsx
+++ b/apps/supernova/src/components/CustomAppShell.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react"
+import React, { useRef } from "react"
+import { useNavigate, useMatches, AnySchema } from "@tanstack/react-router"
 import { AppShell, PageHeader, TopNavigation, TopNavigationItem } from "@cloudoperators/juno-ui-components"
-import { useNavigate, useMatches, useRouter } from "@tanstack/react-router"
 import { useGlobalsEmbedded } from "./StoreProvider"
 
 type NavigationItemType = {
@@ -28,15 +28,20 @@ const navigationItems: NavigationItemType[] = [
 ]
 
 const CustomAppShell = ({ children }: any) => {
+  const visitedPages = useRef<Record<string, AnySchema>>({})
   const navigate = useNavigate()
   const matches = useMatches()
-  const router = useRouter()
   const embedded = useGlobalsEmbedded()
 
   const handleTabSelect = (link: React.ReactNode) => {
+    // save the url state of the current page
+    const currentPath = matches[matches.length - 1].id
+    visitedPages.current[currentPath] = matches[matches.length - 1].search
+
     if (typeof link === "string") {
       navigate({
         to: link,
+        search: visitedPages.current[link] ?? {}, // restore the url state of the target page
       })
     }
   }

--- a/apps/supernova/src/components/CustomAppShell.tsx
+++ b/apps/supernova/src/components/CustomAppShell.tsx
@@ -34,7 +34,7 @@ const CustomAppShell = ({ children }: any) => {
   const embedded = useGlobalsEmbedded()
 
   const handleTabSelect = (link: React.ReactNode) => {
-    // save the url state of the current page
+    // Save the current pages's URL state to restore it later
     const currentPath = matches[matches.length - 1].id
     visitedPages.current[currentPath] = matches[matches.length - 1].search
 

--- a/apps/supernova/src/components/alerts/Alert.tsx
+++ b/apps/supernova/src/components/alerts/Alert.tsx
@@ -4,10 +4,11 @@
  */
 
 import React, { forwardRef, useRef } from "react"
+import { useNavigate, useSearch } from "@tanstack/react-router"
 
 import { DataGridCell, DataGridRow } from "@cloudoperators/juno-ui-components"
 
-import { useGlobalsActions, useShowDetailsFor } from "../StoreProvider"
+import { useShowDetailsFor } from "../StoreProvider"
 import AlertLabels from "./shared/AlertLabels"
 import AlertLinks from "./shared/AlertLinks"
 import CreateSilence from "../silences/CreateSilence"
@@ -16,7 +17,6 @@ import AlertDescription from "./shared/AlertDescription"
 import AlertTimestamp from "./shared/AlertTimestamp"
 import AlertStatus from "./AlertStatus"
 import AlertRegion from "./shared/AlertRegion"
-import { useNavigate } from "@tanstack/react-router"
 
 const cellSeverityClasses = (severity: any) => {
   let borderColor = "border-text-theme-default"
@@ -42,6 +42,9 @@ const cellSeverityClasses = (severity: any) => {
 
 const Alert = ({ alert }: any, ref: any) => {
   const navigate = useNavigate()
+  const { showDetailsFor } = useSearch({
+    from: "/alerts",
+  })
   const rowRef = useRef(null)
 
   const handleShowDetails = (e: any) => {
@@ -61,7 +64,14 @@ const Alert = ({ alert }: any, ref: any) => {
 
     e.stopPropagation()
     e.preventDefault()
-    navigate({ to: "/alerts", search: (prev) => ({ ...prev, showDetailsFor: alert?.fingerprint }) })
+    navigate({
+      to: "/alerts",
+      search: (prev) => ({
+        ...prev,
+        // if the alert is already open, close it, otherwise open the new one
+        showDetailsFor: showDetailsFor !== alert?.fingerprint ? alert?.fingerprint : undefined,
+      }),
+    })
   }
 
   return (


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
This PR addresses issue's that have been found by Esther while testing it on QA.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- `supernova` now remembers url state of a visited page and restores it back when the page is visited again. This fixes the issues of filters being removed when navigating to Alerts after coming from another page like `Silences` and vice versa.
- `greenhouse` now remembers url state of an application and restores it back when opened again.
- In `supernova`: Selected alert in the url state gets removed when clicking on the same item in the list.
- In `doop`:  Selected `violationGroup` gets added and removed to the url when panel opens or closes.


# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- https://github.com/cloudoperators/juno/issues/1173
# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
