### PR TITLE
fix(ui): correct SPDX license header format in generateTailwindThemeClassesJson.ts

### DIFF
--- a/packages/ui-components/src/docs/ColorPalette/generateTailwindThemeClassesJson.ts
+++ b/packages/ui-components/src/docs/ColorPalette/generateTailwindThemeClassesJson.ts
@@ -1,7 +1,7 @@
-// /*
-//  * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
-//  * SPDX-License-Identifier: Apache-2.0
-//  */
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 // import fs from "fs"
 // import tailwindConfig from "../../../tailwind.config"


### PR DESCRIPTION
## Summary
  - Fixed invalid SPDX license expression in
  `packages/ui-components/src/docs/ColorPalette/generateTailwindThemeClassesJson.ts`
  - Changed license header from line comments (`//`) to proper block comment format (`/* */`)

## Problem
  The REUSE API reported the file as having an invalid SPDX license expression because the
  license header was commented out with `//` prefixes, which doesn't match the standard
  format.

## Solution
  Updated the SPDX header to use the standard `/* */` block comment format consistent with all
   other files in the project.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
