### PR TITLE
fix(ci): add runner specification and restore pull-requests permission

### DIFF
--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -191,6 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - name: Remove PR Preview label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/build-push-greenhouse-pr-preview.yaml
+++ b/.github/workflows/build-push-greenhouse-pr-preview.yaml
@@ -178,6 +178,7 @@ jobs:
       packages: write
     uses: cloudoperators/common/.github/workflows/shared-ghcr-cleanup.yaml@d138f9922c75ed1e1ad3ae3bfb68dd8ae3284dc6 # main
     with:
+      runs-on: ubuntu-latest
       package: juno-app-greenhouse-pr-preview
       delete-tags: pr-${{ github.event.pull_request.number }}-*
       delete-partial-images: true

--- a/docs/greenhouse-pr-preview-workflow.md
+++ b/docs/greenhouse-pr-preview-workflow.md
@@ -333,7 +333,7 @@ Note: The `cleanup` job uses a shared reusable workflow, but that workflow canno
 
 ### remove-label job
 
-- `issues: write` - Remove labels from PRs  
+- `issues: write` - Remove labels from PRs
 - `pull-requests: write` - Required for PR label operations (even though Issues API is used)
 
 ## Configuration

--- a/docs/greenhouse-pr-preview-workflow.md
+++ b/docs/greenhouse-pr-preview-workflow.md
@@ -30,8 +30,8 @@ INITIAL SETUP
 ─────────────
 Developer                Workflow                  ArgoCD
     │                        │                        │
-    ├──► Add "pr-build"      │                        │
-    │    label               │                        │
+    ├──► Add "greenhouse-    │                        │
+    │    pr-build" label     │                        │
     │                        │                        │
     │                    ┌───▼────────────────────┐   │
     │                    │ Build Docker image     │   │
@@ -43,8 +43,8 @@ Developer                Workflow                  ArgoCD
     │                    └───┬────────────────────┘   │
     │                        │                        │
     │                    ┌───▼────────────────────┐   │
-    │                    │ Add "pr-preview"       │   │
-    │                    │ label                  │   │
+    │                    │ Add "greenhouse-       │   │
+    │                    │ pr-preview" label      │   │
     │                    └───┬────────────────────┘   │
     │                        │                        │
     │                        ├──────────────────────► │
@@ -62,8 +62,8 @@ Developer                Workflow                  ArgoCD
     ├──► Push commit         │                        │
     │                        │                        │
     │                    ┌───▼────────────────────┐   │
-    │                    │ Check "pr-build"       │   │
-    │                    │ label exists?          │   │
+    │                    │ Check "greenhouse-     │   │
+    │                    │ pr-build" exists?      │   │
     │                    └───┬────────────────────┘   │
     │                        │                        │
     │                ┌───────┴────────┐               │
@@ -72,8 +72,8 @@ Developer                Workflow                  ArgoCD
     │                │                │               │
     │    ┌───────────▼───────┐   ┌────▼────────┐    │
     │    │ Remove            │   │ Skip build  │    │
-    │    │ "pr-preview"      │   │ Exit        │    │
-    │    │ label             │   └─────────────┘    │
+    │    │ "greenhouse-      │   │ Exit        │    │
+    │    │ pr-preview" label │   └─────────────┘    │
     │    └───────────┬───────┘        │             │
     │                │                 │             │
     │                ├─────────────────┼────────────► │
@@ -96,8 +96,8 @@ Developer                Workflow                  ArgoCD
     │    └──────────┬────────┘         │             │
     │               │                  │             │
     │    ┌──────────▼────────┐         │             │
-    │    │ Add "pr-preview" │         │             │
-    │    │ label back       │         │             │
+    │    │ Add "greenhouse-  │         │             │
+    │    │ pr-preview" back  │         │             │
     │    └──────────┬────────┘         │             │
     │               │                  │             │
     │               ├──────────────────┼────────────► │
@@ -125,8 +125,9 @@ Developer                Workflow                  ArgoCD
     │                    └───┬────────────────────┘   │
     │                        │                        │
     │                    ┌───▼────────────────────┐   │
-    │                    │ Remove "pr-preview"    │   │
-    │                    │ label (always runs)    │   │
+    │                    │ Remove "greenhouse-    │   │
+    │                    │ pr-preview" label      │   │
+    │                    │ (always runs)          │   │
     │                    └───┬────────────────────┘   │
     │                        │                        │
     │                    ┌───▼────────────────────┐   │

--- a/docs/greenhouse-pr-preview-workflow.md
+++ b/docs/greenhouse-pr-preview-workflow.md
@@ -333,7 +333,8 @@ Note: The `cleanup` job uses a shared reusable workflow, but that workflow canno
 
 ### remove-label job
 
-- `issues: write` - Remove labels from PRs
+- `issues: write` - Remove labels from PRs  
+- `pull-requests: write` - Required for PR label operations (even though Issues API is used)
 
 ## Configuration
 


### PR DESCRIPTION
# Summary

Fixes two critical issues preventing the shared GHCR cleanup workflow from functioning:

1. **Runner specification**: The shared workflow requires explicit `runs-on` input; without it, jobs hang indefinitely waiting for a non-existent "default" runner
2. **Permissions**: GitHub requires both `issues: write` AND `pull-requests: write` when removing labels from PRs, even though the Issues API is used

# Changes Made

- **Added `runs-on: ubuntu-latest`** to the cleanup job's `with:` inputs
  - The shared workflow defaults to `"default"` which is not a valid GitHub Actions runner label
  - Explicitly specifying `ubuntu-latest` ensures jobs use GitHub's standard hosted runners

- **Restored `pull-requests: write` permission** to the remove-label job
  - GitHub's API returns `403 - Resource not accessible by integration` without this permission
  - The response header `x-accepted-github-permissions: 'issues=write; pull_requests=write'` confirms both are required
  - Updated documentation to clarify both permissions are needed for PR label operations

# Related Issues

Fixes:
- Cleanup job hanging at "Waiting for a runner to pick up this job..."
- Remove label job failing with 403 error: "Resource not accessible by integration"

# Screenshots (if applicable)

N/A - Workflow configuration fixes

# Testing Instructions

1. Close or merge a PR with greenhouse preview images
2. Verify the cleanup job starts immediately (no longer stuck waiting for runner)
3. Verify all three jobs complete successfully:
   - `cleanup` job deletes images
   - `remove-label` job removes the label without 403 errors
   - `notify-on-failure` job is skipped (no failures)
4. Confirm the `greenhouse-pr-preview` label is removed from the closed PR

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. *(N/A - workflow changes)*
- [ ] New and existing unit tests pass locally with my changes. *(N/A - no code changes)*
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes. *(N/A - CI/CD workflow changes don't require changesets)*

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.