### PR TITLE
fix(ci): ignore licenserc spdx templates

### DIFF
--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -1,3 +1,4 @@
+# REUSE-IgnoreStart
 header:
   license:
     spdx-id: Apache-2.0
@@ -7,7 +8,7 @@ header:
     pattern: |
       SPDX-FileCopyrightText: [0-9]+ SAP SE or an SAP affiliate company and Juno contributors
       SPDX-License-Identifier: Apache-2\.0
-
+# REUSE-IgnoreEnd
   paths: # `paths` are the path list that will be checked (and fixed) by license-eye, default is ['**'].
     - "**"
 


### PR DESCRIPTION
Added REUSE ignore markers to the license configuration.

# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Change 1
- Change 2
- Change 3

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- Issue 1: [link to issue]

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
