### PR TITLE
chore(core): update renovate configurations

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
   "enabledManagers": ["npm", "github-actions"],
   "includePaths": ["packages/**", "apps/**", "./package.json", ".github/workflows/**"],
   "rangeStrategy": "update-lockfile",
+  "respectLatest": false,
   "packageRules": [
     {
       "groupName": "github actions",
@@ -18,7 +19,17 @@
       "matchFileNames": ["packages/**", "apps/**", "./package.json"],
       "matchUpdateTypes": ["minor", "patch"],
       "minimumReleaseAge": "7 days",
+      "respectLatest": false,
       "schedule": "every weekend"
+    },
+    {
+      "groupName": "npm major updates",
+      "matchDatasources": ["npm"],
+      "matchFileNames": ["packages/**", "apps/**", "./package.json"],
+      "matchUpdateTypes": ["major"],
+      "recreateWhen": "never",
+      "minimumReleaseAge": "30 days",
+      "respectLatest": false
     }
   ],
   "separateMinorPatch": true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->

This PR improves our Renovate configuration to handle major updates more gracefully and ensure consistent minimum release age enforcement. Previously, major npm updates were "immortal" (auto-recreated when closed) and manual PRs from the dashboard ignored our minimum age settings. Now we have explicit control over major updates with a 30-day minimum age and non-immortal behavior, plus `respectLatest: false` ensures all updates respect their configured minimum ages whether created automatically or manually. This gives us better control while maintaining our safety guardrails of 7 days for minor/patch updates, 14 days for GitHub Actions, and 30 days for major breaking changes.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Updated renovate configurations
- Set `save-exact=true` in `.npmrc` in order to make sure that whenever we add a new package we get exact version so we don't need to pin it later. This way we don't need to add CI check and hence will close #1236 

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- #1311 

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
