### PR TITLE
chore(deps): remove unused @svgr dependencies from example app

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -15,8 +15,8 @@
   },
   "devDependencies": {
     "@cloudoperators/juno-config": "workspace:*",
-    "@svgr/core": "7.0.0",
-    "@svgr/plugin-jsx": "7.0.0",
+    "@svgr/core": "8.1.0",
+    "@svgr/plugin-jsx": "8.1.0",
     "@tailwindcss/vite": "4.3.0",
     "@tanstack/react-query": "5.100.10",
     "@testing-library/jest-dom": "6.9.1",

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -15,8 +15,6 @@
   },
   "devDependencies": {
     "@cloudoperators/juno-config": "workspace:*",
-    "@svgr/core": "8.1.0",
-    "@svgr/plugin-jsx": "8.1.0",
     "@tailwindcss/vite": "4.3.0",
     "@tanstack/react-query": "5.100.10",
     "@testing-library/jest-dom": "6.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,12 +261,6 @@ importers:
       '@cloudoperators/juno-config':
         specifier: workspace:*
         version: link:../../packages/config
-      '@svgr/core':
-        specifier: 8.1.0
-        version: 8.1.0(typescript@6.0.3)
-      '@svgr/plugin-jsx':
-        specifier: 8.1.0
-        version: 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@tanstack/react-query':
         specifier: 5.100.10
         version: 5.100.10(react@19.2.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,11 +262,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/config
       '@svgr/core':
-        specifier: 7.0.0
-        version: 7.0.0(typescript@6.0.3)
+        specifier: 8.1.0
+        version: 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx':
-        specifier: 7.0.0
-        version: 7.0.0
+        specifier: 8.1.0
+        version: 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@tanstack/react-query':
         specifier: 5.100.10
         version: 5.100.10(react@19.2.5)
@@ -3051,20 +3051,8 @@ packages:
       typescript:
         optional: true
 
-  '@svgr/babel-plugin-add-jsx-attribute@7.0.0':
-    resolution: {integrity: sha512-khWbXesWIP9v8HuKCl2NU2HNAyqpSQ/vkIl36Nbn4HIwEYSRWL0H7Gs6idJdha2DkpFDWlsqMELvoCE8lfFY6Q==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-remove-jsx-attribute@7.0.0':
-    resolution: {integrity: sha512-iiZaIvb3H/c7d3TH2HBeK91uI2rMhZNwnsIrvd7ZwGLkFw6mmunOCoVnjdYua662MqGFxlN9xTq4fv9hgR4VXQ==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3075,20 +3063,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@7.0.0':
-    resolution: {integrity: sha512-sQQmyo+qegBx8DfFc04PFmIO1FP1MHI1/QEpzcIcclo5OAISsOJPW76ZIs0bDyO/DBSJEa/tDa1W26pVtt0FRw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0':
     resolution: {integrity: sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-replace-jsx-attribute-value@7.0.0':
-    resolution: {integrity: sha512-i6MaAqIZXDOJeikJuzocByBf8zO+meLwfQ/qMHIjCcvpnfvWf82PFvredEZElErB5glQFJa2KVKk8N2xV6tRRA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3099,20 +3075,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@svgr/babel-plugin-svg-dynamic-title@7.0.0':
-    resolution: {integrity: sha512-BoVSh6ge3SLLpKC0pmmN9DFlqgFy4NxNgdZNLPNJWBUU7TQpDWeBuyVuDW88iXydb5Cv0ReC+ffa5h3VrKfk1w==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@svgr/babel-plugin-svg-dynamic-title@8.0.0':
     resolution: {integrity: sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-svg-em-dimensions@7.0.0':
-    resolution: {integrity: sha512-tNDcBa+hYn0gO+GkP/AuNKdVtMufVhU9fdzu+vUQsR18RIJ9RWe7h/pSBY338RO08wArntwbDk5WhQBmhf2PaA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3123,21 +3087,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@svgr/babel-plugin-transform-react-native-svg@7.0.0':
-    resolution: {integrity: sha512-qw54u8ljCJYL2KtBOjI5z7Nzg8LnSvQOP5hPKj77H4VQL4+HdKbAT5pnkkZLmHKYwzsIHSYKXxHouD8zZamCFQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@svgr/babel-plugin-transform-react-native-svg@8.1.0':
     resolution: {integrity: sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==}
     engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@svgr/babel-plugin-transform-svg-component@7.0.0':
-    resolution: {integrity: sha512-CcFECkDj98daOg9jE3Bh3uyD9kzevCAnZ+UtzG6+BQG/jOQ2OA3jHnX6iG4G1MCJkUQFnUvEv33NvQfqrb/F3A==}
-    engines: {node: '>=12'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -3147,36 +3099,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@svgr/babel-preset@7.0.0':
-    resolution: {integrity: sha512-EX/NHeFa30j5UjldQGVQikuuQNHUdGmbh9kEpBKofGUtF0GUPJ4T4rhoYiqDAOmBOxojyot36JIFiDUHUK1ilQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@svgr/babel-preset@8.1.0':
     resolution: {integrity: sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==}
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@svgr/core@7.0.0':
-    resolution: {integrity: sha512-ztAoxkaKhRVloa3XydohgQQCb0/8x9T63yXovpmHzKMkHO6pkjdsIAWKOS4bE95P/2quVh1NtjSKlMRNzSBffw==}
-    engines: {node: '>=14'}
-
   '@svgr/core@8.1.0':
     resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
     engines: {node: '>=14'}
 
-  '@svgr/hast-util-to-babel-ast@7.0.0':
-    resolution: {integrity: sha512-42Ej9sDDEmsJKjrfQ1PHmiDiHagh/u9AHO9QWbeNx4KmD9yS5d1XHmXUNINfUcykAU+4431Cn+k6Vn5mWBYimQ==}
-    engines: {node: '>=14'}
-
   '@svgr/hast-util-to-babel-ast@8.0.0':
     resolution: {integrity: sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==}
-    engines: {node: '>=14'}
-
-  '@svgr/plugin-jsx@7.0.0':
-    resolution: {integrity: sha512-SWlTpPQmBUtLKxXWgpv8syzqIU8XgFRvyhfkam2So8b3BE0OS0HPe5UfmlJ2KIC+a7dpuuYovPR2WAQuSyMoPw==}
     engines: {node: '>=14'}
 
   '@svgr/plugin-jsx@8.1.0':
@@ -9464,15 +9398,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/babel-plugin-add-jsx-attribute@7.0.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-
-  '@svgr/babel-plugin-remove-jsx-attribute@7.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
 
@@ -9480,15 +9406,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@7.0.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-
   '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-
-  '@svgr/babel-plugin-replace-jsx-attribute-value@7.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
 
@@ -9496,15 +9414,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-dynamic-title@7.0.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-
   '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-
-  '@svgr/babel-plugin-svg-em-dimensions@7.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
 
@@ -9512,33 +9422,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-react-native-svg@7.0.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-
   '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-
-  '@svgr/babel-plugin-transform-svg-component@7.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
 
   '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-
-  '@svgr/babel-preset@7.0.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-plugin-add-jsx-attribute': 7.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-attribute': 7.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 7.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 7.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-dynamic-title': 7.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-svg-em-dimensions': 7.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-react-native-svg': 7.0.0(@babel/core@7.29.0)
-      '@svgr/babel-plugin-transform-svg-component': 7.0.0(@babel/core@7.29.0)
 
   '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
     dependencies:
@@ -9552,16 +9442,6 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
-  '@svgr/core@7.0.0(typescript@6.0.3)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 7.0.0(@babel/core@7.29.0)
-      camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@6.0.3)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@svgr/core@8.1.0(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.0
@@ -9573,24 +9453,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/hast-util-to-babel-ast@7.0.0':
-    dependencies:
-      '@babel/types': 7.29.0
-      entities: 4.5.0
-
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
       '@babel/types': 7.29.0
       entities: 4.5.0
-
-  '@svgr/plugin-jsx@7.0.0':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@svgr/babel-preset': 7.0.0(@babel/core@7.29.0)
-      '@svgr/hast-util-to-babel-ast': 7.0.0
-      svg-parser: 2.0.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
     dependencies:


### PR DESCRIPTION
# Summary

Remove `@svgr/core` and `@svgr/plugin-jsx` from the example app's devDependencies as they are not directly used in the codebase and are already provided as transitive dependencies through `vite-plugin-svgr`.

# Changes Made

- Removed `@svgr/core` from `apps/example/package.json` devDependencies
- Removed `@svgr/plugin-jsx` from `apps/example/package.json` devDependencies
- Updated `pnpm-lock.yaml` accordingly

# Related Issues

N/A - Dependency cleanup

# Screenshots (if applicable)

N/A - No visual changes

# Testing Instructions

1. `pnpm i`
2. `pnpm build`
3. `pnpm test`
4. Verify SVG imports still work correctly in the example app via `pnpm dev`

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.