### PR TITLE
chore(ci): pin remaining deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
   "enabledManagers": ["npm", "github-actions"],
-  "includePaths": ["packages/**", "apps/**", ".github/workflows/**"],
+  "includePaths": ["packages/**", "apps/**", "./package.json", ".github/workflows/**"],
   "rangeStrategy": "update-lockfile",
   "packageRules": [
     {
@@ -13,17 +13,9 @@
       "minimumReleaseAge": "14 days"
     },
     {
-      "groupName": "dependencies for packages",
+      "groupName": "npm dependencies",
       "matchDatasources": ["npm"],
-      "matchFileNames": ["packages/**"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "minimumReleaseAge": "7 days",
-      "schedule": "every weekend"
-    },
-    {
-      "groupName": "dependencies for apps",
-      "matchDatasources": ["npm"],
-      "matchFileNames": ["apps/**"],
+      "matchFileNames": ["packages/**", "apps/**", "./package.json"],
       "matchUpdateTypes": ["minor", "patch"],
       "minimumReleaseAge": "7 days",
       "schedule": "every weekend"

--- a/apps/carbon/package.json
+++ b/apps/carbon/package.json
@@ -27,15 +27,15 @@
   },
   "dependencies": {
     "@cloudoperators/juno-ui-components": "workspace:*",
-    "@tailwindcss/vite": "^4.1.11",
+    "@tailwindcss/vite": "4.1.13",
     "@tanstack/react-query": "5.62.2",
-    "@vitejs/plugin-react": "^4.6.0",
-    "classnames": "^2.5.1",
+    "@vitejs/plugin-react": "4.7.0",
+    "classnames": "2.5.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-error-boundary": "^3.1.0",
-    "wouter": "^3.3.5",
-    "zustand": "^4.5.7"
+    "react-error-boundary": "3.1.4",
+    "wouter": "3.7.1",
+    "zustand": "4.5.7"
   },
   "devDependencies": {
     "@cloudoperators/juno-config": "workspace:*",

--- a/apps/doop/package.json
+++ b/apps/doop/package.json
@@ -31,7 +31,7 @@
     "jsdom": "26.1.0",
     "luxon": "3.7.2",
     "postcss": "8.5.6",
-    "react-markdown": "^9.0.0",
+    "react-markdown": "9.1.0",
     "react-test-renderer": "19.1.1",
     "shadow-dom-testing-library": "1.13.1",
     "tailwindcss": "4.1.13",

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -41,13 +41,13 @@
     "@cloudoperators/juno-oauth": "workspace:*",
     "@cloudoperators/juno-ui-components": "workspace:*",
     "@cloudoperators/juno-url-state-provider": "workspace:*",
-    "@tailwindcss/vite": "^4.1.11",
-    "@vitejs/plugin-react": "^4.6.0",
-    "msw": "^2.6.6",
+    "@tailwindcss/vite": "4.1.13",
+    "@vitejs/plugin-react": "4.7.0",
+    "msw": "2.11.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "vite-plugin-svgr": "^4.3.0",
-    "zustand": "^4.5.7"
+    "vite-plugin-svgr": "4.5.0",
+    "zustand": "4.5.7"
   },
   "scripts": {
     "test": "vitest run",

--- a/apps/greenhouse/package.json
+++ b/apps/greenhouse/package.json
@@ -63,9 +63,9 @@
     "@tanstack/react-router": "1.131.25",
     "@tanstack/react-router-devtools": "1.131.25",
     "lodash": "4.17.21",
-    "rehype": "^13.0.2",
-    "remark": "^14.0.2",
-    "vfile": "^5.3.7",
-    "vfile-message": "^3.1.4"
+    "rehype": "13.0.2",
+    "remark": "14.0.3",
+    "vfile": "5.3.7",
+    "vfile-message": "3.1.4"
   }
 }

--- a/apps/supernova/package.json
+++ b/apps/supernova/package.json
@@ -59,7 +59,7 @@
     "@tanstack/react-router-devtools": "1.131.25",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-error-boundary": "^4.0.13",
+    "react-error-boundary": "4.1.2",
     "zod": "3.24.4"
   }
 }

--- a/apps/template/package.json
+++ b/apps/template/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-error-boundary": "^3.1.0",
-    "zustand": "^4.5.7",
+    "react-error-boundary": "3.1.4",
+    "zustand": "4.5.7",
     "@tanstack/react-query": "5.62.2",
     "@cloudoperators/juno-ui-components": "workspace:*"
   },

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "pre:push": "turbo run lint typecheck"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.27.1",
-    "@commitlint/cli": "^19.4.0",
-    "@commitlint/config-conventional": "^19.2.2",
-    "@types/luxon": "^3.4.2",
-    "@types/node": "^24.0.3",
-    "eslint": "^9.31.0",
-    "husky": "^9.1.5",
-    "license-checker-rseidelsohn": "^4.4.2",
-    "prettier": "^3.2.5",
-    "turbo": "^2.0.3",
-    "typescript": "^5.8.3"
+    "@changesets/cli": "2.29.7",
+    "@commitlint/cli": "19.8.1",
+    "@commitlint/config-conventional": "19.8.1",
+    "@types/luxon": "3.7.1",
+    "@types/node": "24.3.2",
+    "eslint": "9.35.0",
+    "husky": "9.1.7",
+    "license-checker-rseidelsohn": "4.4.2",
+    "prettier": "3.6.2",
+    "turbo": "2.5.6",
+    "typescript": "5.9.2"
   },
   "packageManager": "pnpm@10.11.0",
   "dependencies": {
-    "@tanstack/react-query": "^5.62.2",
-    "zod": "^3.24.2"
+    "@tanstack/react-query": "5.89.0",
+    "zod": "3.25.76"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -18,6 +18,6 @@
     "typescript-eslint": "8.32.1"
   },
   "dependencies": {
-    "@eslint/js": "^9.31.0"
+    "@eslint/js": "9.35.0"
   }
 }

--- a/packages/messages-provider/package.json
+++ b/packages/messages-provider/package.json
@@ -19,9 +19,9 @@
     "pnpm": ">=8.0.0"
   },
   "peerDependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "zustand": "^4.5.7"
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "zustand": "4.5.7"
   },
   "devDependencies": {
     "@cloudoperators/juno-config": "workspace:*",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -26,7 +26,7 @@
     "vite-plugin-dts": "4.5.4"
   },
   "dependencies": {
-    "oauth-pkce": "^0.0.6"
+    "oauth-pkce": "0.0.6"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/url-state-provider/package.json
+++ b/packages/url-state-provider/package.json
@@ -55,8 +55,8 @@
     ]
   },
   "dependencies": {
-    "history": "^5.3.0",
-    "juri": "^1.0.3",
+    "history": "5.3.0",
+    "juri": "1.0.3",
     "query-string": "9.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,44 +9,44 @@ importers:
   .:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.62.2
+        specifier: 5.89.0
         version: 5.89.0(react@19.1.0)
       zod:
-        specifier: ^3.24.2
+        specifier: 3.25.76
         version: 3.25.76
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.27.1
+        specifier: 2.29.7
         version: 2.29.7(@types/node@24.3.2)
       '@commitlint/cli':
-        specifier: ^19.4.0
+        specifier: 19.8.1
         version: 19.8.1(@types/node@24.3.2)(typescript@5.9.2)
       '@commitlint/config-conventional':
-        specifier: ^19.2.2
+        specifier: 19.8.1
         version: 19.8.1
       '@types/luxon':
-        specifier: ^3.4.2
+        specifier: 3.7.1
         version: 3.7.1
       '@types/node':
-        specifier: ^24.0.3
+        specifier: 24.3.2
         version: 24.3.2
       eslint:
-        specifier: ^9.31.0
+        specifier: 9.35.0
         version: 9.35.0(jiti@2.5.1)
       husky:
-        specifier: ^9.1.5
+        specifier: 9.1.7
         version: 9.1.7
       license-checker-rseidelsohn:
-        specifier: ^4.4.2
+        specifier: 4.4.2
         version: 4.4.2
       prettier:
-        specifier: ^3.2.5
+        specifier: 3.6.2
         version: 3.6.2
       turbo:
-        specifier: ^2.0.3
+        specifier: 2.5.6
         version: 2.5.6
       typescript:
-        specifier: ^5.8.3
+        specifier: 5.9.2
         version: 5.9.2
 
   apps/carbon:
@@ -55,16 +55,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui-components
       '@tailwindcss/vite':
-        specifier: ^4.1.11
+        specifier: 4.1.13
         version: 4.1.13(vite@7.1.7(@types/node@24.3.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.81.1)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.0))
       '@tanstack/react-query':
         specifier: 5.62.2
         version: 5.62.2(react@19.1.0)
       '@vitejs/plugin-react':
-        specifier: ^4.6.0
+        specifier: 4.7.0
         version: 4.7.0(vite@7.1.7(@types/node@24.3.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.81.1)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.0))
       classnames:
-        specifier: ^2.5.1
+        specifier: 2.5.1
         version: 2.5.1
       react:
         specifier: 19.1.0
@@ -73,13 +73,13 @@ importers:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
       react-error-boundary:
-        specifier: ^3.1.0
+        specifier: 3.1.4
         version: 3.1.4(react@19.1.0)
       wouter:
-        specifier: ^3.3.5
+        specifier: 3.7.1
         version: 3.7.1(react@19.1.0)
       zustand:
-        specifier: ^4.5.7
+        specifier: 4.5.7
         version: 4.5.7(@types/react@19.1.8)(immer@10.1.3)(react@19.1.0)
     devDependencies:
       '@cloudoperators/juno-config':
@@ -240,7 +240,7 @@ importers:
         specifier: 8.5.6
         version: 8.5.6
       react-markdown:
-        specifier: ^9.0.0
+        specifier: 9.1.0
         version: 9.1.0(@types/react@19.1.8)(react@19.1.0)
       react-test-renderer:
         specifier: 19.1.1
@@ -276,13 +276,13 @@ importers:
         specifier: workspace:*
         version: link:../../packages/url-state-provider
       '@tailwindcss/vite':
-        specifier: ^4.1.11
+        specifier: 4.1.13
         version: 4.1.13(vite@7.1.7(@types/node@24.3.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.81.1)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.0))
       '@vitejs/plugin-react':
-        specifier: ^4.6.0
+        specifier: 4.7.0
         version: 4.7.0(vite@7.1.7(@types/node@24.3.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.81.1)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.0))
       msw:
-        specifier: ^2.6.6
+        specifier: 2.11.2
         version: 2.11.2(@types/node@24.3.2)(typescript@5.9.2)
       react:
         specifier: 19.1.0
@@ -291,10 +291,10 @@ importers:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
       vite-plugin-svgr:
-        specifier: ^4.3.0
+        specifier: 4.5.0
         version: 4.5.0(rollup@4.50.1)(typescript@5.9.2)(vite@7.1.7(@types/node@24.3.2)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.81.1)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.0))
       zustand:
-        specifier: ^4.5.7
+        specifier: 4.5.7
         version: 4.5.7(@types/react@19.1.8)(immer@10.1.3)(react@19.1.0)
     devDependencies:
       '@cloudoperators/juno-config':
@@ -382,16 +382,16 @@ importers:
         specifier: 4.17.21
         version: 4.17.21
       rehype:
-        specifier: ^13.0.2
+        specifier: 13.0.2
         version: 13.0.2
       remark:
-        specifier: ^14.0.2
+        specifier: 14.0.3
         version: 14.0.3
       vfile:
-        specifier: ^5.3.7
+        specifier: 5.3.7
         version: 5.3.7
       vfile-message:
-        specifier: ^3.1.4
+        specifier: 3.1.4
         version: 3.1.4
     devDependencies:
       '@cloudoperators/juno-config':
@@ -645,7 +645,7 @@ importers:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
       react-error-boundary:
-        specifier: ^4.0.13
+        specifier: 4.1.2
         version: 4.1.2(react@19.1.0)
       zod:
         specifier: 3.24.4
@@ -736,10 +736,10 @@ importers:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
       react-error-boundary:
-        specifier: ^3.1.0
+        specifier: 3.1.4
         version: 3.1.4(react@19.1.0)
       zustand:
-        specifier: ^4.5.7
+        specifier: 4.5.7
         version: 4.5.7(@types/react@19.1.8)(immer@10.1.3)(react@19.1.0)
     devDependencies:
       '@cloudoperators/juno-config':
@@ -845,7 +845,7 @@ importers:
   packages/config:
     dependencies:
       '@eslint/js':
-        specifier: ^9.31.0
+        specifier: 9.35.0
         version: 9.35.0
     devDependencies:
       '@eslint/compat':
@@ -940,7 +940,7 @@ importers:
   packages/oauth:
     dependencies:
       oauth-pkce:
-        specifier: ^0.0.6
+        specifier: 0.0.6
         version: 0.0.6
     devDependencies:
       '@cloudoperators/juno-config':
@@ -1091,10 +1091,10 @@ importers:
   packages/url-state-provider:
     dependencies:
       history:
-        specifier: ^5.3.0
+        specifier: 5.3.0
         version: 5.3.0
       juri:
-        specifier: ^1.0.3
+        specifier: 1.0.3
         version: 1.0.3
       query-string:
         specifier: 9.1.1
@@ -1779,10 +1779,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/runtime@7.27.1':
-    resolution: {integrity: sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
@@ -3506,9 +3502,6 @@ packages:
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
-
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -8085,7 +8078,7 @@ snapshots:
 
   '@babel/parser@7.27.5':
     dependencies:
-      '@babel/types': 7.27.6
+      '@babel/types': 7.28.4
 
   '@babel/parser@7.28.0':
     dependencies:
@@ -8696,8 +8689,6 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.27.1(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/runtime@7.27.1': {}
 
   '@babel/runtime@7.28.4': {}
 
@@ -9871,7 +9862,7 @@ snapshots:
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.28.4
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -10701,24 +10692,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.27.5
-      '@babel/types': 7.27.6
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.7
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.27.6
+      '@babel/types': 7.28.4
 
   '@types/babel__template@7.4.4':
     dependencies:
       '@babel/parser': 7.28.4
-      '@babel/types': 7.27.6
+      '@babel/types': 7.28.4
 
   '@types/babel__traverse@7.20.7':
     dependencies:
-      '@babel/types': 7.27.6
+      '@babel/types': 7.28.4
 
   '@types/chai@5.2.2':
     dependencies:
@@ -10756,8 +10747,6 @@ snapshots:
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
-
-  '@types/estree@1.0.7': {}
 
   '@types/estree@1.0.8': {}
 
@@ -11792,7 +11781,7 @@ snapshots:
     dependencies:
       '@types/node': 24.3.2
       cosmiconfig: 9.0.0(typescript@5.9.2)
-      jiti: 2.4.2
+      jiti: 2.5.1
       typescript: 5.9.2
 
   cosmiconfig@8.3.6(typescript@5.9.2):
@@ -12230,7 +12219,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       chalk: 4.1.2
@@ -12670,7 +12659,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -12711,7 +12700,7 @@ snapshots:
 
   history@5.3.0:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.28.4
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -14375,7 +14364,7 @@ snapshots:
 
   react-error-boundary@3.1.4(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.28.4
       react: 19.1.0
 
   react-error-boundary@4.1.2(react@19.1.0):


### PR DESCRIPTION
# Summary

This PR pins dependencies to exact version by taking the version from `pnpm-lock.yaml` file to make sure that we don't loose the patch updates that were already done. Moreover it updates renovate config to include repo level `pacakge.json` and creates one group for all `npm` dependencies rather than having two.

<!-- Provide a short summary explaining the purpose of this pull request. -->

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Pin dependencies to exact version
- Update renovate config to have one group of all npm deps.

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- #1185 

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

Every app should work as before

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
