### PR TITLE
fix(ui): adjust dropdown icon right-gap in ComboBox and Select

### DIFF
--- a/.changeset/fix-dropdown-icon-gap.md
+++ b/.changeset/fix-dropdown-icon-gap.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+Fix dropdown icon right-gap in ComboBox and Select components to match Figma design specs

--- a/.changeset/fix-dropdown-icon-gap.md
+++ b/.changeset/fix-dropdown-icon-gap.md
@@ -2,4 +2,5 @@
 "@cloudoperators/juno-ui-components": patch
 ---
 
-Fix dropdown icon right-gap in ComboBox and Select components to match Figma design specs
+Fix dropdown icon right-gap in ComboBox and Select components to match Figma design specs.
+Fix input text overlapping toggle button and valid/invalid icons by adding dynamic right padding.

--- a/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
+++ b/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
@@ -97,23 +97,15 @@ const invalidStyles = `
 
 const buttonStyles = `
   jn:absolute
-  jn:top-0
-  jn:right-0
-  jn:h-textinput
+  jn:top-[1px]
+  jn:right-2
+  jn:h-[calc(100%-2px)]
   jn:w-6
-  jn:h-4
-  jn:border-l-0
-  jn:border-y-[1px]
-  jn:border-r-[1px]
   jn:rounded-tr
   jn:rounded-br
   jn:appearance-none
   jn:bg-theme-textinput
   jn:text-theme-textinput
-`
-
-const defaultButtonStyles = `
-  jn:border-theme-textinput-default
 `
 
 const invalidButtonStyles = `
@@ -141,7 +133,7 @@ const menuStyles = `
 const iconContainerStyles = `
   jn:absolute
   jn:top-[.4rem]
-  jn:right-6
+  jn:right-8
 `
 
 const centeredIconStyles = `
@@ -489,12 +481,11 @@ export const ComboBox = ({
                   {!hasError && !isLoading ? (
                     <ComboboxButton
                       className={`
-                        juno-combobox-toggle 
+                        juno-combobox-toggle
                         ${buttonStyles}
                         ${disabled ? disabledButtonStyles : ""}
                         ${isInvalid ? "juno-combobox-toggle-invalid " + invalidButtonStyles : ""} 
                         ${isValid ? "juno-combobox-toggle-valid " + validButtonStyles : ""}  
-                        ${isValid || isInvalid ? "" : defaultButtonStyles} 
                       `}
                     >
                       <Icon icon={isOpen ? "expandLess" : "expandMore"} />

--- a/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
+++ b/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
@@ -97,15 +97,23 @@ const invalidStyles = `
 
 const buttonStyles = `
   jn:absolute
-  jn:top-[1px]
-  jn:right-2
-  jn:h-[calc(100%-2px)]
-  jn:w-6
+  jn:top-0
+  jn:right-0
+  jn:pr-2
+  jn:h-textinput
+  jn:w-8
+  jn:border-l-0
+  jn:border-y
+  jn:border-r
   jn:rounded-tr
   jn:rounded-br
   jn:appearance-none
   jn:bg-theme-textinput
   jn:text-theme-textinput
+`
+
+const defaultButtonStyles = `
+  jn:border-theme-textinput-default
 `
 
 const invalidButtonStyles = `
@@ -487,6 +495,7 @@ export const ComboBox = ({
                         ${disabled ? disabledButtonStyles : ""}
                         ${isInvalid ? "juno-combobox-toggle-invalid " + invalidButtonStyles : ""} 
                         ${isValid ? "juno-combobox-toggle-valid " + validButtonStyles : ""}  
+                        ${isValid || isInvalid ? "" : defaultButtonStyles}
                       `}
                     >
                       <Icon icon={isOpen ? "expandLess" : "expandMore"} />

--- a/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
+++ b/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
@@ -454,8 +454,7 @@ export const ComboBox = ({
                   ${disabled ? disabledInputStyles : ""}
                   ${isInvalid ? "juno-combobox-invalid " + invalidStyles : ""} 
                   ${isValid ? "juno-combobox-valid " + validStyles : ""}  
-                  ${isValid || isInvalid ? "" : defaultBorderStyles}   
-                  ${isValid || isInvalid ? "jn:pr-16" : "jn:pr-8"}
+                  ${isValid || isInvalid ? "jn:pr-16" : "jn:pr-8 " + defaultBorderStyles}
                   ${isLoading ? "juno-combobox-loading jn:cursor-not-allowed" : ""}
                   ${hasError ? "juno-combobox-error jn:cursor-not-allowed" : ""}
                   ${className}

--- a/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
+++ b/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
@@ -57,7 +57,7 @@ const inputStyles = `
   jn:text-base
   jn:leading-4
   jn:w-full
-  jn:px-4
+  jn:pl-4
   jn:h-textinput
   jn:text-left
   jn:overflow-hidden
@@ -446,7 +446,8 @@ export const ComboBox = ({
                   ${disabled ? disabledInputStyles : ""}
                   ${isInvalid ? "juno-combobox-invalid " + invalidStyles : ""} 
                   ${isValid ? "juno-combobox-valid " + validStyles : ""}  
-                  ${isValid || isInvalid ? "" : defaultBorderStyles} 
+                  ${isValid || isInvalid ? "" : defaultBorderStyles}   
+                  ${isValid || isInvalid ? "jn:pr-16" : "jn:pr-8"}
                   ${isLoading ? "juno-combobox-loading jn:cursor-not-allowed" : ""}
                   ${hasError ? "juno-combobox-error jn:cursor-not-allowed" : ""}
                   ${className}

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
@@ -15,6 +15,7 @@ import { Button } from "../Button"
 import { NativeSelectOption } from "../NativeSelectOption"
 import { NativeSelect } from "../NativeSelect"
 import { InputGroup } from "../InputGroup"
+import { PortalProvider } from "../PortalProvider"
 
 const meta: Meta<typeof DataGridToolbar> = {
   title: "Components/DataGrid/DataGridToolbar",
@@ -49,6 +50,13 @@ export const Default: Story = {
 }
 
 export const ComplexCustomLayout: Story = {
+  decorators: [
+    (Story) => (
+      <PortalProvider>
+        <Story />
+      </PortalProvider>
+    ),
+  ],
   render: (args: DataGridToolbarProps) => (
     <DataGridToolbar {...args}>
       <Stack direction="horizontal" distribution="between">

--- a/packages/ui-components/src/components/DateTimePicker/DateTimePicker.component.tsx
+++ b/packages/ui-components/src/components/DateTimePicker/DateTimePicker.component.tsx
@@ -590,10 +590,8 @@ export const DateTimePicker = ({
 // Internal type that includes flatpickr instance for internal use
 type InternalDateChangeHandler = (_selectedDate: Date[], _dateStr: string, _instance: flatpickr.Instance) => void
 
-export interface DateTimePickerProps extends Omit<
-  HTMLAttributes<HTMLInputElement>,
-  "defaultValue" | "onFocus" | "onBlur" | "onChange"
-> {
+export interface DateTimePickerProps
+  extends Omit<HTMLAttributes<HTMLInputElement>, "defaultValue" | "onFocus" | "onBlur" | "onChange"> {
   /** Whether the DateTimePicker input element allows direct user keyboard input. Default is `false`.
    */
   allowInput?: boolean

--- a/packages/ui-components/src/components/DateTimePicker/DateTimePicker.component.tsx
+++ b/packages/ui-components/src/components/DateTimePicker/DateTimePicker.component.tsx
@@ -590,8 +590,10 @@ export const DateTimePicker = ({
 // Internal type that includes flatpickr instance for internal use
 type InternalDateChangeHandler = (_selectedDate: Date[], _dateStr: string, _instance: flatpickr.Instance) => void
 
-export interface DateTimePickerProps
-  extends Omit<HTMLAttributes<HTMLInputElement>, "defaultValue" | "onFocus" | "onBlur" | "onChange"> {
+export interface DateTimePickerProps extends Omit<
+  HTMLAttributes<HTMLInputElement>,
+  "defaultValue" | "onFocus" | "onBlur" | "onChange"
+> {
   /** Whether the DateTimePicker input element allows direct user keyboard input. Default is `false`.
    */
   allowInput?: boolean

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -86,8 +86,10 @@ export type SelectContextProps = {
 }
 export const SelectContext = createContext<SelectContextProps | undefined>(undefined)
 
-export interface SelectProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "value" | "defaultValue" | "onChange"> {
+export interface SelectProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "value" | "defaultValue" | "onChange"
+> {
   /** Pass an aria-label to the Select toggle button */
   ariaLabel?: string
   /** The children to render as options. Use the SelectOption component, and SelectDivider if needed. */

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -37,7 +37,8 @@ const toggleStyles = `
   jn:h-[2.375rem]
   jn:inline-flex
   jn:items-center
-  jn:px-4
+  jn:pl-4
+  jn:pr-2
   jn:rounded-3px
   jn:select-none
   jn:text-base

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -86,10 +86,8 @@ export type SelectContextProps = {
 }
 export const SelectContext = createContext<SelectContextProps | undefined>(undefined)
 
-export interface SelectProps extends Omit<
-  ButtonHTMLAttributes<HTMLButtonElement>,
-  "value" | "defaultValue" | "onChange"
-> {
+export interface SelectProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "value" | "defaultValue" | "onChange"> {
   /** Pass an aria-label to the Select toggle button */
   ariaLabel?: string
   /** The children to render as options. Use the SelectOption component, and SelectDivider if needed. */


### PR DESCRIPTION
Closes #1639

## Summary

- **ComboBox**: replaced offset approach (`top-[1px]`/`h-[calc(100%-2px)]`) with a full-height button that carries explicit borders (`border-y`, `border-r`, `border-l-0`), ensuring `defaultButtonStyles`/`invalidButtonStyles`/`validButtonStyles` are consistently applied
- **ComboBox**: fixed input text overlapping toggle button and valid/invalid icons by replacing static `px-4` with dynamic right padding (`pr-8` default, `pr-16` when valid/invalid)
- **Select**: reduced toggle right padding (`px-4` → `pl-4 pr-2`) for consistent chevron gap
- **DataGridToolbar story**: wrapped `ComplexCustomLayout` in `PortalProvider` so the ComboBox dropdown renders with correct theme styles in Storybook

## Test plan

- [ ] Visual check in Storybook: ComboBox and Select dropdown icon aligned with Figma specs
- [ ] Verify all states: default, valid, invalid, disabled, loading, error
- [ ] Check that long input text does not overlap the toggle button or valid/invalid icons
- [ ] Check ComboBox dropdown menu renders correctly in DataGridToolbar `ComplexCustomLayout` story