### PR TITLE
feat(heureka): implements initial filter URL synchronization and its filter pill deletion

### DIFF
--- a/apps/heureka/src/components/Services/ServicesFilters.tsx
+++ b/apps/heureka/src/components/Services/ServicesFilters.tsx
@@ -3,26 +3,75 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback } from "react"
-import { useLoaderData, useNavigate } from "@tanstack/react-router"
+import React, { useCallback, useEffect, useRef } from "react"
+import { useLoaderData, useNavigate, useRouteContext } from "@tanstack/react-router"
 import { Filters } from "../common/Filters"
 import { FilterSettings } from "../common/Filters/types"
-import { getFiltersForUrl } from "./utils"
+import { getFiltersForUrl, getInitialFilters } from "./utils"
+import { SELECTED_FILTER_PREFIX } from "../../constants"
 
 export const ServicesFilters = () => {
   const navigate = useNavigate()
   const { filters, filterSettings } = useLoaderData({ from: "/services/" })
+  const { appProps } = useRouteContext({ from: "/services/" })
+  const initialFiltersApplied = useRef(false)
+
+  // Handle initial filters on first load (similar to doop's useUrlState pattern)
+  useEffect(() => {
+    if (initialFiltersApplied.current) return // Only run once
+
+    // Check URL directly instead of relying on filterSettings to avoid stale closure
+    const urlParams = new URLSearchParams(window.location.search)
+    const hasUrlFilters = Array.from(urlParams.keys()).some((key) => key.startsWith(SELECTED_FILTER_PREFIX))
+    const hasAnySearchParams = urlParams.toString().length > 0
+
+    // Only apply initial filters if no URL filters exist and no search params are present
+    if (
+      !hasUrlFilters &&
+      !hasAnySearchParams &&
+      appProps?.initialFilters?.support_group &&
+      appProps.initialFilters.support_group.length > 0
+    ) {
+      const initialFilters = getInitialFilters(appProps.initialFilters)
+
+      if (initialFilters.length > 0) {
+        const initialFilterSettings = {
+          searchTerm: "",
+          selectedFilters: initialFilters,
+        }
+
+        navigate({
+          to: "/services",
+          search: getFiltersForUrl(initialFilterSettings),
+          replace: true,
+        })
+        initialFiltersApplied.current = true
+      }
+    }
+  }, [navigate, appProps])
 
   const handleFilterChange = useCallback(
     (updatedFilterSettings: FilterSettings) => {
       navigate({
         to: "/services",
-        search: {
-          ...getFiltersForUrl(updatedFilterSettings),
+        search: (prev) => {
+          // Get the new filter URL params
+          const newFilterParams = getFiltersForUrl(updatedFilterSettings)
+
+          // Remove all existing filter params from prev
+          const cleanedPrev = Object.fromEntries(
+            Object.entries(prev).filter(([key]) => !key.startsWith(SELECTED_FILTER_PREFIX))
+          )
+
+          // Merge with new filter params
+          return {
+            ...cleanedPrev,
+            ...newFilterParams,
+          }
         },
       })
     },
-    [filterSettings, navigate]
+    [navigate]
   )
 
   return (

--- a/apps/heureka/src/components/Services/utils.ts
+++ b/apps/heureka/src/components/Services/utils.ts
@@ -279,22 +279,22 @@ export const getNormalizedImageVersionIssuesResponse = (data: any): NormalizedIm
  *   }
  */
 export const getFiltersForUrl = (filterSettings: FilterSettings): Record<string, string | string[]> => {
-  if (!filterSettings?.selectedFilters) {
-    return {}
+  const result: Record<string, string | string[]> = {
+    searchTerm: filterSettings.searchTerm || "",
   }
 
-  return {
-    searchTerm: filterSettings.searchTerm || "",
-    ...filterSettings.selectedFilters.reduce<Record<string, string | string[]>>((acc, filter) => {
+  if (filterSettings?.selectedFilters && filterSettings.selectedFilters.length > 0) {
+    filterSettings.selectedFilters.forEach((filter) => {
       const key = `${SELECTED_FILTER_PREFIX}${filter.name}`
-      if (acc[key]) {
-        acc[key] = Array.isArray(acc[key]) ? [...acc[key], filter.value] : [acc[key], filter.value]
+      if (result[key]) {
+        result[key] = Array.isArray(result[key]) ? [...result[key], filter.value] : [result[key], filter.value]
       } else {
-        acc[key] = filter.value
+        result[key] = filter.value
       }
-      return acc
-    }, {}),
+    })
   }
+
+  return result
 }
 
 export const getNormalizedFilters = (data: GetServiceFiltersQuery | undefined | null): Filter[] =>

--- a/apps/heureka/src/components/Vulnerabilities/VulnerabilitiesFilters.tsx
+++ b/apps/heureka/src/components/Vulnerabilities/VulnerabilitiesFilters.tsx
@@ -8,6 +8,7 @@ import { useLoaderData, useNavigate } from "@tanstack/react-router"
 import { Filters } from "../common/Filters"
 import { FilterSettings } from "../common/Filters/types"
 import { getFiltersForUrl } from "./utils"
+import { SELECTED_FILTER_PREFIX } from "../../constants"
 
 export const VulnerabilitiesFilters = () => {
   const navigate = useNavigate()
@@ -17,12 +18,24 @@ export const VulnerabilitiesFilters = () => {
     (updatedFilterSettings: FilterSettings) => {
       navigate({
         to: "/vulnerabilities",
-        search: {
-          ...getFiltersForUrl(updatedFilterSettings),
+        search: (prev) => {
+          // Get the new filter URL params
+          const newFilterParams = getFiltersForUrl(updatedFilterSettings)
+
+          // Remove all existing filter params from prev
+          const cleanedPrev = Object.fromEntries(
+            Object.entries(prev).filter(([key]) => !key.startsWith(SELECTED_FILTER_PREFIX))
+          )
+
+          // Merge with new filter params
+          return {
+            ...cleanedPrev,
+            ...newFilterParams,
+          }
         },
       })
     },
-    [filterSettings, navigate]
+    [navigate]
   )
 
   return (

--- a/apps/heureka/src/components/common/Filters/SelectedFilters.tsx
+++ b/apps/heureka/src/components/common/Filters/SelectedFilters.tsx
@@ -16,7 +16,7 @@ export const SelectedFilters = ({ selectedFilters, onDelete }: SelectedFiltersPr
   <Stack gap="2" wrap={true}>
     {selectedFilters?.map((filter) => (
       <Pill
-        key={`${name}:${filter.value}`}
+        key={`${filter.name}:${filter.value}`}
         closeable
         pillKey={filter.name}
         pillValue={filter.value}

--- a/apps/heureka/src/routeTree.gen.ts
+++ b/apps/heureka/src/routeTree.gen.ts
@@ -8,141 +8,104 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as VulnerabilitiesRouteRouteImport } from './routes/vulnerabilities/route'
-import { Route as ServicesRouteRouteImport } from './routes/services/route'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as VulnerabilitiesIndexRouteImport } from './routes/vulnerabilities/index'
-import { Route as ServicesIndexRouteImport } from './routes/services/index'
-import { Route as ServicesServiceRouteImport } from './routes/services/$service'
+// Import Routes
 
-const VulnerabilitiesRouteRoute = VulnerabilitiesRouteRouteImport.update({
+import { Route as rootRoute } from './routes/__root'
+import { Route as VulnerabilitiesRouteImport } from './routes/vulnerabilities/route'
+import { Route as ServicesRouteImport } from './routes/services/route'
+import { Route as IndexImport } from './routes/index'
+import { Route as VulnerabilitiesIndexImport } from './routes/vulnerabilities/index'
+import { Route as ServicesIndexImport } from './routes/services/index'
+import { Route as ServicesServiceImport } from './routes/services/$service'
+
+// Create/Update Routes
+
+const VulnerabilitiesRouteRoute = VulnerabilitiesRouteImport.update({
   id: '/vulnerabilities',
   path: '/vulnerabilities',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const ServicesRouteRoute = ServicesRouteRouteImport.update({
+
+const ServicesRouteRoute = ServicesRouteImport.update({
   id: '/services',
   path: '/services',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const IndexRoute = IndexRouteImport.update({
+
+const IndexRoute = IndexImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const VulnerabilitiesIndexRoute = VulnerabilitiesIndexRouteImport.update({
+
+const VulnerabilitiesIndexRoute = VulnerabilitiesIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => VulnerabilitiesRouteRoute,
 } as any)
-const ServicesIndexRoute = ServicesIndexRouteImport.update({
+
+const ServicesIndexRoute = ServicesIndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => ServicesRouteRoute,
 } as any)
-const ServicesServiceRoute = ServicesServiceRouteImport.update({
+
+const ServicesServiceRoute = ServicesServiceImport.update({
   id: '/$service',
   path: '/$service',
   getParentRoute: () => ServicesRouteRoute,
 } as any)
 
-export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/services': typeof ServicesRouteRouteWithChildren
-  '/vulnerabilities': typeof VulnerabilitiesRouteRouteWithChildren
-  '/services/$service': typeof ServicesServiceRoute
-  '/services/': typeof ServicesIndexRoute
-  '/vulnerabilities/': typeof VulnerabilitiesIndexRoute
-}
-export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/services/$service': typeof ServicesServiceRoute
-  '/services': typeof ServicesIndexRoute
-  '/vulnerabilities': typeof VulnerabilitiesIndexRoute
-}
-export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/services': typeof ServicesRouteRouteWithChildren
-  '/vulnerabilities': typeof VulnerabilitiesRouteRouteWithChildren
-  '/services/$service': typeof ServicesServiceRoute
-  '/services/': typeof ServicesIndexRoute
-  '/vulnerabilities/': typeof VulnerabilitiesIndexRoute
-}
-export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/services'
-    | '/vulnerabilities'
-    | '/services/$service'
-    | '/services/'
-    | '/vulnerabilities/'
-  fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/services/$service' | '/services' | '/vulnerabilities'
-  id:
-    | '__root__'
-    | '/'
-    | '/services'
-    | '/vulnerabilities'
-    | '/services/$service'
-    | '/services/'
-    | '/vulnerabilities/'
-  fileRoutesById: FileRoutesById
-}
-export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  ServicesRouteRoute: typeof ServicesRouteRouteWithChildren
-  VulnerabilitiesRouteRoute: typeof VulnerabilitiesRouteRouteWithChildren
-}
+// Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/vulnerabilities': {
-      id: '/vulnerabilities'
-      path: '/vulnerabilities'
-      fullPath: '/vulnerabilities'
-      preLoaderRoute: typeof VulnerabilitiesRouteRouteImport
-      parentRoute: typeof rootRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
     }
     '/services': {
       id: '/services'
       path: '/services'
       fullPath: '/services'
-      preLoaderRoute: typeof ServicesRouteRouteImport
-      parentRoute: typeof rootRouteImport
+      preLoaderRoute: typeof ServicesRouteImport
+      parentRoute: typeof rootRoute
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/vulnerabilities/': {
-      id: '/vulnerabilities/'
-      path: '/'
-      fullPath: '/vulnerabilities/'
-      preLoaderRoute: typeof VulnerabilitiesIndexRouteImport
-      parentRoute: typeof VulnerabilitiesRouteRoute
-    }
-    '/services/': {
-      id: '/services/'
-      path: '/'
-      fullPath: '/services/'
-      preLoaderRoute: typeof ServicesIndexRouteImport
-      parentRoute: typeof ServicesRouteRoute
+    '/vulnerabilities': {
+      id: '/vulnerabilities'
+      path: '/vulnerabilities'
+      fullPath: '/vulnerabilities'
+      preLoaderRoute: typeof VulnerabilitiesRouteImport
+      parentRoute: typeof rootRoute
     }
     '/services/$service': {
       id: '/services/$service'
       path: '/$service'
       fullPath: '/services/$service'
-      preLoaderRoute: typeof ServicesServiceRouteImport
-      parentRoute: typeof ServicesRouteRoute
+      preLoaderRoute: typeof ServicesServiceImport
+      parentRoute: typeof ServicesRouteImport
+    }
+    '/services/': {
+      id: '/services/'
+      path: '/'
+      fullPath: '/services/'
+      preLoaderRoute: typeof ServicesIndexImport
+      parentRoute: typeof ServicesRouteImport
+    }
+    '/vulnerabilities/': {
+      id: '/vulnerabilities/'
+      path: '/'
+      fullPath: '/vulnerabilities/'
+      preLoaderRoute: typeof VulnerabilitiesIndexImport
+      parentRoute: typeof VulnerabilitiesRouteImport
     }
   }
 }
+
+// Create and export the route tree
 
 interface ServicesRouteRouteChildren {
   ServicesServiceRoute: typeof ServicesServiceRoute
@@ -169,11 +132,109 @@ const VulnerabilitiesRouteRouteChildren: VulnerabilitiesRouteRouteChildren = {
 const VulnerabilitiesRouteRouteWithChildren =
   VulnerabilitiesRouteRoute._addFileChildren(VulnerabilitiesRouteRouteChildren)
 
+export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
+  '/services': typeof ServicesRouteRouteWithChildren
+  '/vulnerabilities': typeof VulnerabilitiesRouteRouteWithChildren
+  '/services/$service': typeof ServicesServiceRoute
+  '/services/': typeof ServicesIndexRoute
+  '/vulnerabilities/': typeof VulnerabilitiesIndexRoute
+}
+
+export interface FileRoutesByTo {
+  '/': typeof IndexRoute
+  '/services/$service': typeof ServicesServiceRoute
+  '/services': typeof ServicesIndexRoute
+  '/vulnerabilities': typeof VulnerabilitiesIndexRoute
+}
+
+export interface FileRoutesById {
+  __root__: typeof rootRoute
+  '/': typeof IndexRoute
+  '/services': typeof ServicesRouteRouteWithChildren
+  '/vulnerabilities': typeof VulnerabilitiesRouteRouteWithChildren
+  '/services/$service': typeof ServicesServiceRoute
+  '/services/': typeof ServicesIndexRoute
+  '/vulnerabilities/': typeof VulnerabilitiesIndexRoute
+}
+
+export interface FileRouteTypes {
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/services'
+    | '/vulnerabilities'
+    | '/services/$service'
+    | '/services/'
+    | '/vulnerabilities/'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/' | '/services/$service' | '/services' | '/vulnerabilities'
+  id:
+    | '__root__'
+    | '/'
+    | '/services'
+    | '/vulnerabilities'
+    | '/services/$service'
+    | '/services/'
+    | '/vulnerabilities/'
+  fileRoutesById: FileRoutesById
+}
+
+export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
+  ServicesRouteRoute: typeof ServicesRouteRouteWithChildren
+  VulnerabilitiesRouteRoute: typeof VulnerabilitiesRouteRouteWithChildren
+}
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ServicesRouteRoute: ServicesRouteRouteWithChildren,
   VulnerabilitiesRouteRoute: VulnerabilitiesRouteRouteWithChildren,
 }
-export const routeTree = rootRouteImport
+
+export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "__root.tsx",
+      "children": [
+        "/",
+        "/services",
+        "/vulnerabilities"
+      ]
+    },
+    "/": {
+      "filePath": "index.tsx"
+    },
+    "/services": {
+      "filePath": "services/route.tsx",
+      "children": [
+        "/services/$service",
+        "/services/"
+      ]
+    },
+    "/vulnerabilities": {
+      "filePath": "vulnerabilities/route.tsx",
+      "children": [
+        "/vulnerabilities/"
+      ]
+    },
+    "/services/$service": {
+      "filePath": "services/$service.tsx",
+      "parent": "/services"
+    },
+    "/services/": {
+      "filePath": "services/index.tsx",
+      "parent": "/services"
+    },
+    "/vulnerabilities/": {
+      "filePath": "vulnerabilities/index.tsx",
+      "parent": "/vulnerabilities"
+    }
+  }
+}
+ROUTE_MANIFEST_END */

--- a/apps/heureka/src/routes/services/index.tsx
+++ b/apps/heureka/src/routes/services/index.tsx
@@ -11,7 +11,6 @@ import { fetchServices } from "../../api/fetchServices"
 import { fetchServicesFilters } from "../../api/fetchServicesFilters"
 import {
   extractFilterSettingsFromSearchParams,
-  getInitialFilters,
   getNormalizedFilters,
   sanitizeFilterSettings,
 } from "../../components/Services/utils"
@@ -42,18 +41,11 @@ export const Route = createFileRoute("/services/")({
     const { service, ...rest } = search
     return rest
   },
-  shouldReload: false, // Only reload the route when the user navigates to it or when deps change
-  beforeLoad: ({ context: { appProps }, search }) => {
+  shouldReload: true, // Reload the route when search params change
+  beforeLoad: ({ search }) => {
     const filterSettings = extractFilterSettingsFromSearchParams(search)
     return {
-      filterSettings:
-        // Filters from the URL always have preference over initial filters
-        (filterSettings?.selectedFilters ?? []).length > 0
-          ? filterSettings
-          : {
-              ...filterSettings,
-              selectedFilters: getInitialFilters(appProps?.initialFilters),
-            },
+      filterSettings,
     }
   },
   loader: async ({ context }) => {


### PR DESCRIPTION
# Summary

This PR implements initial filter functionality for the heureka services page, allowing initial filters to be applied from appProps configuration and ensuring they are properly synchronized with the URL. The implementation enables users to delete initial filter pills on the first click.

# Changes Made

- **Added initial filter application logic in ServicesFilters component**: Implemented `useRef` and `useEffect` to control when initial filters are applied from `appProps.initialFilters` to prevent multiple applications during component re-renders
- **Enhanced URL parameter handling**: Added logic to check existing URL parameters and only apply initial filters when no filter parameters are present in the URL
- **Implemented filter deletion functionality**: Ensured that initial filter pills can be properly deleted on first click by tracking application state with `initialFiltersApplied.current`
- **Added direct URL inspection**: Used `new URLSearchParams(window.location.search)` to check current URL state and avoid stale closure issues with React state

# Why useRef and useEffect Were Necessary

The implementation requires a **stateful mechanism to track whether initial filters have been applied** because:

1. **Component Re-render Protection**: Without `useRef`, the initial filter logic would run on every component re-render, potentially causing infinite loops or duplicate filter applications
2. **Avoiding Stale Closures**: The `useEffect` with direct URL inspection prevents React state closure issues where `filterSettings` might contain outdated values
3. **One-time Execution Control**: `initialFiltersApplied.current` ensures the initial filter logic runs exactly once per component lifecycle

# Why TanStack Router Redirect Alone Isn't Sufficient

Using only TanStack Router's `beforeLoad` redirect mechanism has limitations:

1. **No State Persistence**: Route-level redirects don't maintain component-level state about whether initial filters were user-applied or auto-applied
2. **Filter Deletion Issues**: Without tracking application state, deleting an initial filter would immediately trigger another redirect to re-apply it
3. **Component Lifecycle Disconnect**: Route redirects happen before component mounting, making it difficult to coordinate with user interactions like filter deletion

# State Management Architecture Considerations

Based on the current implementation, the **URL-as-state approach with TanStack Router** seems to be the primary state management strategy, which is why the initial filter implementation uses component-level `useRef` rather than a global store. This aligns with the existing codebase pattern where state is managed through URL search parameters and components derive their state from the router.

# Alternative Approaches and Their Challenges

## SessionStorage Approach
**Challenge**: SessionStorage persists across page reloads within the same browser session, which conflicts with the requirement that initial filters should be reapplied on every page reload.

## URL-based Tracking (e.g., `__init` parameter)
**Pros**: Clean separation of concerns, works with TanStack Router patterns
**Cons**: Adds visible parameters to URLs, requires additional schema validation

## Context/State Management
**Pros**: Centralized state management, reusable across components
**Cons**: Additional complexity, requires provider setup and context management, diverges from the current URL-first architecture

The current `useRef`/`useEffect` approach provides the most direct solution for the specific requirement of applying initial filters once per component mount while maintaining the ability to delete them immediately.


# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 1: https://github.com/cloudoperators/juno/issues/1012

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
