### PR TITLE
feat(heureka): wire Jira ticket to dedicated url field for risk acceptance

### DIFF
--- a/.changeset/real-ears-walk.md
+++ b/.changeset/real-ears-walk.md
@@ -1,0 +1,6 @@
+---
+"@cloudoperators/juno-app-heureka": patch
+"@cloudoperators/juno-app-greenhouse": patch
+---
+
+Wire Jira ticket to dedicated url field in createRemediation for risk acceptance, replacing the description-prefix workaround. Surface the ticket in a new "Source Ticket" column in the remediations history panel with improved date formatting and empty-value handling.

--- a/.changeset/real-ears-walk.md
+++ b/.changeset/real-ears-walk.md
@@ -1,6 +1,5 @@
 ---
 "@cloudoperators/juno-app-heureka": patch
-"@cloudoperators/juno-app-greenhouse": patch
 ---
 
 Wire Jira ticket to dedicated url field in createRemediation for risk acceptance, replacing the description-prefix workaround. Surface the ticket in a new "Source Ticket" column in the remediations history panel with improved date formatting and empty-value handling.

--- a/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/RemediationHistoryPanel.test.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/RemediationHistoryPanel.test.tsx
@@ -9,6 +9,7 @@ import { createMemoryHistory, createRootRoute, createRoute, Outlet, RouterProvid
 import { PortalProvider } from "@cloudoperators/juno-ui-components"
 import { RemediationHistoryPanel } from "./index"
 import { getTestRouter } from "../../../../../mocks/getTestRouter"
+import { RemediationTypeValues } from "../../../../../generated/graphql"
 
 vi.mock("../../../../../api/fetchRemediations", () => ({
   fetchRemediations: vi.fn(),
@@ -19,14 +20,15 @@ import { fetchRemediations } from "../../../../../api/fetchRemediations"
 const makeMockRemediationsPromise = (
   edges: Array<{
     id: string
-    type: string | null
+    type: RemediationTypeValues | null
     description: string | null
     url: string | null
     remediatedBy: string | null
     remediationDate: string | null
     expirationDate: string | null
   }>
-) =>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> =>
   Promise.resolve({
     data: {
       Remediations: {
@@ -43,7 +45,9 @@ const makeMockRemediationsPromise = (
     },
     loading: false,
     networkStatus: 7,
+    partial: false,
     error: undefined,
+    dataState: "complete" as const,
   })
 
 const renderPanel = (vulnerability: string | null = null) => {
@@ -86,7 +90,7 @@ describe("RemediationHistoryPanel", () => {
       makeMockRemediationsPromise([
         {
           id: "rem-0",
-          type: "risk_accepted",
+          type: RemediationTypeValues.RiskAccepted,
           description: "Some reason",
           url: "JIRA-1",
           remediatedBy: "user-1",
@@ -106,7 +110,7 @@ describe("RemediationHistoryPanel", () => {
       makeMockRemediationsPromise([
         {
           id: "rem-1",
-          type: "risk_accepted",
+          type: RemediationTypeValues.RiskAccepted,
           description: "Accepted for now",
           url: "JIRA-9999",
           remediatedBy: "user-123",
@@ -124,7 +128,7 @@ describe("RemediationHistoryPanel", () => {
       makeMockRemediationsPromise([
         {
           id: "rem-2",
-          type: "risk_accepted",
+          type: RemediationTypeValues.RiskAccepted,
           description: "No ticket",
           url: null,
           remediatedBy: "user-123",
@@ -143,7 +147,7 @@ describe("RemediationHistoryPanel", () => {
       makeMockRemediationsPromise([
         {
           id: "rem-3",
-          type: "mitigation",
+          type: RemediationTypeValues.Mitigation,
           description: "Applied patch",
           url: "JIRA-0000",
           remediatedBy: "user-456",

--- a/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/RemediationHistoryPanel.test.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/RemediationHistoryPanel.test.tsx
@@ -10,6 +10,42 @@ import { PortalProvider } from "@cloudoperators/juno-ui-components"
 import { RemediationHistoryPanel } from "./index"
 import { getTestRouter } from "../../../../../mocks/getTestRouter"
 
+vi.mock("../../../../../api/fetchRemediations", () => ({
+  fetchRemediations: vi.fn(),
+}))
+
+import { fetchRemediations } from "../../../../../api/fetchRemediations"
+
+const makeMockRemediationsPromise = (
+  edges: Array<{
+    id: string
+    type: string | null
+    description: string | null
+    url: string | null
+    remediatedBy: string | null
+    remediationDate: string | null
+    expirationDate: string | null
+  }>
+) =>
+  Promise.resolve({
+    data: {
+      Remediations: {
+        edges: edges.map((node) => ({
+          node: {
+            ...node,
+            service: "my-service",
+            image: "my-image",
+            vulnerability: "CVE-2024-1234",
+          },
+        })),
+        totalCount: edges.length,
+      },
+    },
+    loading: false,
+    networkStatus: 7,
+    error: undefined,
+  })
+
 const renderPanel = (vulnerability: string | null = null) => {
   const rootRoute = createRootRoute({
     component: () => <Outlet />,
@@ -36,8 +72,93 @@ const renderPanel = (vulnerability: string | null = null) => {
 }
 
 describe("RemediationHistoryPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it("renders without crashing when vulnerability is null (panel closed)", () => {
     renderPanel(null)
     expect(screen.queryByText("Revert False Positive")).not.toBeInTheDocument()
+  })
+
+  it("renders Source Ticket column header and cell value when panel is open", async () => {
+    vi.mocked(fetchRemediations).mockReturnValue(
+      makeMockRemediationsPromise([
+        {
+          id: "rem-0",
+          type: "risk_accepted",
+          description: "Some reason",
+          url: "JIRA-1",
+          remediatedBy: "user-1",
+          remediationDate: "2025-01-01T00:00:00Z",
+          expirationDate: "2026-01-01T00:00:00Z",
+        },
+      ])
+    )
+    renderPanel("CVE-2024-1234")
+    // Wait for data row to confirm Suspense resolved, then check header
+    expect(await screen.findByText("JIRA-1")).toBeInTheDocument()
+    expect(screen.getByText("Source Ticket")).toBeInTheDocument()
+  })
+
+  it("shows url value in Source Ticket cell for risk_accepted remediations", async () => {
+    vi.mocked(fetchRemediations).mockReturnValue(
+      makeMockRemediationsPromise([
+        {
+          id: "rem-1",
+          type: "risk_accepted",
+          description: "Accepted for now",
+          url: "JIRA-9999",
+          remediatedBy: "user-123",
+          remediationDate: "2025-01-15T00:00:00Z",
+          expirationDate: "2026-01-15T00:00:00Z",
+        },
+      ])
+    )
+    renderPanel("CVE-2024-1234")
+    expect(await screen.findByText("JIRA-9999")).toBeInTheDocument()
+  })
+
+  it("shows -- when risk_accepted remediation has no url", async () => {
+    vi.mocked(fetchRemediations).mockReturnValue(
+      makeMockRemediationsPromise([
+        {
+          id: "rem-2",
+          type: "risk_accepted",
+          description: "No ticket",
+          url: null,
+          remediatedBy: "user-123",
+          remediationDate: "2025-01-15T00:00:00Z",
+          expirationDate: "2026-01-15T00:00:00Z",
+        },
+      ])
+    )
+    renderPanel("CVE-2024-1234")
+    // description and remediatedBy are non-null, dates are non-null → only url cell shows --
+    expect(await screen.findByText("--")).toBeInTheDocument()
+  })
+
+  it("shows empty Source Ticket cell for non-risk_accepted remediations", async () => {
+    vi.mocked(fetchRemediations).mockReturnValue(
+      makeMockRemediationsPromise([
+        {
+          id: "rem-3",
+          type: "mitigation",
+          description: "Applied patch",
+          url: "JIRA-0000",
+          remediatedBy: "user-456",
+          remediationDate: "2025-03-01T00:00:00Z",
+          expirationDate: "2026-03-01T00:00:00Z",
+        },
+      ])
+    )
+    renderPanel("CVE-2024-1234")
+    expect(await screen.findByText("Applied patch")).toBeInTheDocument()
+    // url is set on the node but type is not risk_accepted → Source Ticket cell must be empty
+    expect(screen.queryByText("JIRA-0000")).not.toBeInTheDocument()
+    // Verify the Source Ticket cell (6th gridcell in the data row) is empty
+    const dataCells = screen.getAllByRole("gridcell")
+    // gridcells: type(0), expirationDate(1), remediationDate(2), remediatedBy(3), description(4), sourceTicket(5), actions(6)
+    expect(dataCells[5].textContent).toBe("")
   })
 })

--- a/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/RemediationHistoryPanel.test.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/RemediationHistoryPanel.test.tsx
@@ -27,7 +27,6 @@ const makeMockRemediationsPromise = (
     remediationDate: string | null
     expirationDate: string | null
   }>
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> =>
   Promise.resolve({
     data: {

--- a/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
@@ -91,8 +91,8 @@ const RemediationHistoryTable = ({
           <DataGridCell className="whitespace-nowrap">{formatDateTime(r.expirationDate)}</DataGridCell>
           <DataGridCell className="whitespace-nowrap">{formatDateTime(r.remediationDate)}</DataGridCell>
           <DataGridCell>{r.remediatedBy ?? "--"}</DataGridCell>
-          <DataGridCell>{r.description ?? "--"}</DataGridCell>
-          <DataGridCell>{r.url ?? "--"}</DataGridCell>
+          <DataGridCell className="min-w-0">{r.description ?? "--"}</DataGridCell>
+          <DataGridCell className="min-w-0">{r.url ?? "--"}</DataGridCell>
           <DataGridCell className="cursor-default interactive" onClick={(e) => e.stopPropagation()}>
             {revertingId === r.remediationId ? (
               <Spinner variant="primary" size="small" className="ml-auto" />

--- a/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
@@ -47,9 +47,10 @@ function formatDateTime(value: string | null): string {
   if (!value) return "—"
   try {
     const d = new Date(value)
-    return Number.isNaN(d.getTime())
-      ? value
-      : d.toLocaleDateString("en-GB", { year: "numeric", month: "short", day: "numeric" })
+    if (Number.isNaN(d.getTime())) return value
+    const dayMonth = d.toLocaleDateString("en-GB", { month: "short", day: "2-digit" })
+    const year = String(d.getFullYear()).padStart(4, "0")
+    return `${dayMonth} ${year}`
   } catch {
     return value
   }

--- a/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
@@ -44,7 +44,7 @@ type RemediationHistoryPanelProps = {
 const COLUMN_SPAN = 7
 
 function formatDateTime(value: string | null): string {
-  if (!value) return "—"
+  if (!value) return "--"
   try {
     const d = new Date(value)
     if (Number.isNaN(d.getTime())) return value
@@ -93,7 +93,7 @@ const RemediationHistoryTable = ({
           <DataGridCell className="whitespace-nowrap">{formatDateTime(r.remediationDate)}</DataGridCell>
           <DataGridCell>{r.remediatedBy ?? "--"}</DataGridCell>
           <DataGridCell className="min-w-0">{r.description ?? "--"}</DataGridCell>
-          <DataGridCell className="min-w-0">{r.url ?? "--"}</DataGridCell>
+          <DataGridCell className="min-w-0">{r.type === "risk_accepted" ? (r.url ?? "--") : ""}</DataGridCell>
           <DataGridCell className="cursor-default interactive" onClick={(e) => e.stopPropagation()}>
             {revertingId === r.remediationId ? (
               <Spinner variant="primary" size="small" className="ml-auto" />

--- a/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
@@ -88,7 +88,7 @@ const RemediationHistoryTable = ({
     <>
       {remediatedVulnerabilities.map((r: RemediatedVulnerability) => (
         <DataGridRow key={r.remediationId}>
-          <DataGridCell className="whitespace-nowrap">{r.type}</DataGridCell>
+          <DataGridCell className="whitespace-nowrap">{r.type ?? "--"}</DataGridCell>
           <DataGridCell className="whitespace-nowrap">{formatDateTime(r.expirationDate)}</DataGridCell>
           <DataGridCell className="whitespace-nowrap">{formatDateTime(r.remediationDate)}</DataGridCell>
           <DataGridCell>{r.remediatedBy ?? "--"}</DataGridCell>

--- a/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
@@ -22,7 +22,7 @@ import {
 import { fetchRemediations } from "../../../../../api/fetchRemediations"
 import { deleteRemediation } from "../../../../../api/deleteRemediation"
 import { getNormalizedRemediationsResponse } from "../../../../Services/utils"
-import { GetRemediationsQuery, RemediationTypeValues } from "../../../../../generated/graphql"
+import { GetRemediationsQuery } from "../../../../../generated/graphql"
 import { ErrorBoundary } from "../../../../common/ErrorBoundary"
 import { EmptyDataGridRow } from "../../../../common/EmptyDataGridRow"
 import { LoadingDataRow } from "../../../../common/LoadingDataRow"
@@ -87,14 +87,12 @@ const RemediationHistoryTable = ({
     <>
       {remediatedVulnerabilities.map((r: RemediatedVulnerability) => (
         <DataGridRow key={r.remediationId}>
-          <DataGridCell className="whitespace-nowrap">{r.type ?? "—"}</DataGridCell>
+          <DataGridCell className="whitespace-nowrap">{r.type}</DataGridCell>
           <DataGridCell className="whitespace-nowrap">{formatDateTime(r.expirationDate)}</DataGridCell>
           <DataGridCell className="whitespace-nowrap">{formatDateTime(r.remediationDate)}</DataGridCell>
-          <DataGridCell>{r.remediatedBy ?? "—"}</DataGridCell>
-          <DataGridCell>{r.description ?? "—"}</DataGridCell>
-          <DataGridCell>
-            {r.type === RemediationTypeValues.RiskAccepted ? (r.url ?? "—") : null}
-          </DataGridCell>
+          <DataGridCell>{r.remediatedBy ?? "--"}</DataGridCell>
+          <DataGridCell>{r.description ?? "--"}</DataGridCell>
+          <DataGridCell>{r.url ?? "--"}</DataGridCell>
           <DataGridCell className="cursor-default interactive" onClick={(e) => e.stopPropagation()}>
             {revertingId === r.remediationId ? (
               <Spinner variant="primary" size="small" className="ml-auto" />

--- a/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/ImageIssuesList/RemediationHistoryPanel/index.tsx
@@ -22,7 +22,7 @@ import {
 import { fetchRemediations } from "../../../../../api/fetchRemediations"
 import { deleteRemediation } from "../../../../../api/deleteRemediation"
 import { getNormalizedRemediationsResponse } from "../../../../Services/utils"
-import { GetRemediationsQuery } from "../../../../../generated/graphql"
+import { GetRemediationsQuery, RemediationTypeValues } from "../../../../../generated/graphql"
 import { ErrorBoundary } from "../../../../common/ErrorBoundary"
 import { EmptyDataGridRow } from "../../../../common/EmptyDataGridRow"
 import { LoadingDataRow } from "../../../../common/LoadingDataRow"
@@ -41,7 +41,7 @@ type RemediationHistoryPanelProps = {
   refreshKey?: number
 }
 
-const COLUMN_SPAN = 6
+const COLUMN_SPAN = 7
 
 function formatDateTime(value: string | null): string {
   if (!value) return "—"
@@ -92,6 +92,9 @@ const RemediationHistoryTable = ({
           <DataGridCell className="whitespace-nowrap">{formatDateTime(r.remediationDate)}</DataGridCell>
           <DataGridCell>{r.remediatedBy ?? "—"}</DataGridCell>
           <DataGridCell>{r.description ?? "—"}</DataGridCell>
+          <DataGridCell>
+            {r.type === RemediationTypeValues.RiskAccepted ? (r.url ?? "—") : null}
+          </DataGridCell>
           <DataGridCell className="cursor-default interactive" onClick={(e) => e.stopPropagation()}>
             {revertingId === r.remediationId ? (
               <Spinner variant="primary" size="small" className="ml-auto" />
@@ -225,13 +228,14 @@ export const RemediationHistoryPanel = ({
             fallbackRender={getErrorDataRowComponent({ colspan: COLUMN_SPAN })}
             resetKeys={[remediationsPromise]}
           >
-            <DataGrid columns={COLUMN_SPAN} minContentColumns={[0, 1, 2, 3, 5]} cellVerticalAlignment="top">
+            <DataGrid columns={COLUMN_SPAN} minContentColumns={[0, 1, 2, 3, 6]} cellVerticalAlignment="top">
               <DataGridRow>
                 <DataGridHeadCell>Type</DataGridHeadCell>
                 <DataGridHeadCell>Expiration Date</DataGridHeadCell>
                 <DataGridHeadCell>Remediation Date</DataGridHeadCell>
                 <DataGridHeadCell>Remediated By</DataGridHeadCell>
                 <DataGridHeadCell>Description</DataGridHeadCell>
+                <DataGridHeadCell>Source Ticket</DataGridHeadCell>
                 <DataGridHeadCell />
               </DataGridRow>
               <Suspense fallback={<LoadingDataRow colSpan={COLUMN_SPAN} />}>

--- a/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/RiskAcceptanceModal.test.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/RiskAcceptanceModal.test.tsx
@@ -193,7 +193,7 @@ describe("RiskAcceptanceModal", () => {
       )
     })
 
-    it("includes source ticket prefix in description when source ticket is provided", async () => {
+    it("sends source ticket as url field (not embedded in description) when provided", async () => {
       const onConfirm = vi.fn().mockResolvedValue(undefined)
       const user = userEvent.setup()
       renderModal({ onConfirm })
@@ -207,12 +207,13 @@ describe("RiskAcceptanceModal", () => {
 
       expect(onConfirm).toHaveBeenCalledWith(
         expect.objectContaining({
-          description: "Source Ticket: JIRA-9999\n\nAccepted",
+          url: "JIRA-9999",
+          description: "Accepted",
         })
       )
     })
 
-    it("does not include source ticket prefix when source ticket field is empty", async () => {
+    it("omits url field when source ticket field is empty", async () => {
       const onConfirm = vi.fn().mockResolvedValue(undefined)
       const user = userEvent.setup()
       renderModal({ onConfirm })
@@ -223,11 +224,9 @@ describe("RiskAcceptanceModal", () => {
 
       await user.click(screen.getByRole("button", { name: "Accept Risk" }))
 
-      expect(onConfirm).toHaveBeenCalledWith(
-        expect.objectContaining({
-          description: "Accepted",
-        })
-      )
+      const call = onConfirm.mock.calls[0][0]
+      expect(call).not.toHaveProperty("url")
+      expect(call).toMatchObject({ description: "Accepted" })
     })
 
     it("clears error message when Cancel is clicked after a server error", async () => {

--- a/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/RiskAcceptanceModal.test.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/RiskAcceptanceModal.test.tsx
@@ -112,6 +112,7 @@ describe("RiskAcceptanceModal", () => {
       renderModal({ onConfirm })
 
       await user.type(screen.getByPlaceholderText(/Enter your user ID/i), "user-123")
+      await user.type(screen.getByPlaceholderText("e.g. JIRA-1234"), "JIRA-9999")
       await user.type(screen.getByPlaceholderText(/Add a description explaining the reason/i), "Some reason")
       fireEvent.change(screen.getByLabelText("Expiration Date"), { target: { value: "2026-12-31" } })
       await user.click(screen.getByRole("button", { name: "Accept Risk" }))
@@ -142,8 +143,12 @@ describe("RiskAcceptanceModal", () => {
       await user.type(screen.getByPlaceholderText(/Enter your user ID/i), "user-123")
       expect(confirmButton).toBeDisabled()
 
-      // All three required fields → button enabled
+      // Description + user ID + expiration (still missing Jira ticket)
       fireEvent.change(screen.getByLabelText("Expiration Date"), { target: { value: "2026-12-31" } })
+      expect(confirmButton).toBeDisabled()
+
+      // All four required fields → button enabled
+      await user.type(screen.getByPlaceholderText("e.g. JIRA-1234"), "JIRA-9999")
       expect(confirmButton).not.toBeDisabled()
     })
 
@@ -176,6 +181,7 @@ describe("RiskAcceptanceModal", () => {
       renderModal({ onConfirm })
 
       await user.type(screen.getByPlaceholderText(/Enter your user ID/i), "user-123")
+      await user.type(screen.getByPlaceholderText("e.g. JIRA-1234"), "JIRA-9999")
       await user.type(screen.getByPlaceholderText(/Add a description explaining the reason/i), "Low exposure, accepted")
       fireEvent.change(screen.getByLabelText("Expiration Date"), { target: { value: "2026-12-31" } })
 
@@ -188,6 +194,7 @@ describe("RiskAcceptanceModal", () => {
           service: "my-service",
           image: "my-image",
           remediatedBy: "user-123",
+          url: "JIRA-9999",
           description: "Low exposure, accepted",
         })
       )
@@ -213,22 +220,6 @@ describe("RiskAcceptanceModal", () => {
       )
     })
 
-    it("omits url field when source ticket field is empty", async () => {
-      const onConfirm = vi.fn().mockResolvedValue(undefined)
-      const user = userEvent.setup()
-      renderModal({ onConfirm })
-
-      await user.type(screen.getByPlaceholderText(/Enter your user ID/i), "user-123")
-      await user.type(screen.getByPlaceholderText(/Add a description explaining the reason/i), "Accepted")
-      fireEvent.change(screen.getByLabelText("Expiration Date"), { target: { value: "2026-12-31" } })
-
-      await user.click(screen.getByRole("button", { name: "Accept Risk" }))
-
-      const call = onConfirm.mock.calls[0][0]
-      expect(call).not.toHaveProperty("url")
-      expect(call).toMatchObject({ description: "Accepted" })
-    })
-
     it("clears error message when Cancel is clicked after a server error", async () => {
       const onConfirm = vi.fn().mockResolvedValue({ error: "Server error occurred" })
       const onClose = vi.fn()
@@ -236,6 +227,7 @@ describe("RiskAcceptanceModal", () => {
       renderModal({ onConfirm, onClose })
 
       await user.type(screen.getByPlaceholderText(/Enter your user ID/i), "user-123")
+      await user.type(screen.getByPlaceholderText("e.g. JIRA-1234"), "JIRA-9999")
       await user.type(screen.getByPlaceholderText(/Add a description explaining the reason/i), "Some reason")
       fireEvent.change(screen.getByLabelText("Expiration Date"), { target: { value: "2026-12-31" } })
       await user.click(screen.getByRole("button", { name: "Accept Risk" }))

--- a/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/index.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/index.tsx
@@ -174,7 +174,9 @@ export const RiskAcceptanceModal: React.FC<RiskAcceptanceModalProps> = ({
               onClick={handleConfirm}
               label={CONFIRM_LABEL}
               variant="primary"
-              disabled={isSubmitting || !descriptionTrimmed || !isUserIdValid || !sourceTicketTrimmed || !expirationDate}
+              disabled={
+                isSubmitting || !descriptionTrimmed || !isUserIdValid || !sourceTicketTrimmed || !expirationDate
+              }
             />
           </Stack>
         </ModalFooter>

--- a/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/index.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/index.tsx
@@ -86,13 +86,6 @@ export const RiskAcceptanceModal: React.FC<RiskAcceptanceModalProps> = ({
   const descriptionTrimmed = description.trim()
   const sourceTicketTrimmed = sourceTicket.trim()
 
-  const buildDescription = () => {
-    if (sourceTicketTrimmed) {
-      return `Source Ticket: ${sourceTicketTrimmed}\n\n${descriptionTrimmed}`
-    }
-    return descriptionTrimmed
-  }
-
   const handleConfirm = async () => {
     if (!descriptionTrimmed) {
       setDescriptionError("Description is required")
@@ -118,10 +111,11 @@ export const RiskAcceptanceModal: React.FC<RiskAcceptanceModalProps> = ({
         vulnerability,
         service,
         image,
-        description: buildDescription(),
+        description: descriptionTrimmed,
         ...(remediatedBy && { remediatedBy }),
         ...(severityValue !== undefined && { severity: severityValue }),
         expirationDate: expirationDate.toISOString(),
+        ...(sourceTicketTrimmed && { url: sourceTicketTrimmed }),
       }
       const result = await onConfirm(input)
       if (result?.error) {

--- a/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/index.tsx
+++ b/apps/heureka/src/components/Service/ImageDetails/RiskAcceptanceModal/index.tsx
@@ -55,6 +55,7 @@ export const RiskAcceptanceModal: React.FC<RiskAcceptanceModalProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [descriptionError, setDescriptionError] = useState<string>("")
   const [userIdError, setUserIdError] = useState<string>("")
+  const [sourceTicketError, setSourceTicketError] = useState<string>("")
   const [expirationDateError, setExpirationDateError] = useState<string>("")
   const [apiError, setApiError] = useState<string | null>(null)
   const isMountedRef = useRef(true)
@@ -78,6 +79,7 @@ export const RiskAcceptanceModal: React.FC<RiskAcceptanceModalProps> = ({
       setExpirationDate(null)
       setDescriptionError("")
       setUserIdError("")
+      setSourceTicketError("")
       setExpirationDateError("")
       setApiError(null)
     }
@@ -95,6 +97,10 @@ export const RiskAcceptanceModal: React.FC<RiskAcceptanceModalProps> = ({
       setUserIdError("User ID is required")
       return
     }
+    if (!sourceTicketTrimmed) {
+      setSourceTicketError("Jira ticket is required")
+      return
+    }
     if (!expirationDate) {
       setExpirationDateError("Expiration date is required")
       return
@@ -102,6 +108,7 @@ export const RiskAcceptanceModal: React.FC<RiskAcceptanceModalProps> = ({
 
     setDescriptionError("")
     setUserIdError("")
+    setSourceTicketError("")
     setExpirationDateError("")
     setIsSubmitting(true)
     try {
@@ -167,7 +174,7 @@ export const RiskAcceptanceModal: React.FC<RiskAcceptanceModalProps> = ({
               onClick={handleConfirm}
               label={CONFIRM_LABEL}
               variant="primary"
-              disabled={isSubmitting || !descriptionTrimmed || !isUserIdValid || !expirationDate}
+              disabled={isSubmitting || !descriptionTrimmed || !isUserIdValid || !sourceTicketTrimmed || !expirationDate}
             />
           </Stack>
         </ModalFooter>
@@ -204,9 +211,15 @@ export const RiskAcceptanceModal: React.FC<RiskAcceptanceModalProps> = ({
           <TextInput
             label="Jira Ticket / Risk Acceptance Source Ticket"
             value={sourceTicket}
-            onChange={(e) => setSourceTicket(e.target.value)}
+            onChange={(e) => {
+              setSourceTicket(e.target.value)
+              if (sourceTicketError) setSourceTicketError("")
+            }}
             placeholder="e.g. JIRA-1234"
-            helptext="Optional. Reference ticket for this risk acceptance decision."
+            required
+            invalid={!!sourceTicketError}
+            errortext={sourceTicketError}
+            helptext="Reference ticket for this risk acceptance decision."
           />
         </div>
         <div>

--- a/apps/heureka/src/components/Services/utils.ts
+++ b/apps/heureka/src/components/Services/utils.ts
@@ -623,9 +623,9 @@ export const getNormalizedRemediationsResponse = (
         vulnerability: node.vulnerability || null,
         vulnerabilityId: null,
         remediationDate: node.remediationDate != null ? String(node.remediationDate) : null,
-        remediatedBy: node.remediatedBy ?? null,
+        remediatedBy: node.remediatedBy?.trim() || null,
         expirationDate: node.expirationDate != null ? String(node.expirationDate) : null,
-        url: node.url ?? null,
+        url: node.url?.trim() || null,
       }
     })
 

--- a/apps/heureka/src/components/Services/utils.ts
+++ b/apps/heureka/src/components/Services/utils.ts
@@ -278,6 +278,7 @@ export type RemediatedVulnerability = {
   remediationDate: string | null
   remediatedBy: string | null
   expirationDate: string | null
+  url: string | null
 }
 
 type NormalizedServiceImageVulnerabilities = {
@@ -624,6 +625,7 @@ export const getNormalizedRemediationsResponse = (
         remediationDate: node.remediationDate != null ? String(node.remediationDate) : null,
         remediatedBy: node.remediatedBy ?? null,
         expirationDate: node.expirationDate != null ? String(node.expirationDate) : null,
+        url: node.url ?? null,
       }
     })
 

--- a/apps/heureka/src/generated/graphql.ts
+++ b/apps/heureka/src/generated/graphql.ts
@@ -1296,6 +1296,7 @@ export type Remediation = Node & {
   serviceId?: Maybe<Scalars["ID"]["output"]>
   severity?: Maybe<SeverityValues>
   type?: Maybe<RemediationTypeValues>
+  url?: Maybe<Scalars["String"]["output"]>
   vulnerability?: Maybe<Scalars["String"]["output"]>
   vulnerabilityId?: Maybe<Scalars["ID"]["output"]>
 }
@@ -1320,6 +1321,7 @@ export type RemediationFilter = {
   severity?: InputMaybe<Array<InputMaybe<SeverityValues>>>
   state?: InputMaybe<Array<StateFilter>>
   type?: InputMaybe<Array<InputMaybe<RemediationTypeValues>>>
+  url?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
   vulnerability?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>
 }
 
@@ -1332,6 +1334,7 @@ export type RemediationInput = {
   service?: InputMaybe<Scalars["String"]["input"]>
   severity?: InputMaybe<SeverityValues>
   type?: InputMaybe<RemediationTypeValues>
+  url?: InputMaybe<Scalars["String"]["input"]>
   vulnerability?: InputMaybe<Scalars["String"]["input"]>
 }
 
@@ -1795,6 +1798,7 @@ export type CreateRemediationMutation = {
     serviceId?: string | null
     severity?: SeverityValues | null
     type?: RemediationTypeValues | null
+    url?: string | null
     vulnerability?: string | null
     vulnerabilityId?: string | null
   }
@@ -1828,6 +1832,7 @@ export type GetRemediationsQuery = {
         expirationDate?: any | null
         remediationDate?: any | null
         remediatedBy?: string | null
+        url?: string | null
       }
     } | null> | null
   } | null
@@ -2189,6 +2194,7 @@ export const CreateRemediationDocument = gql`
       serviceId
       severity
       type
+      url
       vulnerability
       vulnerabilityId
     }
@@ -2213,6 +2219,7 @@ export const GetRemediationsDocument = gql`
           expirationDate
           remediationDate
           remediatedBy
+          url
         }
       }
       totalCount

--- a/apps/heureka/src/graphql/Remediations/createRemediation.graphql
+++ b/apps/heureka/src/graphql/Remediations/createRemediation.graphql
@@ -14,6 +14,7 @@ mutation CreateRemediation($input: RemediationInput!) {
     serviceId
     severity
     type
+    url
     vulnerability
     vulnerabilityId
   }

--- a/apps/heureka/src/graphql/Remediations/getRemediations.graphql
+++ b/apps/heureka/src/graphql/Remediations/getRemediations.graphql
@@ -14,6 +14,7 @@ query GetRemediations($filter: RemediationFilter) {
         expirationDate
         remediationDate
         remediatedBy
+        url
       }
     }
     totalCount


### PR DESCRIPTION
# Summary

The API's `Remediation` type exposes a dedicated `url` field for storing a Jira/source ticket reference. This PR wires the existing Jira ticket input in the Risk Acceptance modal to that field, removing the previous workaround that embedded the ticket in the `description` string. The ticket is now also surfaced as a dedicated "Source Ticket" column in the remediations history panel.

# Changes Made

- Added `url` to `RemediationInput` and `Remediation` in the generated GraphQL types, `createRemediation` mutation, and `getRemediations` query
- Updated `RiskAcceptanceModal` to pass the Jira ticket as a plain string in the `url` field of `RemediationInput` instead of prepending it to `description`
- Added `url` to the `RemediatedVulnerability` type and `getNormalizedRemediationsResponse` utility
- Added a "Source Ticket" column to the remediations history panel showing the `url` value
- Updated all no-data fallback values in the remediations panel to use `--`
- Fixed empty string fallback for `remediatedBy` and `url` fields by normalizing with `?.trim() || null`
- Applied `min-w-0` to description and source ticket cells to prevent text collision with adjacent columns
- Fixed date formatting in the remediations panel to always show a 2-digit day and 4-digit zero-padded year (e.g. `01 Jan 2025`)


# Related Issues

- Issue 1: closes #1698 

# Screenshots (if applicable)

<img width="3374" height="1898" alt="B44D6925-954A-4E1A-930D-7F4BA68BDADE" src="https://github.com/user-attachments/assets/3a16f8d0-15e7-45b7-977d-2eb79dca03cf" />



# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm TASK`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
