### PR TITLE
feat(greenhouse): make exposed service names clickable links

### DIFF
--- a/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/ExposedServices.test.tsx
+++ b/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/ExposedServices.test.tsx
@@ -82,4 +82,49 @@ describe("ExposedServices", () => {
     expect(screen.getByText("8080")).toBeInTheDocument()
     expect(screen.getByText("http")).toBeInTheDocument()
   })
+
+  it("should render service names as links with correct URLs", () => {
+    const mockPlugin: Plugin = {
+      metadata: {
+        name: "test-plugin",
+      },
+      spec: {
+        pluginDefinition: "test-definition",
+        pluginDefinitionRef: { name: "test-definition" },
+        deletionPolicy: "Delete",
+      },
+      status: {
+        exposedServices: {
+          "https://example.com": {
+            name: "example-service",
+            namespace: "default",
+            type: "ingress",
+            protocol: "https",
+            port: 443,
+          },
+          "https://api.example.com": {
+            name: "api-service",
+            namespace: "api-namespace",
+            type: "service",
+            protocol: "http",
+            port: 8080,
+          },
+        },
+      },
+    }
+
+    render(<ExposedServices plugin={mockPlugin} />)
+
+    // Check first service link
+    const exampleLink = screen.getByRole("link", { name: "example-service" })
+    expect(exampleLink).toHaveAttribute("href", "https://example.com")
+    expect(exampleLink).toHaveAttribute("target", "_blank")
+    expect(exampleLink).toHaveAttribute("rel", "noopener noreferrer")
+
+    // Check second service link
+    const apiLink = screen.getByRole("link", { name: "api-service" })
+    expect(apiLink).toHaveAttribute("href", "https://api.example.com")
+    expect(apiLink).toHaveAttribute("target", "_blank")
+    expect(apiLink).toHaveAttribute("rel", "noopener noreferrer")
+  })
 })

--- a/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/ExposedServices.tsx
+++ b/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/ExposedServices.tsx
@@ -37,7 +37,11 @@ export const ExposedServices: React.FC<ExposedServicesProps> = ({ plugin }) => {
           </DataGridRow>
           {entries.map(([url, service]) => (
             <DataGridRow key={url}>
-              <DataGridCell>{service.name}</DataGridCell>
+              <DataGridCell>
+                <a href={url} target="_blank" rel="noopener noreferrer" className="text-theme-link hover:underline">
+                  {service.name}
+                </a>
+              </DataGridCell>
               <DataGridCell>{service.namespace}</DataGridCell>
               <DataGridCell>{service.port}</DataGridCell>
               <DataGridCell>{service.protocol}</DataGridCell>


### PR DESCRIPTION
# Summary

Make exposed service names in plugin instance details clickable links that open the service URLs in a new tab.

# Changes Made

- Updated ExposedServices component to render service names as anchor tags
- Added link styling with hover effects
- Added comprehensive test coverage for link attributes
- Links open in new tab with security attributes (noopener noreferrer)

# Testing Instructions

1. `pnpm i`
2. `cd apps/greenhouse && pnpm test ExposedServices.test.tsx`
3. Verify all tests pass

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] My changes generate no new warnings or errors.