### PR TITLE
fix(deps): address CVE-2026-33750 in brace-expansion

### DIFF
--- a/.changeset/blue-brooms-begin.md
+++ b/.changeset/blue-brooms-begin.md
@@ -1,0 +1,5 @@
+---
+"juno": patch
+---
+
+fix: address CVE-2026-33750 vulnerability in brace-expansion

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "overrides": {
       "minimatch": ">=10.2.4",
       "flatted": ">=3.4.2",
-      "picomatch": ">=4.0.4"
+      "picomatch": ">=4.0.4",
+      "brace-expansion": ">=5.0.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   minimatch: '>=10.2.4'
   flatted: '>=3.4.2'
   picomatch: '>=4.0.4'
+  brace-expansion: '>=5.0.5'
 
 importers:
 
@@ -4022,8 +4023,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -10572,7 +10573,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -12584,7 +12585,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

- Fixes Dependabot alert #153: brace-expansion zero-step sequence causes process hang and memory exhaustion (CVE-2026-33750, medium severity)
- Added pnpm global override `brace-expansion: >=5.0.5` — parent package `minimatch@latest` still resolves vulnerable `5.0.4`

## Test plan

- [ ] `pnpm install && pnpm why brace-expansion` shows `5.0.5`
- [ ] `pnpm run build` passes
- [ ] `pnpm run test` passes
- [ ] Verify apps in ArgoCD preview environment