### PR TITLE
fix(ci): use GitHub API for PR preview image cleanup

### DIFF
--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -173,60 +173,13 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install crane
-        run: |
-          VERSION="v0.21.5"
-          OS="Linux"
-          ARCH="x86_64"
-          EXPECTED_SHA256="9f823ae5ee25803161110f957b5fd4538f714d40cdf25dacb4914fefafd246bf"
-
-          curl -fsSL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" -o crane.tar.gz
-          echo "${EXPECTED_SHA256}  crane.tar.gz" | sha256sum -c -
-          tar -xzf crane.tar.gz crane
-          sudo install -m 0755 crane /usr/local/bin/crane
-          rm crane.tar.gz
-
-          crane version
-
       - name: Delete PR preview images
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          IMAGE_BASE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}"
-
-          echo "Looking for images matching pr-${PR_NUMBER}-*"
-
-          # List all tags and delete matching ones. Cleanup should be tolerant when
-          # no repository exists yet or when there are no matching PR tags.
-          TAGS="$(crane ls "${IMAGE_BASE}" 2>/dev/null || true)"
-          MATCHING_TAGS="$(printf '%s\n' "${TAGS}" | grep "^pr-${PR_NUMBER}-" || true)"
-
-          if [ -z "${MATCHING_TAGS}" ]; then
-            echo "No preview images found for PR ${PR_NUMBER}"
-          else
-            DELETE_FAILED=0
-
-            while IFS= read -r tag; do
-              echo "Deleting ${IMAGE_BASE}:${tag}"
-              if ! crane delete "${IMAGE_BASE}:${tag}"; then
-                echo "Failed to delete ${IMAGE_BASE}:${tag}"
-                DELETE_FAILED=1
-              fi
-            done <<< "${MATCHING_TAGS}"
-
-            if [ "${DELETE_FAILED}" -ne 0 ]; then
-              echo "Cleanup failed for PR ${PR_NUMBER}: one or more preview images could not be deleted"
-              exit 1
-            fi
-          fi
-
-          echo "Cleanup completed for PR ${PR_NUMBER}"
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          package: ${{ env.IMAGE_NAME }}
+          delete-tags: pr-${{ github.event.pull_request.number }}-*
+          delete-partial-images: true
 
       - name: Remove PR Preview label
         if: always()

--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -164,7 +164,8 @@ jobs:
   cleanup:
     name: Cleanup PR Preview Image
     # Skip if PR is not closed or from a forked repository
-    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -174,7 +175,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Delete PR preview images
-        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           package: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
# Summary

Fixes the PR preview image cleanup failure by replacing `crane delete` with the `dataaxiom/ghcr-cleanup-action` that properly uses GitHub's Package API. The previous approach failed because GHCR doesn't support the Docker Registry DELETE endpoint.

# Changes Made

- **Replaced crane-based cleanup with `dataaxiom/ghcr-cleanup-action`**:
  - Removed Docker login step (not needed)
  - Removed crane installation and version check
  - Removed bash script using `crane delete`
  - Added `dataaxiom/ghcr-cleanup-action` step with wildcard tag pattern `pr-{NUMBER}-*`
- Uses the same action version that the greenhouse repo uses for consistency
- Enables `delete-partial-images` to clean up incomplete multi-arch images

# Related Issues

Fixes the GHCR cleanup error:
Error: DELETE https://ghcr.io/v2/.../manifests/...: UNSUPPORTED: The operation is unsupported.

# Screenshots (if applicable)

N/A - CI/CD workflow changes only

# Testing Instructions

1. Close or merge a PR that has greenhouse preview images built
2. Verify the cleanup job runs successfully without the `UNSUPPORTED` error
3. Check that all images tagged with `pr-{NUMBER}-*` are deleted from GHCR

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. *(N/A - workflow changes)*
- [ ] New and existing unit tests pass locally with my changes. *(N/A - no code changes)*
- [ ] I have made corresponding changes to the documentation (if applicable). *(N/A)*
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes. *(N/A - CI/CD workflow changes don't require changesets)*

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.