### PR TITLE
refactor(ci): use shared GHCR cleanup workflow and add Slack notifications

### DIFF
--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -176,7 +176,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       packages: write
-    uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@4443dc4 # PR#59
+    uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@d138f9922c75ed1e1ad3ae3bfb68dd8ae3284dc6 # main
     with:
       package: juno-app-greenhouse-pr-preview
       delete-tags: pr-${{ github.event.pull_request.number }}-*

--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -172,7 +172,8 @@ jobs:
   cleanup:
     name: Cleanup PR Preview Image
     # Skip if PR is not closed or from a forked repository
-    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       packages: write
     uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@d1a776c4a34f7c85aa252bf52b7fa92afa9e547e # PR#59
@@ -184,7 +185,8 @@ jobs:
   remove-label:
     name: Remove PR Preview Label
     needs: cleanup
-    if: always() && github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    if: always() && github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -212,11 +214,16 @@ jobs:
             }
 
   notify-on-failure:
-    if: failure()
-    needs: [cleanup]
+    if: github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.cleanup.result == 'failure'
+    needs: [ cleanup ]
     uses: cloudoperators/juno/.github/workflows/shared-slack-notification.yaml@e69fd9982d52aa1e1623ceda55875724843516b6 # main
     with:
       title: "🚨 Greenhouse PR Preview Image Cleanup Failed 🚨"
-      body: "Failed to delete preview images for PR #${{ github.event.pull_request.number }}. Please check the logs and manually clean up if needed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Check the logs>"
+      body: "Failed to delete preview images for PR #${{
+        github.event.pull_request.number }}. Please check the logs and manually
+        clean up if needed. <${{ github.server_url }}/${{ github.repository
+        }}/actions/runs/${{ github.run_id }}|Check the logs>"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -176,7 +176,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       packages: write
-    uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@17d3d6b80851574fcd8c7b6e5c4fe6aee2922359 # main
+    uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@4443dc4 # PR#59
     with:
       package: juno-app-greenhouse-pr-preview
       delete-tags: pr-${{ github.event.pull_request.number }}-*
@@ -217,6 +217,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       needs.cleanup.result == 'failure'
     needs: [ cleanup ]
+    permissions: {}
     uses: cloudoperators/juno/.github/workflows/shared-slack-notification.yaml@e69fd9982d52aa1e1623ceda55875724843516b6 # main
     with:
       title: "🚨 Greenhouse PR Preview Image Cleanup Failed 🚨"

--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -1,3 +1,10 @@
+# Greenhouse PR Preview Workflow
+#
+# Automatically builds Docker images for pull requests and manages their deployment
+# via ArgoCD label-based triggers.
+#
+# For detailed documentation, see: docs/greenhouse-pr-preview-workflow.md
+#
 # Workflow Flow:
 # Initial Setup:
 # 1. Developer sets 'greenhouse-pr-build' label on PR
@@ -15,6 +22,7 @@
 # 1. PR is closed or merged
 # 2. Action deletes all Docker images matching pr-{number}-*
 # 3. Action removes PR-Preview label
+# 4. Sends Slack notification on failure
 
 name: Build Greenhouse PR Preview 🔬
 
@@ -203,10 +211,10 @@ jobs:
 
   notify-on-failure:
     if: failure()
-    needs: [cleanup, remove-label]
+    needs: [cleanup]
     uses: cloudoperators/juno/.github/workflows/shared-slack-notification.yaml@e69fd9982d52aa1e1623ceda55875724843516b6 # main
     with:
-      title: "🚨 Greenhouse PR Preview Cleanup Failed 🚨"
-      body: "An error occurred while cleaning up PR #${{ github.event.pull_request.number }} preview images. Please check the logs for more information. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Check the logs>"
+      title: "🚨 Greenhouse PR Preview Image Cleanup Failed 🚨"
+      body: "Failed to delete preview images for PR #${{ github.event.pull_request.number }}. Please check the logs and manually clean up if needed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Check the logs>"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -164,26 +164,23 @@ jobs:
   cleanup:
     name: Cleanup PR Preview Image
     # Skip if PR is not closed or from a forked repository
-    if: github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@d1a776c4a34f7c85aa252bf52b7fa92afa9e547e # PR#59
+    with:
+      package: juno-app-greenhouse-pr-preview
+      delete-tags: pr-${{ github.event.pull_request.number }}-*
+      delete-partial-images: true
+
+  remove-label:
+    name: Remove PR Preview Label
+    needs: cleanup
+    if: always() && github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
-      # Both issues and pull-requests write permissions are needed for label operations
       issues: write
       pull-requests: write
     steps:
-      - name: Delete PR preview images
-        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          package: ${{ env.IMAGE_NAME }}
-          delete-tags: pr-${{ github.event.pull_request.number }}-*
-          delete-partial-images: true
-
       - name: Remove PR Preview label
-        if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -173,6 +173,8 @@ jobs:
     name: Cleanup PR Preview Image
     # Skip if PR is not closed or from a forked repository
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      packages: write
     uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@d1a776c4a34f7c85aa252bf52b7fa92afa9e547e # PR#59
     with:
       package: juno-app-greenhouse-pr-preview

--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -176,7 +176,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       packages: write
-    uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@d1a776c4a34f7c85aa252bf52b7fa92afa9e547e # PR#59
+    uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@17d3d6b80851574fcd8c7b6e5c4fe6aee2922359 # main
     with:
       package: juno-app-greenhouse-pr-preview
       delete-tags: pr-${{ github.event.pull_request.number }}-*
@@ -190,7 +190,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: write
     steps:
       - name: Remove PR Preview label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -200,3 +200,13 @@ jobs:
                 throw error;
               }
             }
+
+  notify-on-failure:
+    if: failure()
+    needs: [cleanup, remove-label]
+    uses: cloudoperators/juno/.github/workflows/shared-slack-notification.yaml@e69fd9982d52aa1e1623ceda55875724843516b6 # main
+    with:
+      title: "🚨 Greenhouse PR Preview Cleanup Failed 🚨"
+      body: "An error occurred while cleaning up PR #${{ github.event.pull_request.number }} preview images. Please check the logs for more information. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Check the logs>"
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -23,12 +23,12 @@ env:
 
 jobs:
   reuse-compliance:
-    uses: cloudoperators/common/.github/workflows/shared-reuse.yaml@4443dc42f73e1283004860195279e3aed837b4e8 # main
+    uses: cloudoperators/common/.github/workflows/shared-reuse.yaml@d138f9922c75ed1e1ad3ae3bfb68dd8ae3284dc6 # main
 
   license-headers:
     permissions:
       contents: write
-    uses: cloudoperators/common/.github/workflows/shared-license.yaml@4443dc42f73e1283004860195279e3aed837b4e8 # main
+    uses: cloudoperators/common/.github/workflows/shared-license.yaml@d138f9922c75ed1e1ad3ae3bfb68dd8ae3284dc6 # main
     with:
       apply_header: false
 

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -23,17 +23,17 @@ env:
 
 jobs:
   reuse-compliance:
-    uses: cloudoperators/common/.github/workflows/shared-reuse.yaml@17d3d6b80851574fcd8c7b6e5c4fe6aee2922359 # main
+    uses: cloudoperators/common/.github/workflows/shared-reuse.yaml@4443dc42f73e1283004860195279e3aed837b4e8 # main
 
   license-headers:
     permissions:
       contents: write
-    uses: cloudoperators/common/.github/workflows/shared-license.yaml@17d3d6b80851574fcd8c7b6e5c4fe6aee2922359 # main
+    uses: cloudoperators/common/.github/workflows/shared-license.yaml@4443dc42f73e1283004860195279e3aed837b4e8 # main
     with:
       apply_header: false
 
   cache-dependencies:
-    runs-on: [ubuntu-latest]
+    runs-on: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
@@ -65,7 +65,7 @@ jobs:
 
   checks:
     needs: cache-dependencies
-    runs-on: [ubuntu-latest]
+    runs-on: [ ubuntu-latest ]
     strategy:
       matrix:
         include:

--- a/docs/greenhouse-pr-preview-workflow.md
+++ b/docs/greenhouse-pr-preview-workflow.md
@@ -334,7 +334,6 @@ Note: The `cleanup` job uses a shared reusable workflow, but that workflow canno
 ### remove-label job
 
 - `issues: write` - Remove labels from PRs
-- `pull-requests: write` - Manage PR labels
 
 ## Configuration
 

--- a/docs/greenhouse-pr-preview-workflow.md
+++ b/docs/greenhouse-pr-preview-workflow.md
@@ -235,8 +235,9 @@ Deletes Docker images using the shared GHCR cleanup workflow when the PR is clos
 **Workflow:**
 
 Uses `cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml` with:
+
 - `package`: juno-app-greenhouse-pr-preview
-- `delete-tags`: pr-{number}-* (wildcard pattern)
+- `delete-tags`: pr-{number}-\* (wildcard pattern)
 - `delete-partial-images`: true
 
 ### remove-label
@@ -266,6 +267,7 @@ Sends Slack notifications when image cleanup fails.
 **Notification:**
 
 Sends alert to Slack with:
+
 - PR number
 - Link to workflow logs
 - Request for manual cleanup if needed
@@ -307,6 +309,7 @@ The label removal step runs with `if: always()` to ensure the preview is torn do
 ### Slack Notifications
 
 If image cleanup fails, a Slack notification is sent with:
+
 - PR number
 - Link to workflow logs
 - Alert emoji for visibility

--- a/docs/greenhouse-pr-preview-workflow.md
+++ b/docs/greenhouse-pr-preview-workflow.md
@@ -325,12 +325,16 @@ This ensures the team is aware of orphaned images that may need manual cleanup.
 - `issues: write` - Add/remove labels on PRs
 - `pull-requests: write` - Manage PR labels
 
+### cleanup job
+
+- `packages: write` - Delete container images
+
+Note: The `cleanup` job uses a shared reusable workflow, but that workflow cannot elevate `GITHUB_TOKEN` permissions beyond what the caller grants. The caller workflow must still declare the permissions required for cleanup to succeed, such as `packages: write` for deleting container images.
+
 ### remove-label job
 
 - `issues: write` - Remove labels from PRs
 - `pull-requests: write` - Manage PR labels
-
-Note: The `cleanup` job inherits permissions from the shared workflow it calls.
 
 ## Configuration
 

--- a/docs/greenhouse-pr-preview-workflow.md
+++ b/docs/greenhouse-pr-preview-workflow.md
@@ -115,8 +115,8 @@ Developer                Workflow                  ArgoCD
     ├──► Close/Merge PR      │                        │
     │                        │                        │
     │                    ┌───▼────────────────────┐   │
-    │                    │ Install crane          │   │
-    │                    │ (with SHA256 check)    │   │
+    │                    │ Call shared cleanup    │   │
+    │                    │ workflow (GHCR API)    │   │
     │                    └───┬────────────────────┘   │
     │                        │                        │
     │                    ┌───▼────────────────────┐   │
@@ -127,6 +127,11 @@ Developer                Workflow                  ArgoCD
     │                    ┌───▼────────────────────┐   │
     │                    │ Remove "pr-preview"    │   │
     │                    │ label (always runs)    │   │
+    │                    └───┬────────────────────┘   │
+    │                        │                        │
+    │                    ┌───▼────────────────────┐   │
+    │                    │ Notify on failure      │   │
+    │                    │ (Slack alert)          │   │
     │                    └───┬────────────────────┘   │
     │                        │                        │
     │                        ├──────────────────────► │
@@ -173,8 +178,9 @@ To stop building previews without closing the PR:
 When the PR is closed or merged:
 
 1. The workflow automatically:
-   - Deletes all Docker images matching `pr-{number}-*`
+   - Calls the shared GHCR cleanup workflow to delete all Docker images matching `pr-{number}-*`
    - Removes the `greenhouse-pr-preview` label (even if image deletion fails)
+   - Sends a Slack notification if image deletion fails
    - ArgoCD detects the label removal and deletes the preview deployment
 
 ## Docker Images
@@ -219,19 +225,50 @@ Builds and pushes the Docker image when the `greenhouse-pr-build` label is prese
 
 ### cleanup
 
-Deletes Docker images and removes labels when the PR is closed.
+Deletes Docker images using the shared GHCR cleanup workflow when the PR is closed.
 
 **Conditions:**
 
 - PR action is `closed`
 - PR is from the same repository (not a fork)
 
+**Workflow:**
+
+Uses `cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml` with:
+- `package`: juno-app-greenhouse-pr-preview
+- `delete-tags`: pr-{number}-* (wildcard pattern)
+- `delete-partial-images`: true
+
+### remove-label
+
+Removes the preview label after cleanup completes.
+
+**Conditions:**
+
+- Runs `always()` (even if cleanup fails)
+- PR action is `closed`
+- PR is from the same repository (not a fork)
+
 **Steps:**
 
-1. Login to GitHub Container Registry
-2. Install crane (with SHA256 checksum verification)
-3. List all tags and delete matching `pr-{number}-*` images
-4. Remove `greenhouse-pr-preview` label (runs even if deletion fails)
+1. Remove `greenhouse-pr-preview` label
+2. Handles 404 errors gracefully (label already removed)
+
+### notify-on-failure
+
+Sends Slack notifications when image cleanup fails.
+
+**Conditions:**
+
+- Runs only if `cleanup` job fails
+- PR action is `closed`
+
+**Notification:**
+
+Sends alert to Slack with:
+- PR number
+- Link to workflow logs
+- Request for manual cleanup if needed
 
 ## Safety Features
 
@@ -263,27 +300,34 @@ This prevents:
 
 The workflow skips execution when the `greenhouse-pr-preview` label is added to prevent triggering itself in a loop.
 
-### Supply Chain Security
-
-The crane binary is installed with SHA256 checksum verification:
-
-```bash
-EXPECTED_SHA256="9f823ae5ee25803161110f957b5fd4538f714d40cdf25dacb4914fefafd246bf"
-curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v0.21.5/go-containerregistry_Linux_x86_64.tar.gz" -o crane.tar.gz
-echo "${EXPECTED_SHA256}  crane.tar.gz" | sha256sum -c -
-```
-
 ### Resilient Cleanup
 
 The label removal step runs with `if: always()` to ensure the preview is torn down even if image deletion fails. This prevents orphaned ArgoCD deployments.
 
+### Slack Notifications
+
+If image cleanup fails, a Slack notification is sent with:
+- PR number
+- Link to workflow logs
+- Alert emoji for visibility
+
+This ensures the team is aware of orphaned images that may need manual cleanup.
+
 ## Permissions
 
-Both jobs require the following permissions:
+### build-and-push job
 
 - `contents: read` - Read repository code
-- `packages: write` - Push/delete container images
+- `packages: write` - Push container images
 - `issues: write` - Add/remove labels on PRs
+- `pull-requests: write` - Manage PR labels
+
+### remove-label job
+
+- `issues: write` - Remove labels from PRs
+- `pull-requests: write` - Manage PR labels
+
+Note: The `cleanup` job inherits permissions from the shared workflow it calls.
 
 ## Configuration
 
@@ -299,7 +343,7 @@ PR_PREVIEW_LABEL: "greenhouse-pr-preview"
 
 ### Path Filters
 
-The workflow only triggers when files under `apps/greenhouse/**` are modified.
+**Note**: The workflow triggers on any PR file changes. The `greenhouse-pr-build` label is the only control for enabling preview builds. This allows you to create previews for changes to Greenhouse itself or its dependent plugins (heureka, doop, supernova) or shared packages.
 
 ## Troubleshooting
 
@@ -318,9 +362,10 @@ The workflow only triggers when files under `apps/greenhouse/**` are modified.
 ### Images Not Cleaning Up
 
 1. Check the cleanup job logs
-2. Verify the crane installation succeeded
-3. Check that the `greenhouse-pr-preview` label was removed
-4. The workflow will still remove the label even if image deletion fails
+2. Verify the shared workflow was called successfully
+3. Check for Slack notification about the failure
+4. Check that the `greenhouse-pr-preview` label was removed (this happens regardless of image cleanup success)
+5. If notified, manually clean up images via GitHub Packages UI or API
 
 ### Stale Preview
 
@@ -341,4 +386,5 @@ If the `greenhouse-pr-build` label is removed but the preview stays:
 
 - [ArgoCD Label-Based Deployment](https://argo-cd.readthedocs.io/)
 - [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
-- [Crane CLI](https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md)
+- [Shared GHCR Cleanup Workflow](https://github.com/cloudoperators/common/blob/main/.github/workflows/shared-ghcr-cleanup.yaml)
+- [dataaxiom/ghcr-cleanup-action](https://github.com/dataaxiom/ghcr-cleanup-action)


### PR DESCRIPTION
# Summary

Updates the PR preview cleanup to use the shared GHCR cleanup workflow from `cloudoperators/common` instead of calling the `dataaxiom/ghcr-cleanup-action` directly. This provides consistency with the greenhouse repo approach and centralizes cleanup logic maintenance. Additionally adds Slack notifications on cleanup failure and updates the workflow documentation.

# Changes Made

- **Replaced `cleanup` job** with shared workflow call:
  - Now uses `cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@d1a776c4a34f7c85aa252bf52b7fa92afa9e547e` (PR#59 with the `delete-tags` fix)
  - Passes `package`, `delete-tags`, and `delete-partial-images` as workflow inputs
  - Removed direct action call, permissions, and runner configuration (handled by shared workflow)
- **Created new `remove-label` job**:
  - Split label removal into separate job since shared workflow only handles image deletion
  - Depends on `cleanup` job with `needs: cleanup`
  - Uses `if: always()` to run even if cleanup fails
  - Minimal permissions: only `issues: write` and `pull-requests: write`
- **Added `notify-on-failure` job**:
  - Sends Slack notification if image cleanup fails
  - Includes PR number and direct link to workflow logs
  - Only monitors `cleanup` job (label removal failures are non-critical)
- **Updated workflow file header**:
  - Added reference to documentation file
  - Updated flow description to include Slack notifications
- **Updated documentation** (`docs/greenhouse-pr-preview-workflow.md`):
  - Updated PR CLOSE/MERGE flow diagram
  - Documented new job structure (cleanup, remove-label, notify-on-failure)
  - Removed crane references, added shared workflow references
  - Updated permissions section for new job structure
  - Added Slack notification feature to safety features
  - Updated troubleshooting section
  - Updated related documentation links

# Related Issues

Follows up on #1682 which fixed the GHCR cleanup by switching from `crane` to the GitHub API. This PR now aligns with the org-wide shared workflow pattern used by the greenhouse repo and adds error alerting.

# Screenshots (if applicable)

N/A - CI/CD workflow and documentation changes only

# Testing Instructions

1. Close or merge a PR that has greenhouse preview images built (with `greenhouse-pr-preview` label)
2. Verify all three jobs run successfully:
   - `cleanup` job calls the shared workflow and deletes all images tagged with `pr-{NUMBER}-*`
   - `remove-label` job removes the `greenhouse-pr-preview` label
   - `notify-on-failure` job is skipped (no failures)
3. Confirm no GHCR deletion errors
4. Verify the label is removed from the PR
5. Review the updated documentation to ensure accuracy
6. (Optional) To test failure notification, temporarily break the cleanup and verify Slack notification is sent

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. *(N/A - workflow changes)*
- [ ] New and existing unit tests pass locally with my changes. *(N/A - no code changes)*
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes. *(N/A - CI/CD workflow changes don't require changesets)*

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.