### PR TITLE
chore(ci): enables npm trusted publishing for juno-messages-provider

### DIFF
--- a/.changeset/loud-moles-return.md
+++ b/.changeset/loud-moles-return.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-messages-provider": patch
+---
+
+Updates message provider using trusted publishing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,10 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0

--- a/packages/messages-provider/package.json
+++ b/packages/messages-provider/package.json
@@ -3,7 +3,14 @@
   "version": "0.2.37",
   "description": "Messages provider",
   "author": "UI-Team",
-  "repository": "https://github.com/cloudoperators/juno/tree/main/packages/messages-provider",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudoperators/juno.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "source": "src/index.js",
   "main": "build/index.js",
   "module": "build/index.js",


### PR DESCRIPTION
# Summary
Updates the npm version because npm must be ≥ 11.5.1 for trusted publishing to work. In addition I added the registry URL to the release workflow to ensure that all publish operations during CI explicitly target the public npm registry, avoiding any interference from other registry settings and aligning with npm’s trusted publishing expectations.

# Changes Made

- Updated the release GitHub Actions workflow to configure the npm registry and upgrade npm before running the Changesets publish step
- Adjusted the `@cloudoperators/juno-messages-provider` `package.json` to use the monorepo root Git repository URL and add a publishConfig pointing to the public npm registry with public access

# Related Issues

Issue 1: #1405 

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
