### PR TITLE
fix(supernova): apply default filter in silences

### DIFF
--- a/.changeset/large-dancers-occur.md
+++ b/.changeset/large-dancers-occur.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-supernova": patch
+---
+
+Apply default "active" filter in /silences page.


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
In supernova the default `active` filter is applied in `/silences` page.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Default `active` filter applied.
- Improved typescript type to leverage power of ts when working with predefined routes.

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- #1262

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

https://github.com/user-attachments/assets/c419b8fd-607b-4ef8-baf2-f9abfd88c1c9


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
