### PR TITLE
fix(ci): removes registery url from node setup

### DIFF
--- a/.changeset/odd-ants-fall.md
+++ b/.changeset/odd-ants-fall.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-messages-provider": patch
+---
+
+Test upload message provider with trusted publishing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: https://registry.npmjs.org
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "check-format": "prettier --config ./.prettierrc --check \"**/*.{js,jsx,ts,tsx,md}\" ",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "pnpm run build && changeset publish",
+    "release": "pnpm run build && changeset publish -r --no-git-checks",
     "prepare": "husky",
     "pkg:run": "turbo run dev --filter",
     "pkg": "pnpm run pkg:run --",


### PR DESCRIPTION
# Summary
Since the pnpm/changesets automatically takes the registery url, this PR remove registery url from release.yaml workflow for trusted publishing. 


# Changes Made

- removes registery url from node setup in release.yaml
- add -r --no-git-checks tag to pnpm publish
- Change 3

# Related Issues

- Issue 1:  #1405 

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
