### PR TITLE
chore(ci): allow renovate to check all apps and packages grouped

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,11 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
   "enabledManagers": ["npm", "github-actions"],
-  "includePaths": [
-    "packages/ui-components/**",
-    "apps/heureka/**",
-    ".github/workflows/**"
-  ],
+  "includePaths": ["packages/**", "apps/**", ".github/workflows/**"],
   "rangeStrategy": "update-lockfile",
   "packageRules": [
     {
@@ -17,17 +13,17 @@
       "minimumReleaseAge": "14 days"
     },
     {
-      "groupName": "dependencies for ui-components",
+      "groupName": "dependencies for packages",
       "matchDatasources": ["npm"],
-      "matchFileNames": ["packages/ui-components/**"],
+      "matchFileNames": ["packages/**"],
       "matchUpdateTypes": ["minor", "patch"],
       "minimumReleaseAge": "7 days",
       "schedule": "every weekend"
     },
     {
-      "groupName": "dependencies for heureka",
+      "groupName": "dependencies for apps",
       "matchDatasources": ["npm"],
-      "matchFileNames": ["apps/heureka/**"],
+      "matchFileNames": ["apps/**"],
       "matchUpdateTypes": ["minor", "patch"],
       "minimumReleaseAge": "7 days",
       "schedule": "every weekend"


### PR DESCRIPTION
# Summary

Enables Renovate to check all apps and packages in a grouped manner for streamlined dependency updates.

# Changes Made

- Change renovate configuration

# Related Issue
 - [x] #1178 

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
