### PR TITLE
feat(ui): add confirmButtonVariant prop to ModalFooter, Modal

### DIFF
--- a/.changeset/quick-hairs-lay.md
+++ b/.changeset/quick-hairs-lay.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+feat(ui): add confirmButtonVariant prop to ModalFooter, Modal, default to primary-danger

--- a/packages/ui-components/src/components/Button/Button.component.tsx
+++ b/packages/ui-components/src/components/Button/Button.component.tsx
@@ -264,7 +264,7 @@ export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonPr
 
 Button.displayName = "Button"
 
-type ButtonVariant = "primary" | "primary-danger" | "default" | "subdued"
+export type ButtonVariant = "primary" | "primary-danger" | "default" | "subdued"
 type ButtonSize = "small" | "default"
 
 export interface ButtonProps extends Omit<HTMLProps<HTMLAnchorElement> | HTMLProps<HTMLButtonElement>, "size"> {

--- a/packages/ui-components/src/components/Button/index.ts
+++ b/packages/ui-components/src/components/Button/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { Button, type ButtonProps } from "./Button.component"
+export { Button, type ButtonProps, type ButtonVariant } from "./Button.component"

--- a/packages/ui-components/src/components/Modal/Modal.component.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.component.tsx
@@ -18,6 +18,7 @@ import { createPortal } from "react-dom"
 import { FocusTrap } from "focus-trap-react"
 import { ModalFooter } from "../ModalFooter/index"
 import { Icon, KnownIcons } from "../Icon/Icon.component"
+import { ButtonVariant } from "../Button/index"
 import { usePortalRef } from "../PortalProvider/PortalProvider.component"
 
 /*
@@ -106,6 +107,7 @@ export const Modal = ({
   confirmButtonLabel = "",
   cancelButtonLabel = "",
   confirmButtonIcon,
+  confirmButtonVariant,
   cancelButtonIcon,
   disableConfirmButton = false,
   disableCancelButton = false,
@@ -237,6 +239,7 @@ export const Modal = ({
                       confirmButtonLabel={confirmButtonLabel}
                       cancelButtonLabel={cancelButtonLabel}
                       confirmButtonIcon={confirmButtonIcon}
+                      confirmButtonVariant={confirmButtonVariant}
                       cancelButtonIcon={cancelButtonIcon}
                       disableConfirmButton={disableConfirmButton}
                       disableCancelButton={disableCancelButton}
@@ -351,6 +354,12 @@ export interface ModalProps extends Omit<HTMLProps<HTMLDivElement>, "size" | "ti
    * Pass an Icon name to show on the confirming action button.
    */
   confirmButtonIcon?: KnownIcons
+
+  /**
+   * The variant of the confirm button.
+   * @default "primary"
+   */
+  confirmButtonVariant?: ButtonVariant
 
   /**
    * Pass an icon name to show on the cancelling button.

--- a/packages/ui-components/src/components/Modal/Modal.test.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.test.tsx
@@ -181,6 +181,11 @@ describe("Modal", () => {
     expect(screen.queryByRole("button", { name: "Click here to Proceed" })).toHaveClass("juno-button-primary")
   })
 
+  test("forwards confirmButtonVariant to the confirm button", () => {
+    render(<Modal open confirmButtonLabel="Confirm" confirmButtonVariant="primary-danger" />)
+    expect(screen.getByRole("button", { name: "Confirm" })).toHaveClass("juno-button-primary-danger")
+  })
+
   test("closes the modal when clicking the close button in the title bar", async () => {
     await waitFor(() =>
       render(

--- a/packages/ui-components/src/components/ModalFooter/ModalFooter.component.tsx
+++ b/packages/ui-components/src/components/ModalFooter/ModalFooter.component.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { ReactNode, MouseEvent, MouseEventHandler, HTMLProps } from "react"
-import { Button } from "../Button/index"
+import { Button, ButtonVariant } from "../Button/index"
 import { ButtonRow } from "../ButtonRow/index"
 import { KnownIcons } from "../Icon/Icon.component"
 
@@ -35,6 +35,7 @@ export const ModalFooter = ({
   confirmButtonLabel = "",
   cancelButtonLabel = "",
   confirmButtonIcon,
+  confirmButtonVariant,
   cancelButtonIcon,
   disableConfirmButton = false,
   disableCancelButton = false,
@@ -67,7 +68,7 @@ export const ModalFooter = ({
             onClick={handleCancelClick}
           />
           <Button
-            variant="primary"
+            variant={confirmButtonVariant || "primary"}
             label={confirmButtonLabel || "Confirm"}
             icon={confirmButtonIcon || undefined}
             disabled={disableConfirmButton}
@@ -77,7 +78,7 @@ export const ModalFooter = ({
       ) : (
         <ButtonRow>
           <Button
-            variant="subdued"
+            variant={confirmButtonVariant || "primary"}
             label={cancelButtonLabel || "Close"}
             disabled={disableCancelButton}
             icon={cancelButtonIcon || undefined}
@@ -117,6 +118,12 @@ export interface ModalFooterProps extends HTMLProps<HTMLDivElement> {
    * Pass an Icon name to show on the confirming action button.
    */
   confirmButtonIcon?: KnownIcons
+
+  /**
+   * The variant of the confirm button.
+   * @default "primary"
+   */
+  confirmButtonVariant?: ButtonVariant
 
   /**
    * Pass an icon name to show on the cancelling button.

--- a/packages/ui-components/src/components/ModalFooter/ModalFooter.stories.tsx
+++ b/packages/ui-components/src/components/ModalFooter/ModalFooter.stories.tsx
@@ -23,6 +23,10 @@ const meta: Meta<ModalFooterProps> = {
     children: {
       control: false,
     },
+    confirmButtonVariant: {
+      options: ["primary", "primary-danger", "default", "subdued"],
+      control: { type: "select" },
+    },
   },
   parameters: {
     actions: { argTypesRegex: null },

--- a/packages/ui-components/src/components/ModalFooter/ModalFooter.test.tsx
+++ b/packages/ui-components/src/components/ModalFooter/ModalFooter.test.tsx
@@ -79,6 +79,28 @@ describe("ModalFooter", () => {
     expect(screen.getByTestId("my-modal-footer")).toHaveAttribute("name", "My little ModalFooter")
   })
 
+  describe("confirmButtonVariant", () => {
+    test("renders the Close button with 'primary' variant by default", () => {
+      render(<ModalFooter />)
+      expect(screen.getByRole("button", { name: "Close" })).toHaveClass("juno-button-primary")
+    })
+
+    test("renders the Confirm button with 'primary' variant by default", () => {
+      render(<ModalFooter confirmButtonLabel="Confirm" />)
+      expect(screen.getByRole("button", { name: "Confirm" })).toHaveClass("juno-button-primary")
+    })
+
+    test("renders the Confirm button with the variant as passed", () => {
+      render(<ModalFooter confirmButtonLabel="Confirm" confirmButtonVariant="primary-danger" />)
+      expect(screen.getByRole("button", { name: "Confirm" })).toHaveClass("juno-button-primary-danger")
+    })
+
+    test("renders the Close button with the variant as passed", () => {
+      render(<ModalFooter confirmButtonVariant="subdued" />)
+      expect(screen.getByRole("button", { name: "Close" })).toHaveClass("juno-button-subdued")
+    })
+  })
+
   describe("Disabled Button Tests", () => {
     test("renders a disabled confirm action button when disableConfirmButton is true and ensures onConfirm isn't triggered", () => {
       const onClickSpy = vi.fn()


### PR DESCRIPTION
* add a `confirmButtonVariant` prop to `ModalFooter` and `Modal`
* export `ButtonVariant` type from `Button` that can be consumed by `ModalFooter` and `Modal`
* new `confirmButtonVariant` prop defaults to `primary-danger`, thus satisfying #1637 partially
* closes #1626 