### PR TITLE
fix(infra): add repository field to k8s-client and template packages

### DIFF
--- a/.changeset/chubby-eggs-create.md
+++ b/.changeset/chubby-eggs-create.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-k8s-client": patch
+"@cloudoperators/juno-package-template": patch
+---
+
+Fixes npm publish failures caused by missing repository fields in package.json files during provenance verification with OIDC trusted publishing.

--- a/packages/k8s-client/package.json
+++ b/packages/k8s-client/package.json
@@ -27,6 +27,8 @@
     "clean": "rm -rf build && rm -rf node_modules && rm -rf .turbo",
     "clean:cache": "rm -rf .turbo"
   },
+  "repository": "https://github.com/cloudoperators/juno/tree/main/packages/k8s-client",
+  "license": "Apache-2.0",
   "keywords": [
     "kubernetes",
     "js",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -7,6 +7,7 @@
   "main": "build/index.js",
   "module": "build/index.js",
   "license": "Apache-2.0",
+  "repository": "https://github.com/cloudoperators/juno/tree/main/packages/template",
   "type": "module",
   "types": "build/types/index.d.ts",
   "files": [


### PR DESCRIPTION
# Summary

Fixes npm publish failures caused by missing repository fields in package.json files during provenance verification with OIDC trusted publishing.

# Changes Made

- Added `repository` field to `@cloudoperators/juno-k8s-client` package.json
- Added `license` field to `@cloudoperators/juno-k8s-client` package.json
- Added `repository` field to `@cloudoperators/juno-package-template` package.json

# Related Issues

- Related to #1652 (npm trusted publishing with OIDC authentication)

# Screenshots (if applicable)

N/A - Package metadata changes only

# Testing Instructions

1. `pnpm i`
2. Verify package.json changes in `packages/k8s-client/package.json` and `packages/template/package.json`
3. Verify all public packages have repository field: `for pkg in packages/*/package.json; do if ! grep -q '"private".*true' "$pkg" && ! grep -q '"repository"' "$pkg"; then echo "$pkg";
fi; done` (should return empty)

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.