### PR TITLE
feat(ui): update Modal docs, stories

### DIFF
--- a/.changeset/fifty-apes-poke.md
+++ b/.changeset/fifty-apes-poke.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+feat(ui): update Modal docs, stories

--- a/docs/ux/modals.md
+++ b/docs/ux/modals.md
@@ -45,7 +45,7 @@ Do not show Modals without user interaction. A Modal must be triggered by a prio
 
 ### One Primary Action
 
-A Modal should have only one primary action. This is the action triggered when the user presses the **Enter** key while the Modal is open. The button that triggers the primary action is always the rightmost button.
+A Modal should have only one primary action. This is the action triggered when the user presses the **Enter** key while the Modal is open. The button that triggers the primary action is always the rightmost button, and it is a button of the `primary` variant, regardless of whether the Mmodal has only this one button or multiple buttons.
 
 ### Redundant Cancel/Close
 

--- a/docs/ux/modals.md
+++ b/docs/ux/modals.md
@@ -45,7 +45,7 @@ Do not show Modals without user interaction. A Modal must be triggered by a prio
 
 ### One Primary Action
 
-A Modal should have only one primary action. This is the action triggered when the user presses the **Enter** key while the Modal is open. The button that triggers the primary action is always the rightmost button, and it is a button of the `primary` variant, regardless of whether the Mmodal has only this one button or multiple buttons.
+A Modal should have only one primary action. This is the action triggered when the user presses the **Enter** key while the Modal is open. The button that triggers the primary action is always the rightmost button, and it is a button of the `primary` variant, regardless of whether the Modal has only this one button or multiple buttons.
 
 ### Redundant Cancel/Close
 

--- a/packages/ui-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.stories.tsx
@@ -8,6 +8,7 @@ import { Modal, ModalProps } from "./Modal.component"
 import { ModalFooter } from "../ModalFooter/index"
 import { Button } from "../Button/index"
 import { ButtonRow } from "../ButtonRow/index"
+import { Checkbox } from "../Checkbox/index"
 import { Form } from "../Form/index"
 import { FormRow } from "../FormRow/index"
 import { TextInput } from "../TextInput/index"
@@ -111,6 +112,77 @@ export const SimpleConfirmNonDestructiveAction: Story = {
       "Assign the role Operator to user@example.com? This will grant access to all resources in the selected project.",
     cancelButtonLabel: "Cancel",
     confirmButtonLabel: "Assign Role",
+  },
+}
+
+export const ConfirmDesctructiveActionLowRisk: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story: "A user-initiated low risk destructive action. Note the Confirm button is always enabled.",
+      },
+    },
+  },
+  args: {
+    title: "Delete Snapshot 'snap-20240115'",
+    children: "Snapshot 'snap-20240115' will be permanently deleted and cannot be recovered.",
+    confirmButtonVariant: "primary-danger",
+    confirmButtonLabel: "Delete Snapshot",
+  },
+}
+
+export const ConfirmDesctructiveActionMediumRisk: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A user-initiated medium risk destructive action. Note the Confirm button is initially disabled, will be enabled once user checks the checkbox.",
+      },
+    },
+  },
+  args: {
+    title: "Remove User 'jsmith'",
+    children: (
+      <div>
+        <p className="jn:mb-4">
+          Removing user &apos;jsmith&apos; will immediately revoke all their access to project resources.
+        </p>
+
+        <Checkbox label="Check the box to confirm removing user" />
+      </div>
+    ),
+    confirmButtonVariant: "primary-danger",
+    confirmButtonLabel: "Remove User",
+  },
+}
+
+export const ConfirmDesctructiveActionHighRisk: Story = {
+  render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A user-initiated high risk destructive action. Note the Confirm button is initially disabled, and will be enabled once the user re-types a given phrase.",
+      },
+    },
+  },
+  args: {
+    title: "Delete Project 'production-eu'",
+    children: (
+      <div>
+        <p className="jn:mb-4">
+          This will permanently delete the projectand all associated resources, including clusters, configurations, and
+          stored data.
+        </p>
+        <p className="jn:mb-4">This action cannot be undone.</p>
+
+        <TextInput placeholder="Type 'DELETE' to confirm deletion" />
+      </div>
+    ),
+    confirmButtonVariant: "primary-danger",
+    confirmButtonLabel: "Delete Project",
   },
 }
 

--- a/packages/ui-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.stories.tsx
@@ -11,7 +11,6 @@ import { ButtonRow } from "../ButtonRow/index"
 import { Form } from "../Form/index"
 import { FormRow } from "../FormRow/index"
 import { TextInput } from "../TextInput/index"
-import { Checkbox } from "../Checkbox/index"
 import { Icon } from "../Icon/index"
 import { PortalProvider } from "../PortalProvider/index"
 import { Select } from "../Select/index"
@@ -83,33 +82,54 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story: "A modal dialog for simple acknowledgement.",
+      },
+    },
+  },
   args: {
-    children: <p>A default modal.</p>,
-    disableConfirmButton: false,
-    disableCancelButton: false,
+    title: "Maintenance Mode Enabled for 'cluster-eu-1'",
+    children:
+      "Automated alerts and health checks for this cluster have been suspended. Turn off maintenance mode to resume normal monitoring.",
   },
 }
 
-export const SimpleConfirmDialog: Story = {
+export const SimpleConfirmNonDestructiveAction: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story: "A modal dialog for confirming or canceling a non-destructive action.",
+      },
+    },
+  },
   args: {
-    children: <p>Are you sure you want to proceed?</p>,
+    title: "Assign Role to user@example.com",
+    children:
+      "Assign the role Operator to user@example.com? This will grant access to all resources in the selected project.",
     cancelButtonLabel: "Cancel",
-    confirmButtonLabel: "Yes, Proceed",
+    confirmButtonLabel: "Assign Role",
   },
 }
 
 export const SimpleConfirmDialogWithDisabledButtons: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "In order to disable all buttons on a Modal, both `disableConfirmButton` and `disableCancelButton` need to be set to `true`.",
+      },
+    },
+  },
   args: {
-    children: (
-      <p>
-        This modal has a disabled Confirm and Cancel button. Note that disableCancelButton also disables the top-right
-        Close button.
-      </p>
-    ),
+    title: "Assign Role to user@example.com",
+    children:
+      "Assign the role Operator to user@example.com? This will grant access to all resources in the selected project.",
     cancelButtonLabel: "Cancel",
-    confirmButtonLabel: "Yes, Proceed",
+    confirmButtonLabel: "Assign Role",
     disableConfirmButton: true,
     disableCancelButton: true,
   },
@@ -117,7 +137,16 @@ export const SimpleConfirmDialogWithDisabledButtons: Story = {
 
 export const AutoFocusDialog: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "In order to auto-focus an interactive element in the modal, assign an `id` and pass this `id` to the `initialFocus` prop.",
+      },
+    },
+  },
   args: {
+    title: "Enter a Phrase",
     children: <TextInput id="focusOnMe" />,
     initialFocus: "#focusOnMe",
   },
@@ -164,6 +193,13 @@ const ReusableForm = () => (
 
 export const DefaultWithForm: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story: "A default size Modal with a form.",
+      },
+    },
+  },
   args: {
     title: "Default Modal Form",
     initialFocus: "#firstname",
@@ -175,6 +211,13 @@ export const DefaultWithForm: Story = {
 
 export const LargeWithForm: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story: "A `large` size Modal with a form.",
+      },
+    },
+  },
   args: {
     size: "large",
     title: "Large Modal Form",
@@ -187,6 +230,13 @@ export const LargeWithForm: Story = {
 
 export const XLWithForm: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story: "An `xl` size Modal with a form.",
+      },
+    },
+  },
   args: {
     size: "xl",
     title: "XL With Form",
@@ -199,6 +249,13 @@ export const XLWithForm: Story = {
 
 export const XXLWithForm: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story: "An `2xl` size Modal with a form.",
+      },
+    },
+  },
   args: {
     size: "2xl",
     title: "2XL With Form",
@@ -211,6 +268,14 @@ export const XXLWithForm: Story = {
 
 export const NonCloseable: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A modal that can not be closed. Generally considered an antipattern, there may be cases where this is needed. Set `closeable` to `false`.",
+      },
+    },
+  },
   args: {
     title: "Non-Closeable Modal",
     children:
@@ -221,6 +286,14 @@ export const NonCloseable: Story = {
 
 export const CloseOnBackdropClick: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Modals can feel more lightweight and less intrusive when the user can click outside the Modal to close it. Set `closeOnBackdropClick` to `true` to enable this behaviour.",
+      },
+    },
+  },
   args: {
     title: "Close on Backdrop Click",
     children: <p>This Modal closes when clicking the backdrop.</p>,
@@ -230,40 +303,31 @@ export const CloseOnBackdropClick: Story = {
 
 export const DisabledCloseButton: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story: "In order to specifically disable the X-Close button, set `disableCloseButton`to `true`.",
+      },
+    },
+  },
   args: {
-    title: "Disabled Close Button Modal",
+    title: "Disabled X-Close Button Modal",
     children: <p>This Modal has a disabled top-right close button.</p>,
     disableCloseButton: true,
     cancelButtonLabel: "Cancel",
   },
 }
 
-export const Login: Story = {
-  render: Template,
-  args: {
-    title: "Log In",
-    initialFocus: "#username",
-    children: (
-      <>
-        <FormRow>
-          <TextInput label="Username" name="username" id="username" autoComplete="on" />
-        </FormRow>
-        <FormRow>
-          <TextInput type="password" label="Password" name="password" id="password" />
-        </FormRow>
-        <FormRow>
-          <Checkbox label="Remember Me" id="remember-me" />
-        </FormRow>
-      </>
-    ),
-    modalFooter: (
-      <ModalFooter confirmButtonLabel="Log In" confirmButtonIcon="accountCircle" cancelButtonLabel="Never Mind" />
-    ),
-  },
-}
-
 export const CustomModalFooter: Story = {
   render: Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "For complex use cases that require more than a Confirm and a Cancel button, a custom `ModalFooter` with buttons and additional elements can be passed to `Modal`.",
+      },
+    },
+  },
   args: {
     title: "Modal with Custom ModalFooter",
     size: "large",
@@ -275,9 +339,9 @@ export const CustomModalFooter: Story = {
           Have some custom content
         </span>
         <ButtonRow>
-          <Button variant="primary-danger">Button 1</Button>
-          <Button variant="primary">Button 2</Button>
-          <Button>Button 3</Button>
+          <Button variant="subdued">Cancel</Button>
+          <Button variant="primary-danger">Destroy</Button>
+          <Button variant="primary">Proceed</Button>
         </ButtonRow>
       </ModalFooter>
     ),

--- a/packages/ui-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.stories.tsx
@@ -132,8 +132,38 @@ export const ConfirmDesctructiveActionLowRisk: Story = {
   },
 }
 
+const MediumRiskTemplate = (args: ModalProps) => {
+  const [isOpen, setOpen] = useState(false)
+  const [confirmed, setConfirmed] = useState(false)
+  return (
+    <>
+      <Button label="Open Modal" variant="primary" onClick={() => setOpen(true)} />
+      <Modal
+        open={isOpen}
+        onCancel={() => {
+          setOpen(false)
+          setConfirmed(false)
+        }}
+        disableConfirmButton={!confirmed}
+        {...args}
+      >
+        <div>
+          <p className="jn:mb-4">
+            Removing user &apos;jsmith&apos; will immediately revoke all their access to project resources.
+          </p>
+          <Checkbox
+            label="Check the box to confirm removing user 'jsmith'"
+            checked={confirmed}
+            onChange={(e) => setConfirmed(e.target.checked)}
+          />
+        </div>
+      </Modal>
+    </>
+  )
+}
+
 export const ConfirmDesctructiveActionMediumRisk: Story = {
-  render: Template,
+  render: MediumRiskTemplate,
   parameters: {
     docs: {
       description: {
@@ -144,22 +174,46 @@ export const ConfirmDesctructiveActionMediumRisk: Story = {
   },
   args: {
     title: "Remove User 'jsmith'",
-    children: (
-      <div>
-        <p className="jn:mb-4">
-          Removing user &apos;jsmith&apos; will immediately revoke all their access to project resources.
-        </p>
-
-        <Checkbox label="Check the box to confirm removing user" />
-      </div>
-    ),
     confirmButtonVariant: "primary-danger",
     confirmButtonLabel: "Remove User",
   },
 }
 
+const HighRiskTemplate = (args: ModalProps) => {
+  const [isOpen, setOpen] = useState(false)
+  const [inputValue, setInputValue] = useState("")
+  return (
+    <>
+      <Button label="Open Modal" variant="primary" onClick={() => setOpen(true)} />
+      <Modal
+        open={isOpen}
+        onCancel={() => {
+          setOpen(false)
+          setInputValue("")
+        }}
+        disableConfirmButton={inputValue !== "DELETE"}
+        {...args}
+      >
+        <div>
+          <p className="jn:mb-4">
+            This will permanently delete the project &apos;production-eu&apos; and all associated resources, including
+            clusters, configurations, and stored data.
+          </p>
+          <p className="jn:mb-4">This action cannot be undone.</p>
+          <p className="jn:mb-4">Type &apos;DELETE&apos; (all caps, no quotes) in the field below to confirm:</p>
+          <TextInput
+            placeholder="Type 'DELETE' to confirm deletion"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+          />
+        </div>
+      </Modal>
+    </>
+  )
+}
+
 export const ConfirmDesctructiveActionHighRisk: Story = {
-  render: Template,
+  render: HighRiskTemplate,
   parameters: {
     docs: {
       description: {
@@ -170,17 +224,6 @@ export const ConfirmDesctructiveActionHighRisk: Story = {
   },
   args: {
     title: "Delete Project 'production-eu'",
-    children: (
-      <div>
-        <p className="jn:mb-4">
-          This will permanently delete the projectand all associated resources, including clusters, configurations, and
-          stored data.
-        </p>
-        <p className="jn:mb-4">This action cannot be undone.</p>
-
-        <TextInput placeholder="Type 'DELETE' to confirm deletion" />
-      </div>
-    ),
     confirmButtonVariant: "primary-danger",
     confirmButtonLabel: "Delete Project",
   },

--- a/packages/ui-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.stories.tsx
@@ -212,7 +212,7 @@ const HighRiskTemplate = (args: ModalProps) => {
   )
 }
 
-export const ConfirmDesctructiveActionHighRisk: Story = {
+export const ConfirmDestructiveActionHighRisk: Story = {
   render: HighRiskTemplate,
   parameters: {
     docs: {


### PR DESCRIPTION
- update Modal uxdocs to reflect usage of a `primary` button for forward action (even if there is only one button)
- add story descriptions
- update some stories to be more relatable to real-world needs
- remove Log In Modal story (we explicitly forbid Modal Sign In in the uxdocs)
- add functional stories for three-tiered destructive action confirmation modals
- closes #1637 
- closes #1625