### PR TITLE
fix(juno): pass unescaped url state to decoder

### DIFF
--- a/.changeset/vast-jokes-matter.md
+++ b/.changeset/vast-jokes-matter.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-supernova": patch
+"@cloudoperators/juno-app-doop": patch
+---
+
+Call `decodeURIComponent` in order to unescape certain characters that were escaped by `URLSearchParams.toString()`.

--- a/apps/doop/src/App.tsx
+++ b/apps/doop/src/App.tsx
@@ -93,7 +93,12 @@ const App = (props: AppProps = {}) => {
         searchParams.delete("__s") // Remove the old state from the search params
       }
 
-      const searchStringWithoutLegacyUrlState = searchParams.toString()
+      /**
+       * We need to decode because calling .toString() on URLSearchParams
+       * returns encoded string which escapes certain values like comma(,)
+       * and the original intention is we use decoderV2 on the raw string
+       * */
+      const searchStringWithoutLegacyUrlState = decodeURIComponent(searchParams.toString())
 
       return { ...decodeV2(searchStringWithoutLegacyUrlState), ...newUrlState, legacyUrlState }
     },

--- a/apps/supernova/src/App.tsx
+++ b/apps/supernova/src/App.tsx
@@ -112,8 +112,12 @@ function App(props: AppProps) {
         newUrlState = convertAppStateToUrlState(readLegacyUrlState(urlStateManager.currentState()))
         searchParams.delete("__s") // Remove the old state from the search params
       }
-
-      const searchStringWithoutLegacyUrlState = searchParams.toString()
+      /**
+       * We need to decode because calling .toString() on URLSearchParams
+       * returns encoded string which escapes certain values like comma(,)
+       * and the original intention is we use decoderV2 on the raw string
+       * */
+      const searchStringWithoutLegacyUrlState = decodeURIComponent(searchParams.toString())
       return { ...decodeV2(searchStringWithoutLegacyUrlState), ...newUrlState }
     },
   })


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->
In order to support legacy url state we have a parser in `doop` and `supernova` where we convert old url state to the new one and remove `__s` from the url search parameter so we don't keep in the url anymore. But the problem is that after removing `__s` url search param we convert it back to string so the decoder takes over but calling `URLSearchParam.toString` escapes certain characters like comma `,` and we don't want that.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Pass the unescaped string to decoder.
- Change 2
- Change 3

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- #1269 

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
