### PR TITLE
chore(heureka): enable no-unused-vars rule

### DIFF
--- a/apps/heureka/eslint.config.mjs
+++ b/apps/heureka/eslint.config.mjs
@@ -16,10 +16,10 @@ export default [
     rules: {
       "prefer-const": "off",
       "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": "error",
       "no-extra-boolean-cast": "off",
       "react/prop-types": "off",
       "react/react-in-jsx-scope": "off",
-      "react/no-unused-vars": "off",
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "off",
       "tailwindcss/classnames-order": "off",
@@ -39,6 +39,6 @@ export default [
       "@typescript-eslint/require-await": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
     },
-    ignores: ["vitest.config.ts", "vite.config.ts", "vitest.setup.ts", "tailwind.config.ts"],
+    ignores: ["vitest.config.ts", "vite.config.ts", "vitest.setup.ts", "tailwind.config.ts", "**/routeTree.gen.ts"],
   },
 ]

--- a/apps/heureka/src/components/Services/ServicesList/ServicePanel.tsx
+++ b/apps/heureka/src/components/Services/ServicesList/ServicePanel.tsx
@@ -32,6 +32,7 @@ export const ServicePanel = () => {
     navigate({
       to: "/services",
       search: (prev) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { service, ...rest } = prev
         return { ...rest }
       },

--- a/apps/heureka/src/components/Vulnerabilities/Vulnerabilities.test.tsx
+++ b/apps/heureka/src/components/Vulnerabilities/Vulnerabilities.test.tsx
@@ -10,7 +10,7 @@ import { PortalProvider } from "@cloudoperators/juno-ui-components/index"
 import { Vulnerabilities } from "./index"
 import { Filter, FilterSettings } from "../common/Filters/types"
 import { getTestRouter } from "../../mocks/getTestRouter"
-import { mockVulnerabilitiesPromise, mockVulnerabilityFiltersPromise } from "../../mocks/promises"
+import { mockVulnerabilitiesPromise } from "../../mocks/promises"
 
 const mockFilters: Filter[] = [
   {

--- a/apps/heureka/src/components/Vulnerabilities/VulnerabilitiesList/VulnerabilityDetailsPanel/VulnerabilityServicesTotalCount.tsx
+++ b/apps/heureka/src/components/Vulnerabilities/VulnerabilitiesList/VulnerabilityDetailsPanel/VulnerabilityServicesTotalCount.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { use } from "react"
+import { use } from "react"
 import { Vulnerability } from "../../utils"
 import { ApolloQueryResult } from "@apollo/client"
 import { GetVulnerabilitiesQuery } from "../../../../generated/graphql"

--- a/apps/heureka/src/components/Vulnerabilities/VulnerabilitiesList/VulnerabilityDetailsPanel/index.tsx
+++ b/apps/heureka/src/components/Vulnerabilities/VulnerabilitiesList/VulnerabilityDetailsPanel/index.tsx
@@ -22,7 +22,7 @@ export const VulnerabilityPanel = () => {
   const navigate = useNavigate()
   const { queryClient, apiClient } = useRouteContext({ from: "/vulnerabilities/" })
   const { vulnerability } = useSearch({ from: "/vulnerabilities/" })
-  const [currentServicesCursor, setCurrentServicesCursor] = useState<string | null | undefined>(undefined)
+  const [currentServicesCursor] = useState<string | null | undefined>(undefined)
 
   // Create a stable promise for vulnerability details (including support groups)
   // This promise doesn't change when pagination happens
@@ -69,7 +69,8 @@ export const VulnerabilityPanel = () => {
     navigate({
       to: "/vulnerabilities",
       search: (prev) => {
-        const { vulnerability, ...rest } = prev
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { vulnerability, ...rest } = prev // we're omitting 'vulnerability' from the deps so route does not reload when it changes
         return { ...rest }
       },
     })

--- a/apps/heureka/src/components/common/ErrorBoundary/index.test.tsx
+++ b/apps/heureka/src/components/common/ErrorBoundary/index.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, ReactElement } from "react"
+import React, { useEffect } from "react"
 import { render, screen } from "@testing-library/react"
 import { ErrorBoundary } from "./index"
 

--- a/apps/heureka/src/components/common/Filters/index.tsx
+++ b/apps/heureka/src/components/common/Filters/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useEffect } from "react"
+import React, { useCallback } from "react"
 import { Button, InputGroup, SearchInput, Stack } from "@cloudoperators/juno-ui-components"
 import { FilterSelect } from "./FilterSelect"
 import { Filter, FilterSettings, SelectedFilter } from "./types"

--- a/apps/heureka/src/components/common/Navigation.tsx
+++ b/apps/heureka/src/components/common/Navigation.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { ReactNode, useRef } from "react"
+import React, { useRef } from "react"
 import { TopNavigation, TopNavigationItem } from "@cloudoperators/juno-ui-components"
 import { useNavigate, useLocation } from "@tanstack/react-router"
 
@@ -11,11 +11,6 @@ type NavigationItemType = {
   label: string
   value: string
   path: string
-}
-
-type NavigationPropsType = {
-  activeItem?: ReactNode
-  onChange?: (value: ReactNode) => void
 }
 
 const navigationItems: NavigationItemType[] = [
@@ -31,7 +26,7 @@ const navigationItems: NavigationItemType[] = [
   },
 ]
 
-export const Navigation = ({ activeItem }: NavigationPropsType) => {
+export const Navigation = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const isVulnerabilitiesActive = location.pathname.toLowerCase().includes("vulnerabilities")

--- a/apps/heureka/src/components/common/SeverityCount.tsx
+++ b/apps/heureka/src/components/common/SeverityCount.tsx
@@ -11,7 +11,6 @@ import {
   TooltipContent,
   KnownIcons,
   BadgeVariantType,
-  Icon,
 } from "@cloudoperators/juno-ui-components"
 
 type SeverityCountProps = {

--- a/apps/heureka/src/routes/services/$service.tsx
+++ b/apps/heureka/src/routes/services/$service.tsx
@@ -6,7 +6,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { z } from "zod"
 import { Service } from "../../components/Service"
-import { LoaderWithCrumb } from "../-types"
 import { fetchService } from "../../api/fetchService"
 
 const serviceSearchSchema = z.object({
@@ -17,7 +16,8 @@ export const Route = createFileRoute("/services/$service")({
   validateSearch: serviceSearchSchema,
   shouldReload: false,
   loaderDeps: ({ search }) => {
-    const { imageVersion, ...rest } = search
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { imageVersion, ...rest } = search // we're omitting 'imageVersion' from the deps so route does not reload when it changes
     return { ...rest }
   },
   loader: ({ context, params: { service } }) => {

--- a/apps/heureka/src/routes/services/index.tsx
+++ b/apps/heureka/src/routes/services/index.tsx
@@ -39,7 +39,8 @@ export type ServicesSearchParams = z.infer<typeof servicesSearchSchema>
 export const Route = createFileRoute("/services/")({
   validateSearch: servicesSearchSchema,
   loaderDeps: ({ search }) => {
-    const { service, ...rest } = search
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { service, ...rest } = search // we're omitting 'service' from the deps so route does not reload when it changes
     return rest
   },
   shouldReload: false, // Only reload the route when the user navigates to it or when deps change

--- a/apps/heureka/src/routes/vulnerabilities/index.tsx
+++ b/apps/heureka/src/routes/vulnerabilities/index.tsx
@@ -37,17 +37,14 @@ export type VulnerabilitiesSearchParams = z.infer<typeof vulnerabilitiesSearchSc
 export const Route = createFileRoute("/vulnerabilities/")({
   validateSearch: vulnerabilitiesSearchSchema,
   loaderDeps: ({ search }) => {
-    const { vulnerability, ...rest } = search
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { vulnerability, ...rest } = search // we're omitting 'service' from the deps so route does not reload when it changes
     return rest
   },
   shouldReload: false,
-  beforeLoad: ({ search }) => {
-    const { vulnerability, ...restSearch } = search
-    const filterSettings = extractFilterSettingsFromSearchParams(restSearch)
-    return {
-      filterSettings,
-    }
-  },
+  beforeLoad: ({ search }) => ({
+    filterSettings: extractFilterSettingsFromSearchParams(search),
+  }),
   loader: async ({ context }) => {
     const { queryClient, apiClient, filterSettings } = context
 


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
This PR enables `@typescript-eslint/no-unused-vars` eslint rule which will not allow us to leave unused variables/imports that are not intentional.


# Changes Made

<!-- List the changes that were made in this pull request. -->

- Enabled `@typescript-eslint/no-unused-vars` rule
- Ignored `routeTree.gen.ts` file
- Ignored this rule for the lines where the intention is clear about why we're doing it.


# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- #1115 

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
