### PR TITLE
feat(ui): add `DataGrid` header stories

### DIFF
--- a/.changeset/wide-things-dig.md
+++ b/.changeset/wide-things-dig.md
@@ -1,5 +1,5 @@
 ---
-"@cloudoperators/juno-ui-components": patch
+"@cloudoperators/juno-ui-components": minor
 ---
 
 feat(ui): add `DataGrid` header stories

--- a/.changeset/wide-things-dig.md
+++ b/.changeset/wide-things-dig.md
@@ -3,3 +3,5 @@
 ---
 
 feat(ui): add `DataGrid` header stories
+feat(docs): filter out `js:`-prefix from classNames in storyabook code examples (everywhere, this is a global storybook setting now for ui-components)
+BREAKING CHANGE: remove `alignRight` prop (the component now relies purely on composition)

--- a/.changeset/wide-things-dig.md
+++ b/.changeset/wide-things-dig.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+feat(ui): add `DataGrid` header stories

--- a/docs/ux/datagrid.md
+++ b/docs/ux/datagrid.md
@@ -40,9 +40,8 @@ More specifically, these are any combination of the following elements. Each ele
 
 (TODO: Illustration of the fully featured header with overlayed/indicated zones)
 
-### Zone 1: Bulk Actions, Sorting, Action(s)
+### Zone 1: Sorting, Action(s)
 
-- Bulk Actions: Actions that can be run on multiple items in the DataGrid at once. Contains a Checkbox to select/deselect all items, and requires a Checkbox on each individual item / row.
 - Sorting: Select to choose what to sort by, and a button to toggle sort direction
 - Other Actions Overflow Menu: Any actions global to the data set other than the primary action
 - Primary Action: The primary, i.e. most likely action for users. If users can create new items in the DataGrid, this can be done using the primary action button
@@ -53,10 +52,11 @@ More specifically, these are any combination of the following elements. Each ele
 - Search: A SearchBox to perform a string-based search on the data and display the matching items. Make sure to manage user expectations as to what exactly will be searched, i.e. if the string entered is only matched against a single or a subset of fields, the placeholder should indicate that (e.g. "Search Description" if only descriptions can be searched)
 - Filter Pills: Each filter that has been configured by the user using the Filter element(s) and that is currently active is displayed here. As a last item, there is a button that allows for clearing all active filters at once.
 
-### Zone 3: DataGrid View/State, Refresh
+### Zone 3: DataGrid View/State, Bulk Actions, Refresh
 
-- Item Count: The number of items of the set that is currently visible as a whole (not only on the current page). If filters or searches are active, the number of matching items and the total number of items in the data set is being displayed.
-- Last Update, Update/Refresh: The date and time of the last refresh of the data displayed, and a button to trigger a refresh.
+- Bulk Actions: Actions that can be run on multiple items in the DataGrid at once. Positioned on the left side of Zone 3. Contains a Checkbox to select/deselect all items, and a menu of available bulk actions. Requires a Checkbox on each individual item / row.
+- Item Count: The number of items of the set that is currently visible as a whole (not only on the current page), displayed in the center. If filters or searches are active, the number of matching items and the total number of items in the data set is being displayed.
+- Last Update, Update/Refresh: The date and time of the last refresh of the data displayed, and a button to trigger a refresh. Positioned on the right side of Zone 3.
 
 All of the above elements are optional in the sense that none of them will be required for any given DataGrid. However, if you find yourself in a situation where none of the above options is needed or desired, reconsider whether using a DataGrid is the right choice to display the given data. This case can occur, but it is rare. In most cases a simple list is then a more appropriate option to display the data.
 

--- a/docs/ux/datagrid.md
+++ b/docs/ux/datagrid.md
@@ -54,7 +54,7 @@ More specifically, these are any combination of the following elements. Each ele
 
 ### Zone 3: DataGrid View/State, Bulk Actions, Refresh
 
-- Bulk Actions: Actions that can be run on multiple items in the DataGrid at once. Positioned on the left side of Zone 3. Contains a Checkbox to select/deselect all items, and a menu of available bulk actions. Requires a Checkbox on each individual item / row.
+- Bulk Actions: Actions that can be run on multiple items in the DataGrid at once. Positioned on the left side of Zone 3. Contains a Checkbox to select/deselect all items, and a menu of available bulk actions. Requires a Checkbox on each individual item / row. Bulk action controls should be disabled until at least one item is selected. The select-all checkbox follows a tri-state model: unchecked when no items are selected, indeterminate when some are, and checked when all are. Clicking the checkbox in the unchecked or indeterminate state selects all items; clicking it in the checked state deselects all.
 - Item Count: The number of items of the set that is currently visible as a whole (not only on the current page), displayed in the center. If filters or searches are active, the number of matching items and the total number of items in the data set is being displayed.
 - Last Update, Update/Refresh: The date and time of the last refresh of the data displayed, and a button to trigger a refresh. Positioned on the right side of Zone 3.
 

--- a/packages/ui-components/.storybook/preview.js
+++ b/packages/ui-components/.storybook/preview.js
@@ -19,6 +19,11 @@ const preview = {
         date: /Date$/,
       },
     },
+    docs: {
+      source: {
+        transform: (src) => src.replace(/\bjn:/g, ""),
+      },
+    },
   },
 
   tags: ["autodocs"],

--- a/packages/ui-components/src/components/Button/Button.component.tsx
+++ b/packages/ui-components/src/components/Button/Button.component.tsx
@@ -22,7 +22,6 @@ const btnBase = `
   jn:justify-center 
   jn:items-center
   jn:rounded
-  jn:shadow-sm 
   jn:w-auto
   jn:focus:outline-hidden 
   jn:focus-visible:ring-2

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -84,32 +84,35 @@ export const WithPrimaryAction: Story = {
 
 export const WithFiltersSearchAndState: Story = {
   render: () => (
-    <DataGridToolbar>
-      <Stack direction="vertical" gap="2">
-        {/* Zone 2: Filters + Search */}
-        <Stack distribution="between" alignment="center">
-          <InputGroup>
-            <Select width="auto" className="jn:min-w-44">
-              <SelectOption value="region" label="Region" />
-              <SelectOption value="status" label="Status" />
-              <SelectOption value="az" label="Availability Zone" />
-            </Select>
-            <ComboBox>
-              <ComboBoxOption value="eu-west-1" label="eu-west-1" />
-              <ComboBoxOption value="us-east-1" label="us-east-1" />
-              <ComboBoxOption value="ap-south-1" label="ap-south-1" />
-            </ComboBox>
-          </InputGroup>
-          <SearchInput placeholder="Search servers…" />
-        </Stack>
+    <>
+      <DataGridToolbar>
+        <Stack direction="vertical" gap="2">
+          {/* Zone 2: Filters + Search */}
+          <Stack distribution="between" alignment="center">
+            <InputGroup>
+              <Select width="auto" className="jn:min-w-44">
+                <SelectOption value="region" label="Region" />
+                <SelectOption value="status" label="Status" />
+                <SelectOption value="az" label="Availability Zone" />
+              </Select>
+              <ComboBox>
+                <ComboBoxOption value="eu-west-1" label="eu-west-1" />
+                <ComboBoxOption value="us-east-1" label="us-east-1" />
+                <ComboBoxOption value="ap-south-1" label="ap-south-1" />
+              </ComboBox>
+            </InputGroup>
+            <SearchInput placeholder="Search servers…" />
+          </Stack>
 
-        {/* Zone 2 cont: Active filter pills */}
-        <Stack gap="2" wrap>
-          <Pill pillKey="Region" pillValue="eu-west-1" closeable />
-          <Pill pillKey="Status" pillValue="Running" closeable />
-          <Button label="Clear filters" size="xs" />
+          {/* Zone 2 cont: Active filter pills */}
+          <Stack gap="2" wrap>
+            <Pill pillKey="Region" pillValue="eu-west-1" closeable />
+            <Pill pillKey="Status" pillValue="Running" closeable />
+            <Button label="Clear filters" size="xs" />
+          </Stack>
         </Stack>
-
+      </DataGridToolbar>
+      <DataGridToolbar>
         {/* Zone 3: Item count + Refresh */}
         <Stack distribution="between" alignment="center" className="jn:text-sm">
           <span>Showing 2 of 4 servers</span>
@@ -118,8 +121,8 @@ export const WithFiltersSearchAndState: Story = {
             <Button label="Update" size="xs" />
           </Stack>
         </Stack>
-      </Stack>
-    </DataGridToolbar>
+      </DataGridToolbar>
+    </>
   ),
   parameters: {
     docs: {
@@ -208,26 +211,25 @@ export const FullyFeatured: Story = {
                 <Pill pillKey="Status" pillValue="Running" closeable />
                 <Button label="Clear filters" size="xs" />
               </Stack>
-
-              {/* Zone 3: Bulk actions + item count + refresh */}
-              <Stack distribution="between" alignment="center" className="jn:text-sm">
-                <Stack gap="2" alignment="center">
-                  <Checkbox />
-                  <PopupMenu className="jn:flex jn:items-center">
-                    <PopupMenuToggle
-                      {...({ as: Button, size: "xs", icon: "moreVert", label: "Show Actions" } as any)}
-                    />
-                    <PopupMenuOptions>
-                      <PopupMenuItem label="Download" />
-                      <PopupMenuItem label="Delete" />
-                    </PopupMenuOptions>
-                  </PopupMenu>
-                </Stack>
-                <span className="jn:theme-color-text-light">Showing 2 of 4 servers</span>
-                <Stack gap="2" alignment="center">
-                  <span>Last update: 20.05.2026 @09:41</span>
-                  <Button label="Update" size="xs" />
-                </Stack>
+            </Stack>
+          </DataGridToolbar>
+          <DataGridToolbar>
+            {/* Zone 3: Bulk actions + item count + refresh */}
+            <Stack distribution="between" alignment="center" className="jn:text-sm">
+              <Stack gap="2" alignment="center">
+                <Checkbox />
+                <PopupMenu className="jn:flex jn:items-center">
+                  <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Show Actions" } as any)} />
+                  <PopupMenuOptions>
+                    <PopupMenuItem label="Download" />
+                    <PopupMenuItem label="Delete" />
+                  </PopupMenuOptions>
+                </PopupMenu>
+              </Stack>
+              <span className="jn:theme-color-text-light">Showing 2 of 4 servers</span>
+              <Stack gap="2" alignment="center">
+                <span>Last update: 20.05.2026 @09:41</span>
+                <Button label="Update" size="xs" />
               </Stack>
             </Stack>
           </DataGridToolbar>
@@ -287,6 +289,7 @@ export const FullyFeatured: Story = {
       </Stack>
       <Stack gap="0.5">
         <PopupMenu>
+          <PopupMenuToggle {...({ as: Button, icon: "moreVert" } as any)} />
           <PopupMenuOptions>
             <PopupMenuItem label="Export CSV" />
             <PopupMenuItem label="Refresh all" />
@@ -297,10 +300,9 @@ export const FullyFeatured: Story = {
     </Stack>
   </Stack>
 
-  {/* Zones 2+3 — DataGridToolbar provides background and spacing */}
+  {/* Zone 2 — DataGridToolbar provides background and spacing */}
   <DataGridToolbar>
     <Stack direction="vertical" gap="2">
-      {/* Zone 2: Filters + Search */}
       <Stack distribution="between" alignment="center">
         <InputGroup>
           <Select width="auto" className="jn:min-w-44">
@@ -316,31 +318,31 @@ export const FullyFeatured: Story = {
         </InputGroup>
         <SearchInput placeholder="Search servers…" />
       </Stack>
-
-      {/* Zone 2 cont: Active filter pills */}
       <Stack gap="2" wrap>
         <Pill pillKey="Region" pillValue="eu-west-1" closeable />
         <Pill pillKey="Status" pillValue="Running" closeable />
-        <Button label="Clear filters" variant="subdued" size="xs" />
+        <Button label="Clear filters" size="xs" />
       </Stack>
+    </Stack>
+  </DataGridToolbar>
 
-      {/* Zone 3: Bulk actions + item count + refresh */}
-      <Stack distribution="between" alignment="center">
-        <Stack gap="2" alignment="center">
-          <Checkbox />
-          <PopupMenu className="jn:flex jn:items-center">
-            <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Show Actions" } as any)} />
-            <PopupMenuOptions>
-              <PopupMenuItem label="Download" />
-              <PopupMenuItem label="Delete" />
-            </PopupMenuOptions>
-          </PopupMenu>
-        </Stack>
-        <span>Showing 2 of 4 servers</span>
-        <Stack gap="2" alignment="center">
-          <span>Last update: 20.05.2026 @09:41</span>
-          <Button label="Update" size="xs" />
-        </Stack>
+  {/* Zone 3 — separate DataGridToolbar */}
+  <DataGridToolbar>
+    <Stack distribution="between" alignment="center" className="jn:text-sm">
+      <Stack gap="2" alignment="center">
+        <Checkbox />
+        <PopupMenu className="jn:flex jn:items-center">
+          <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Show Actions" } as any)} />
+          <PopupMenuOptions>
+            <PopupMenuItem label="Download" />
+            <PopupMenuItem label="Delete" />
+          </PopupMenuOptions>
+        </PopupMenu>
+      </Stack>
+      <span className="jn:theme-color-text-light">Showing 2 of 4 servers</span>
+      <Stack gap="2" alignment="center">
+        <span>Last update: 20.05.2026 @09:41</span>
+        <Button label="Update" size="xs" />
       </Stack>
     </Stack>
   </DataGridToolbar>

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -174,7 +174,9 @@ export const FullyFeatured: Story = {
               </Stack>
               <Stack gap="0.5">
                 <PopupMenu>
-                  <PopupMenuToggle {...({ as: Button, icon: "moreVert" } as any)} />
+                  <PopupMenuToggle as={React.Fragment}>
+                    <Button icon="moreVert" title="More actions" />
+                  </PopupMenuToggle>
                   <PopupMenuOptions>
                     <PopupMenuItem label="Export CSV" />
                     <PopupMenuItem label="Refresh all" />
@@ -219,7 +221,9 @@ export const FullyFeatured: Story = {
               <Stack gap="2" alignment="center">
                 <Checkbox aria-label="Select all items" />
                 <PopupMenu className="jn:flex jn:items-center">
-                  <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Actions" } as any)} />
+                  <PopupMenuToggle as={React.Fragment}>
+                    <Button size="xs" icon="moreVert" label="Actions" />
+                  </PopupMenuToggle>
                   <PopupMenuOptions>
                     <PopupMenuItem label="Download" />
                     <PopupMenuItem label="Delete" />

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -111,7 +111,7 @@ export const WithFiltersSearchAndState: Story = {
         </Stack>
 
         {/* Zone 3: Item count + Refresh */}
-        <Stack distribution="between" alignment="center">
+        <Stack distribution="between" alignment="center" className="jn:text-sm">
           <span>Showing 2 of 4 servers</span>
           <Stack gap="2" alignment="center">
             <span>Last update: 20.05.2026 @09:41</span>
@@ -160,19 +160,26 @@ export const FullyFeatured: Story = {
         <Stack direction="vertical">
           {/* Zone 1: Sorting + primary action — bare Stack, no background */}
           <Stack distribution="end" alignment="center" gap="2" className="jn:pb-2">
-            <Select width="auto" className="jn:min-w-40">
-              <SelectOption value="name" label="Name" />
-              <SelectOption value="status" label="Status" />
-              <SelectOption value="region" label="Region" />
-            </Select>
-            <SortButton order={sortOrder} onChange={setSortOrder} />
-            <PopupMenu>
-              <PopupMenuOptions>
-                <PopupMenuItem label="Export CSV" />
-                <PopupMenuItem label="Refresh all" />
-              </PopupMenuOptions>
-            </PopupMenu>
-            <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
+            <Stack gap="2">
+              <Stack gap="0.5">
+                <Select width="auto" className="jn:min-w-40">
+                  <SelectOption value="name" label="Name" />
+                  <SelectOption value="status" label="Status" />
+                  <SelectOption value="region" label="Region" />
+                </Select>
+                <SortButton order={sortOrder} onChange={setSortOrder} />
+              </Stack>
+              <Stack gap="0.5">
+                <PopupMenu>
+                  <PopupMenuToggle {...({ as: Button, icon: "moreVert" } as any)} />
+                  <PopupMenuOptions>
+                    <PopupMenuItem label="Export CSV" />
+                    <PopupMenuItem label="Refresh all" />
+                  </PopupMenuOptions>
+                </PopupMenu>
+                <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
+              </Stack>
+            </Stack>
           </Stack>
 
           {/* Zones 2+3 — DataGridToolbar provides background and spacing */}
@@ -269,19 +276,25 @@ export const FullyFeatured: Story = {
 <Stack direction="vertical">
   {/* Zone 1 — bare Stack, no background */}
   <Stack distribution="end" alignment="center" gap="2" className="jn:pb-2">
-    <Select width="auto" className="jn:min-w-40">
-      <SelectOption value="name" label="Name" />
-      <SelectOption value="status" label="Status" />
-      <SelectOption value="region" label="Region" />
-    </Select>
-    <SortButton order={sortOrder} onChange={setSortOrder} />
-    <PopupMenu>
-      <PopupMenuOptions>
-        <PopupMenuItem label="Export CSV" />
-        <PopupMenuItem label="Refresh all" />
-      </PopupMenuOptions>
-    </PopupMenu>
-    <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
+    <Stack gap="2">
+      <Stack gap="0.5">
+        <Select width="auto" className="jn:min-w-40">
+          <SelectOption value="name" label="Name" />
+          <SelectOption value="status" label="Status" />
+          <SelectOption value="region" label="Region" />
+        </Select>
+        <SortButton order={sortOrder} onChange={setSortOrder} />
+      </Stack>
+      <Stack gap="0.5">
+        <PopupMenu>
+          <PopupMenuOptions>
+            <PopupMenuItem label="Export CSV" />
+            <PopupMenuItem label="Refresh all" />
+          </PopupMenuOptions>
+        </PopupMenu>
+        <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
+      </Stack>
+    </Stack>
   </Stack>
 
   {/* Zones 2+3 — DataGridToolbar provides background and spacing */}

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -76,6 +76,7 @@ export const WithPrimaryAction: Story = {
         story:
           "The simplest DataGrid header: a single primary action. No `DataGridToolbar` needed — Zone 1 content sits directly in a `Stack`.",
       },
+      source: { type: "dynamic" },
     },
   },
 }
@@ -125,6 +126,7 @@ export const WithFiltersSearchAndState: Story = {
         story:
           "Zones 2 and 3: filter controls, active filter pills, search, item count, and a refresh button. `DataGridToolbar` provides the background and spacing. Zone 1 is not needed here — no bulk actions or primary action required for this view.",
       },
+      source: { type: "dynamic" },
     },
   },
 }
@@ -165,7 +167,7 @@ export const FullyFeatured: Story = {
           </Stack>
 
           {/* Zones 2+3 — DataGridToolbar provides background and spacing */}
-          <DataGridToolbar className="jn:bg-theme-background-lvl-1">
+          <DataGridToolbar>
             <Stack direction="vertical" gap="2">
               {/* Zone 2: Filters + Search */}
               <Stack distribution="between" alignment="center">
@@ -226,7 +228,96 @@ export const FullyFeatured: Story = {
     docs: {
       description: {
         story:
-          "Fully featured DataGrid header — the golden-path reference. Zone 1 (bulk actions, sort, primary action) is a bare `Stack` with no wrapper — no background, no `DataGridToolbar`. Zones 2+3 (filters, active filter pills, search, item count, refresh) are wrapped in `DataGridToolbar` which provides the background and spacing. Every zone and every element within it is optional.",
+          "Fully featured DataGrid header. Zone 1 (bulk actions, sort, primary action) is a bare `Stack` with no wrapper — no background, no `DataGridToolbar`. Zones 2+3 (filters, active filter pills, search, item count, refresh) are wrapped in `DataGridToolbar` which provides the background and spacing. Every zone and every element within it is optional.",
+      },
+      // Keep this source.code in sync with the render function above
+      source: {
+        code: `
+<Stack direction="vertical">
+  {/* Zone 1 — bare Stack, no wrapper, no background */}
+  <Stack distribution="between" alignment="center" className="jn:pb-2">
+    <Stack gap="2" alignment="center">
+      <Checkbox label="Select all" />
+      <PopupMenu>
+        <PopupMenuOptions>
+          <PopupMenuItem label="Download" />
+          <PopupMenuItem label="Delete" />
+        </PopupMenuOptions>
+      </PopupMenu>
+    </Stack>
+    <Stack gap="2" alignment="center">
+      <Select>
+        <SelectOption value="name" label="Name" />
+        <SelectOption value="status" label="Status" />
+        <SelectOption value="region" label="Region" />
+      </Select>
+      <SortButton order={sortOrder} onChange={setSortOrder} />
+      <PopupMenu>
+        <PopupMenuOptions>
+          <PopupMenuItem label="Export CSV" />
+          <PopupMenuItem label="Refresh all" />
+        </PopupMenuOptions>
+      </PopupMenu>
+      <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
+    </Stack>
+  </Stack>
+
+  {/* Zones 2+3 — DataGridToolbar provides background and spacing */}
+  <DataGridToolbar>
+    <Stack direction="vertical" gap="2">
+      {/* Zone 2: Filters + Search */}
+      <Stack distribution="between" alignment="center">
+        <InputGroup>
+          <Select>
+            <SelectOption value="region" label="Region" />
+            <SelectOption value="status" label="Status" />
+            <SelectOption value="az" label="Availability Zone" />
+          </Select>
+          <ComboBox>
+            <ComboBoxOption value="eu-west-1" label="eu-west-1" />
+            <ComboBoxOption value="us-east-1" label="us-east-1" />
+            <ComboBoxOption value="ap-south-1" label="ap-south-1" />
+          </ComboBox>
+        </InputGroup>
+        <SearchInput placeholder="Search servers…" />
+      </Stack>
+
+      {/* Zone 2 cont: Active filter pills */}
+      <Stack gap="2" wrap>
+        <Pill pillKey="Region" pillValue="eu-west-1" closeable />
+        <Pill pillKey="Status" pillValue="Running" closeable />
+        <Button label="Clear filters" variant="subdued" size="xs" />
+      </Stack>
+
+      {/* Zone 3: Item count + Refresh */}
+      <Stack distribution="between" alignment="center">
+        <span>Showing 2 of 4 servers</span>
+        <Stack gap="2" alignment="center">
+          <span>Last update: 20.05.2026 @09:41</span>
+          <Button label="Update" size="small" />
+        </Stack>
+      </Stack>
+    </Stack>
+  </DataGridToolbar>
+</Stack>
+
+<DataGrid columns={4}>
+  <DataGridRow>
+    <DataGridHeadCell>Name</DataGridHeadCell>
+    <DataGridHeadCell>Region</DataGridHeadCell>
+    <DataGridHeadCell>Status</DataGridHeadCell>
+    <DataGridHeadCell>Availability Zone</DataGridHeadCell>
+  </DataGridRow>
+  {servers.map((s) => (
+    <DataGridRow key={s.id}>
+      <DataGridCell>{s.name}</DataGridCell>
+      <DataGridCell>{s.region}</DataGridCell>
+      <DataGridCell>{s.status}</DataGridCell>
+      <DataGridCell>{s.az}</DataGridCell>
+    </DataGridRow>
+  ))}
+</DataGrid>
+        `.trim(),
       },
     },
   },

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -41,9 +41,9 @@ The DataGrid header is a composition pattern, not a single component. It sits ab
 
 The header is structured in up to three zones:
 
-- **Zone 1 — Actions:** Bulk actions (select-all checkbox + action menu), sorting controls, an optional overflow menu for global actions, and the primary action (e.g. "Create"). This zone has no background — it is a plain \`Stack\` with no wrapper component.
+- **Zone 1 — Actions:** Sorting controls, an optional overflow menu for global actions, and the primary action (e.g. "Create"). This zone has no background — it is a plain \`Stack\` with no wrapper component.
 - **Zone 2 — Filters and Search:** One or more filter inputs (typically a \`Select\` + \`ComboBox\` in an \`InputGroup\`), a \`SearchInput\`, and active filter pills with a "Clear filters" button.
-- **Zone 3 — DataGrid State:** Item count (total, or "X of Y" when filters are active), last update timestamp, and a refresh button.
+- **Zone 3 — DataGrid State:** Bulk actions (select-all checkbox + action menu) on the left, item count in the middle (total, or "X of Y" when filters are active), and last update timestamp with a refresh button on the right.
 
 Zones 2 and 3 share a background and are wrapped together in a single \`DataGridToolbar\`, which provides the background color, padding, and separation from the grid below.
 
@@ -88,7 +88,7 @@ export const WithFiltersSearchAndState: Story = {
         {/* Zone 2: Filters + Search */}
         <Stack distribution="between" alignment="center">
           <InputGroup>
-            <Select>
+            <Select width="auto" className="jn:min-w-44">
               <SelectOption value="region" label="Region" />
               <SelectOption value="status" label="Status" />
               <SelectOption value="az" label="Availability Zone" />
@@ -114,7 +114,7 @@ export const WithFiltersSearchAndState: Story = {
           <span>Showing 2 of 4 servers</span>
           <Stack gap="2" alignment="center">
             <span>Last update: 20.05.2026 @09:41</span>
-            <Button label="Update" size="small" />
+            <Button label="Update" size="xs" />
           </Stack>
         </Stack>
       </Stack>
@@ -157,32 +157,21 @@ export const FullyFeatured: Story = {
     return (
       <>
         <Stack direction="vertical">
-          {/* Zone 1: Actions — no DataGridToolbar needed, no background */}
-          <Stack distribution="between" alignment="center" className="jn:pb-2">
-            <Stack gap="2" alignment="center">
-              <Checkbox label="Select all" />
-              <PopupMenu>
-                <PopupMenuOptions>
-                  <PopupMenuItem label="Download" />
-                  <PopupMenuItem label="Delete" />
-                </PopupMenuOptions>
-              </PopupMenu>
-            </Stack>
-            <Stack gap="2" alignment="center">
-              <Select>
-                <SelectOption value="name" label="Name" />
-                <SelectOption value="status" label="Status" />
-                <SelectOption value="region" label="Region" />
-              </Select>
-              <SortButton order={sortOrder} onChange={setSortOrder} />
-              <PopupMenu>
-                <PopupMenuOptions>
-                  <PopupMenuItem label="Export CSV" />
-                  <PopupMenuItem label="Refresh all" />
-                </PopupMenuOptions>
-              </PopupMenu>
-              <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
-            </Stack>
+          {/* Zone 1: Sorting + primary action — bare Stack, no background */}
+          <Stack distribution="end" alignment="center" gap="2" className="jn:pb-2">
+            <Select width="auto" className="jn:min-w-40">
+              <SelectOption value="name" label="Name" />
+              <SelectOption value="status" label="Status" />
+              <SelectOption value="region" label="Region" />
+            </Select>
+            <SortButton order={sortOrder} onChange={setSortOrder} />
+            <PopupMenu>
+              <PopupMenuOptions>
+                <PopupMenuItem label="Export CSV" />
+                <PopupMenuItem label="Refresh all" />
+              </PopupMenuOptions>
+            </PopupMenu>
+            <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
           </Stack>
 
           {/* Zones 2+3 — DataGridToolbar provides background and spacing */}
@@ -191,7 +180,7 @@ export const FullyFeatured: Story = {
               {/* Zone 2: Filters + Search */}
               <Stack distribution="between" alignment="center">
                 <InputGroup>
-                  <Select>
+                  <Select width="auto" className="jn:min-w-44">
                     <SelectOption value="region" label="Region" />
                     <SelectOption value="status" label="Status" />
                     <SelectOption value="az" label="Availability Zone" />
@@ -212,12 +201,21 @@ export const FullyFeatured: Story = {
                 <Button label="Clear filters" variant="subdued" size="xs" />
               </Stack>
 
-              {/* Zone 3: Item count + Refresh */}
-              <Stack distribution="between" alignment="center">
+              {/* Zone 3: Bulk actions + item count + refresh */}
+              <Stack distribution="between" alignment="center" className="jn:text-sm">
+                <Stack gap="2" alignment="center">
+                  <Checkbox label="Select all" />
+                  <PopupMenu>
+                    <PopupMenuOptions>
+                      <PopupMenuItem label="Download" />
+                      <PopupMenuItem label="Delete" />
+                    </PopupMenuOptions>
+                  </PopupMenu>
+                </Stack>
                 <span>Showing 2 of 4 servers</span>
                 <Stack gap="2" alignment="center">
                   <span>Last update: 20.05.2026 @09:41</span>
-                  <Button label="Update" size="small" />
+                  <Button label="Update" size="xs" />
                 </Stack>
               </Stack>
             </Stack>
@@ -247,38 +245,27 @@ export const FullyFeatured: Story = {
     docs: {
       description: {
         story:
-          "Fully featured DataGrid header. Zone 1 (bulk actions, sort, primary action) is a bare `Stack` with no wrapper — no background, no `DataGridToolbar`. Zones 2+3 (filters, active filter pills, search, item count, refresh) are wrapped in `DataGridToolbar` which provides the background and spacing. Every zone and every element within it is optional.",
+          "Fully featured DataGrid header. Zone 1 (sort, overflow menu, primary action) is a bare `Stack` — no background, no `DataGridToolbar`. Zones 2+3 are wrapped in `DataGridToolbar`. Zone 3 carries bulk actions (checkbox + action menu) on the left, item count in the middle, and last update + refresh on the right. Every zone and every element within it is optional.",
       },
       // Keep this source.code in sync with the render function above
       source: {
         code: `
 <Stack direction="vertical">
-  {/* Zone 1 — bare Stack, no wrapper, no background */}
-  <Stack distribution="between" alignment="center" className="jn:pb-2">
-    <Stack gap="2" alignment="center">
-      <Checkbox label="Select all" />
-      <PopupMenu>
-        <PopupMenuOptions>
-          <PopupMenuItem label="Download" />
-          <PopupMenuItem label="Delete" />
-        </PopupMenuOptions>
-      </PopupMenu>
-    </Stack>
-    <Stack gap="2" alignment="center">
-      <Select>
-        <SelectOption value="name" label="Name" />
-        <SelectOption value="status" label="Status" />
-        <SelectOption value="region" label="Region" />
-      </Select>
-      <SortButton order={sortOrder} onChange={setSortOrder} />
-      <PopupMenu>
-        <PopupMenuOptions>
-          <PopupMenuItem label="Export CSV" />
-          <PopupMenuItem label="Refresh all" />
-        </PopupMenuOptions>
-      </PopupMenu>
-      <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
-    </Stack>
+  {/* Zone 1 — bare Stack, no background */}
+  <Stack distribution="end" alignment="center" gap="2" className="jn:pb-2">
+    <Select width="auto" className="jn:min-w-40">
+      <SelectOption value="name" label="Name" />
+      <SelectOption value="status" label="Status" />
+      <SelectOption value="region" label="Region" />
+    </Select>
+    <SortButton order={sortOrder} onChange={setSortOrder} />
+    <PopupMenu>
+      <PopupMenuOptions>
+        <PopupMenuItem label="Export CSV" />
+        <PopupMenuItem label="Refresh all" />
+      </PopupMenuOptions>
+    </PopupMenu>
+    <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
   </Stack>
 
   {/* Zones 2+3 — DataGridToolbar provides background and spacing */}
@@ -287,7 +274,7 @@ export const FullyFeatured: Story = {
       {/* Zone 2: Filters + Search */}
       <Stack distribution="between" alignment="center">
         <InputGroup>
-          <Select>
+          <Select width="auto" className="jn:min-w-44">
             <SelectOption value="region" label="Region" />
             <SelectOption value="status" label="Status" />
             <SelectOption value="az" label="Availability Zone" />
@@ -308,12 +295,21 @@ export const FullyFeatured: Story = {
         <Button label="Clear filters" variant="subdued" size="xs" />
       </Stack>
 
-      {/* Zone 3: Item count + Refresh */}
+      {/* Zone 3: Bulk actions + item count + refresh */}
       <Stack distribution="between" alignment="center">
+        <Stack gap="2" alignment="center">
+          <Checkbox label="Select all" />
+          <PopupMenu>
+            <PopupMenuOptions>
+              <PopupMenuItem label="Download" />
+              <PopupMenuItem label="Delete" />
+            </PopupMenuOptions>
+          </PopupMenu>
+        </Stack>
         <span>Showing 2 of 4 servers</span>
         <Stack gap="2" alignment="center">
           <span>Last update: 20.05.2026 @09:41</span>
-          <Button label="Update" size="small" />
+          <Button label="Update" size="xs" />
         </Stack>
       </Stack>
     </Stack>

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -223,7 +223,7 @@ export const FullyFeatured: Story = {
                     </PopupMenuOptions>
                   </PopupMenu>
                 </Stack>
-                <span>Showing 2 of 4 servers</span>
+                <span className="jn:theme-color-text-light">Showing 2 of 4 servers</span>
                 <Stack gap="2" alignment="center">
                   <span>Last update: 20.05.2026 @09:41</span>
                   <Button label="Update" size="xs" />

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -217,7 +217,7 @@ export const FullyFeatured: Story = {
             {/* Zone 3: Bulk actions + item count + refresh */}
             <Stack distribution="between" alignment="center" className="jn:text-sm">
               <Stack gap="2" alignment="center">
-                <Checkbox />
+                <Checkbox aria-label="Select all items" />
                 <PopupMenu className="jn:flex jn:items-center">
                   <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Actions" } as any)} />
                   <PopupMenuOptions>

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -9,6 +9,7 @@ import { DataGrid } from "./DataGrid.component"
 import { DataGridRow } from "../DataGridRow"
 import { DataGridCell } from "../DataGridCell"
 import { DataGridHeadCell } from "../DataGridHeadCell"
+import { DataGridCheckboxCell } from "../DataGridCheckboxCell"
 import { DataGridToolbar } from "../DataGridToolbar"
 import { Stack } from "../Stack"
 import { Button } from "../Button"
@@ -16,7 +17,7 @@ import { Checkbox } from "../Checkbox"
 import { Select } from "../Select"
 import { SelectOption } from "../SelectOption"
 import { SortButton } from "../SortButton"
-import { PopupMenu, PopupMenuOptions, PopupMenuItem } from "../PopupMenu"
+import { PopupMenu, PopupMenuOptions, PopupMenuItem, PopupMenuToggle } from "../PopupMenu"
 import { InputGroup } from "../InputGroup"
 import { ComboBox } from "../ComboBox"
 import { ComboBoxOption } from "../ComboBoxOption"
@@ -204,8 +205,11 @@ export const FullyFeatured: Story = {
               {/* Zone 3: Bulk actions + item count + refresh */}
               <Stack distribution="between" alignment="center" className="jn:text-sm">
                 <Stack gap="2" alignment="center">
-                  <Checkbox label="Select all" />
-                  <PopupMenu>
+                  <Checkbox />
+                  <PopupMenu className="jn:flex jn:items-center">
+                    <PopupMenuToggle
+                      {...({ as: Button, size: "xs", icon: "moreVert", label: "Show Actions" } as any)}
+                    />
                     <PopupMenuOptions>
                       <PopupMenuItem label="Download" />
                       <PopupMenuItem label="Delete" />
@@ -222,19 +226,31 @@ export const FullyFeatured: Story = {
           </DataGridToolbar>
         </Stack>
 
-        <DataGrid columns={4}>
+        <DataGrid columns={6} minContentColumns={[0, 5]}>
           <DataGridRow>
+            <DataGridHeadCell />
             <DataGridHeadCell>Name</DataGridHeadCell>
             <DataGridHeadCell>Region</DataGridHeadCell>
             <DataGridHeadCell>Status</DataGridHeadCell>
             <DataGridHeadCell>Availability Zone</DataGridHeadCell>
+            <DataGridHeadCell />
           </DataGridRow>
           {servers.map((s) => (
             <DataGridRow key={s.id}>
+              <DataGridCheckboxCell />
               <DataGridCell>{s.name}</DataGridCell>
               <DataGridCell>{s.region}</DataGridCell>
               <DataGridCell>{s.status}</DataGridCell>
               <DataGridCell>{s.az}</DataGridCell>
+              <DataGridCell>
+                <PopupMenu>
+                  <PopupMenuOptions>
+                    <PopupMenuItem label="Edit" />
+                    <PopupMenuItem label="Download" />
+                    <PopupMenuItem label="Delete" />
+                  </PopupMenuOptions>
+                </PopupMenu>
+              </DataGridCell>
             </DataGridRow>
           ))}
         </DataGrid>
@@ -298,8 +314,9 @@ export const FullyFeatured: Story = {
       {/* Zone 3: Bulk actions + item count + refresh */}
       <Stack distribution="between" alignment="center">
         <Stack gap="2" alignment="center">
-          <Checkbox label="Select all" />
-          <PopupMenu>
+          <Checkbox />
+          <PopupMenu className="jn:flex jn:items-center">
+            <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Show Actions" } as any)} />
             <PopupMenuOptions>
               <PopupMenuItem label="Download" />
               <PopupMenuItem label="Delete" />
@@ -316,19 +333,31 @@ export const FullyFeatured: Story = {
   </DataGridToolbar>
 </Stack>
 
-<DataGrid columns={4}>
+<DataGrid columns={6} minContentColumns={[0, 5]}>
   <DataGridRow>
+    <DataGridHeadCell />
     <DataGridHeadCell>Name</DataGridHeadCell>
     <DataGridHeadCell>Region</DataGridHeadCell>
     <DataGridHeadCell>Status</DataGridHeadCell>
     <DataGridHeadCell>Availability Zone</DataGridHeadCell>
+    <DataGridHeadCell />
   </DataGridRow>
   {servers.map((s) => (
     <DataGridRow key={s.id}>
+      <DataGridCheckboxCell />
       <DataGridCell>{s.name}</DataGridCell>
       <DataGridCell>{s.region}</DataGridCell>
       <DataGridCell>{s.status}</DataGridCell>
       <DataGridCell>{s.az}</DataGridCell>
+      <DataGridCell>
+        <PopupMenu>
+          <PopupMenuOptions>
+            <PopupMenuItem label="Edit" />
+            <PopupMenuItem label="Download" />
+            <PopupMenuItem label="Delete" />
+          </PopupMenuOptions>
+        </PopupMenu>
+      </DataGridCell>
     </DataGridRow>
   ))}
 </DataGrid>

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -46,7 +46,7 @@ The header is structured in up to three zones:
 - **Zone 2 — Filters and Search:** One or more filter inputs (typically a \`Select\` + \`ComboBox\` in an \`InputGroup\`), a \`SearchInput\`, and active filter pills with a "Clear filters" button.
 - **Zone 3 — DataGrid State:** Bulk actions (select-all checkbox + action menu) on the left, item count in the middle (total, or "X of Y" when filters are active), and last update timestamp with a refresh button on the right.
 
-Zones 2 and 3 share a background and are wrapped together in a single \`DataGridToolbar\`, which provides the background color, padding, and separation from the grid below.
+Zones 2 and 3 each use their own \`DataGridToolbar\`, which provides the background, padding, and separation from the grid.
 
 Every zone and every element within a zone is optional. Only include what the specific DataGrid needs. If none of the above is needed, reconsider whether a DataGrid is the right pattern at all.
         `,
@@ -219,7 +219,7 @@ export const FullyFeatured: Story = {
               <Stack gap="2" alignment="center">
                 <Checkbox />
                 <PopupMenu className="jn:flex jn:items-center">
-                  <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Show Actions" } as any)} />
+                  <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Actions" } as any)} />
                   <PopupMenuOptions>
                     <PopupMenuItem label="Download" />
                     <PopupMenuItem label="Delete" />
@@ -270,7 +270,7 @@ export const FullyFeatured: Story = {
     docs: {
       description: {
         story:
-          "Fully featured DataGrid header. Zone 1 (sort, overflow menu, primary action) is a bare `Stack` — no background, no `DataGridToolbar`. Zones 2+3 are wrapped in `DataGridToolbar`. Zone 3 carries bulk actions (checkbox + action menu) on the left, item count in the middle, and last update + refresh on the right. Every zone and every element within it is optional.",
+          "Fully featured DataGrid header. Zone 1 (sort, overflow menu, primary action) is a bare `Stack` — no background, no `DataGridToolbar`. Zones 2 and 3 each get their own `DataGridToolbar`. Zone 3 carries bulk actions (checkbox + action menu) on the left, item count in the middle, and last update + refresh on the right. Every zone and every element within it is optional.",
       },
       // Keep this source.code in sync with the render function above
       source: {

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -131,6 +131,25 @@ export const WithFiltersSearchAndState: Story = {
   },
 }
 
+export const WithSearchOnly: Story = {
+  render: () => (
+    <DataGridToolbar>
+      <Stack distribution="end" alignment="center">
+        <SearchInput placeholder="Search servers…" />
+      </Stack>
+    </DataGridToolbar>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Zone 2 with search only — no filter controls needed. Use this when the dataset doesn't require structured filtering.",
+      },
+      source: { type: "dynamic" },
+    },
+  },
+}
+
 export const FullyFeatured: Story = {
   render: () => {
     const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc")

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -1,0 +1,233 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from "react"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { DataGrid } from "./DataGrid.component"
+import { DataGridRow } from "../DataGridRow"
+import { DataGridCell } from "../DataGridCell"
+import { DataGridHeadCell } from "../DataGridHeadCell"
+import { DataGridToolbar } from "../DataGridToolbar"
+import { Stack } from "../Stack"
+import { Button } from "../Button"
+import { Checkbox } from "../Checkbox"
+import { Select } from "../Select"
+import { SelectOption } from "../SelectOption"
+import { SortButton } from "../SortButton"
+import { PopupMenu, PopupMenuOptions, PopupMenuItem } from "../PopupMenu"
+import { InputGroup } from "../InputGroup"
+import { ComboBox } from "../ComboBox"
+import { ComboBoxOption } from "../ComboBoxOption"
+import { SearchInput } from "../SearchInput"
+import { Pill } from "../Pill"
+import { PortalProvider } from "../PortalProvider"
+
+const meta: Meta = {
+  title: "Components/DataGrid/DataGrid Header",
+  decorators: [
+    (Story) => (
+      <PortalProvider>
+        <Story />
+      </PortalProvider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+The DataGrid header is a composition pattern, not a single component. It sits above the column headers and holds everything users need to interact with and configure the dataset.
+
+The header is structured in up to three zones:
+
+- **Zone 1 — Actions:** Bulk actions (select-all checkbox + action menu), sorting controls, an optional overflow menu for global actions, and the primary action (e.g. "Create"). This zone has no background — it is a plain \`Stack\` with no wrapper component.
+- **Zone 2 — Filters and Search:** One or more filter inputs (typically a \`Select\` + \`ComboBox\` in an \`InputGroup\`), a \`SearchInput\`, and active filter pills with a "Clear filters" button.
+- **Zone 3 — DataGrid State:** Item count (total, or "X of Y" when filters are active), last update timestamp, and a refresh button.
+
+Zones 2 and 3 share a background and are wrapped together in a single \`DataGridToolbar\`, which provides the background color, padding, and separation from the grid below.
+
+Every zone and every element within a zone is optional. Only include what the specific DataGrid needs. If none of the above is needed, reconsider whether a DataGrid is the right pattern at all.
+        `,
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const servers = [
+  { id: "1", name: "node-prod-01", region: "eu-west-1", status: "Running", az: "AZ-1" },
+  { id: "2", name: "node-prod-02", region: "eu-west-1", status: "Stopped", az: "AZ-2" },
+  { id: "3", name: "node-staging-01", region: "us-east-1", status: "Running", az: "AZ-1" },
+  { id: "4", name: "node-dev-01", region: "ap-south-1", status: "Error", az: "AZ-3" },
+]
+
+export const WithPrimaryAction: Story = {
+  render: () => (
+    <Stack distribution="end" className="jn:pb-2">
+      <Button label="Create Server" variant="primary" />
+    </Stack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The simplest DataGrid header: a single primary action. No `DataGridToolbar` needed — Zone 1 content sits directly in a `Stack`.",
+      },
+    },
+  },
+}
+
+export const WithFiltersSearchAndState: Story = {
+  render: () => (
+    <DataGridToolbar>
+      <Stack direction="vertical" gap="2">
+        {/* Zone 2: Filters + Search */}
+        <Stack distribution="between" alignment="center">
+          <InputGroup>
+            <Select>
+              <SelectOption value="region" label="Region" />
+              <SelectOption value="status" label="Status" />
+              <SelectOption value="az" label="Availability Zone" />
+            </Select>
+            <ComboBox>
+              <ComboBoxOption value="eu-west-1" label="eu-west-1" />
+              <ComboBoxOption value="us-east-1" label="us-east-1" />
+              <ComboBoxOption value="ap-south-1" label="ap-south-1" />
+            </ComboBox>
+          </InputGroup>
+          <SearchInput placeholder="Search servers…" />
+        </Stack>
+
+        {/* Zone 2 cont: Active filter pills */}
+        <Stack gap="2" wrap>
+          <Pill pillKey="Region" pillValue="eu-west-1" closeable />
+          <Pill pillKey="Status" pillValue="Running" closeable />
+          <Button label="Clear filters" variant="subdued" size="xs" />
+        </Stack>
+
+        {/* Zone 3: Item count + Refresh */}
+        <Stack distribution="between" alignment="center">
+          <span>Showing 2 of 4 servers</span>
+          <Stack gap="2" alignment="center">
+            <span>Last update: 20.05.2026 @09:41</span>
+            <Button label="Update" size="small" />
+          </Stack>
+        </Stack>
+      </Stack>
+    </DataGridToolbar>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Zones 2 and 3: filter controls, active filter pills, search, item count, and a refresh button. `DataGridToolbar` provides the background and spacing. Zone 1 is not needed here — no bulk actions or primary action required for this view.",
+      },
+    },
+  },
+}
+
+export const FullyFeatured: Story = {
+  render: () => {
+    const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc")
+
+    return (
+      <>
+        <Stack direction="vertical">
+          {/* Zone 1: Actions — no DataGridToolbar needed, no background */}
+          <Stack distribution="between" alignment="center" className="jn:pb-2">
+            <Stack gap="2" alignment="center">
+              <Checkbox label="Select all" />
+              <PopupMenu>
+                <PopupMenuOptions>
+                  <PopupMenuItem label="Download" />
+                  <PopupMenuItem label="Delete" />
+                </PopupMenuOptions>
+              </PopupMenu>
+            </Stack>
+            <Stack gap="2" alignment="center">
+              <Select>
+                <SelectOption value="name" label="Name" />
+                <SelectOption value="status" label="Status" />
+                <SelectOption value="region" label="Region" />
+              </Select>
+              <SortButton order={sortOrder} onChange={setSortOrder} />
+              <PopupMenu>
+                <PopupMenuOptions>
+                  <PopupMenuItem label="Export CSV" />
+                  <PopupMenuItem label="Refresh all" />
+                </PopupMenuOptions>
+              </PopupMenu>
+              <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
+            </Stack>
+          </Stack>
+
+          {/* Zones 2+3 — DataGridToolbar provides background and spacing */}
+          <DataGridToolbar className="jn:bg-theme-background-lvl-1">
+            <Stack direction="vertical" gap="2">
+              {/* Zone 2: Filters + Search */}
+              <Stack distribution="between" alignment="center">
+                <InputGroup>
+                  <Select>
+                    <SelectOption value="region" label="Region" />
+                    <SelectOption value="status" label="Status" />
+                    <SelectOption value="az" label="Availability Zone" />
+                  </Select>
+                  <ComboBox>
+                    <ComboBoxOption value="eu-west-1" label="eu-west-1" />
+                    <ComboBoxOption value="us-east-1" label="us-east-1" />
+                    <ComboBoxOption value="ap-south-1" label="ap-south-1" />
+                  </ComboBox>
+                </InputGroup>
+                <SearchInput placeholder="Search servers…" />
+              </Stack>
+
+              {/* Zone 2 cont: Active filter pills */}
+              <Stack gap="2" wrap>
+                <Pill pillKey="Region" pillValue="eu-west-1" closeable />
+                <Pill pillKey="Status" pillValue="Running" closeable />
+                <Button label="Clear filters" variant="subdued" size="xs" />
+              </Stack>
+
+              {/* Zone 3: Item count + Refresh */}
+              <Stack distribution="between" alignment="center">
+                <span>Showing 2 of 4 servers</span>
+                <Stack gap="2" alignment="center">
+                  <span>Last update: 20.05.2026 @09:41</span>
+                  <Button label="Update" size="small" />
+                </Stack>
+              </Stack>
+            </Stack>
+          </DataGridToolbar>
+        </Stack>
+
+        <DataGrid columns={4}>
+          <DataGridRow>
+            <DataGridHeadCell>Name</DataGridHeadCell>
+            <DataGridHeadCell>Region</DataGridHeadCell>
+            <DataGridHeadCell>Status</DataGridHeadCell>
+            <DataGridHeadCell>Availability Zone</DataGridHeadCell>
+          </DataGridRow>
+          {servers.map((s) => (
+            <DataGridRow key={s.id}>
+              <DataGridCell>{s.name}</DataGridCell>
+              <DataGridCell>{s.region}</DataGridCell>
+              <DataGridCell>{s.status}</DataGridCell>
+              <DataGridCell>{s.az}</DataGridCell>
+            </DataGridRow>
+          ))}
+        </DataGrid>
+      </>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Fully featured DataGrid header — the golden-path reference. Zone 1 (bulk actions, sort, primary action) is a bare `Stack` with no wrapper — no background, no `DataGridToolbar`. Zones 2+3 (filters, active filter pills, search, item count, refresh) are wrapped in `DataGridToolbar` which provides the background and spacing. Every zone and every element within it is optional.",
+      },
+    },
+  },
+}

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -107,7 +107,7 @@ export const WithFiltersSearchAndState: Story = {
         <Stack gap="2" wrap>
           <Pill pillKey="Region" pillValue="eu-west-1" closeable />
           <Pill pillKey="Status" pillValue="Running" closeable />
-          <Button label="Clear filters" variant="subdued" size="xs" />
+          <Button label="Clear filters" size="xs" />
         </Stack>
 
         {/* Zone 3: Item count + Refresh */}
@@ -199,7 +199,7 @@ export const FullyFeatured: Story = {
               <Stack gap="2" wrap>
                 <Pill pillKey="Region" pillValue="eu-west-1" closeable />
                 <Pill pillKey="Status" pillValue="Running" closeable />
-                <Button label="Clear filters" variant="subdued" size="xs" />
+                <Button label="Clear filters" size="xs" />
               </Stack>
 
               {/* Zone 3: Bulk actions + item count + refresh */}

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -185,7 +185,7 @@ export const FullyFeatured: Story = {
             </Stack>
           </Stack>
 
-          {/* Zones 2+3 — DataGridToolbar provides background and spacing */}
+          {/* Zone 2 — DataGridToolbar provides background and spacing */}
           <DataGridToolbar>
             <Stack direction="vertical" gap="2">
               {/* Zone 2: Filters + Search */}
@@ -332,7 +332,7 @@ export const FullyFeatured: Story = {
       <Stack gap="2" alignment="center">
         <Checkbox />
         <PopupMenu className="jn:flex jn:items-center">
-          <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Show Actions" } as any)} />
+          <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Actions" } as any)} />
           <PopupMenuOptions>
             <PopupMenuItem label="Download" />
             <PopupMenuItem label="Delete" />

--- a/packages/ui-components/src/components/DataGridCell/DataGridCell.component.tsx
+++ b/packages/ui-components/src/components/DataGridCell/DataGridCell.component.tsx
@@ -19,11 +19,12 @@ const cellBaseStyles = (nowrap: boolean, cellVerticalAlignment: CellVerticalAlig
 			`
         : ""
     }
-		jn:px-5
-		jn:py-3
+		jn:px-3
+		jn:py-2
 		jn:border-b
 		jn:border-theme-background-lvl-2
 		jn:h-full
+    jn:text-sm
 	`
 }
 

--- a/packages/ui-components/src/components/DataGridHeadCell/DataGridHeadCell.component.tsx
+++ b/packages/ui-components/src/components/DataGridHeadCell/DataGridHeadCell.component.tsx
@@ -9,8 +9,7 @@ import { DataGridCell } from "../DataGridCell/index"
 const headCellBaseStyles = `
 	jn:font-bold
 	jn:text-theme-high
-	jn:bg-theme-background-lvl-1
-	jn:border-theme-background-lvl-0
+	jn:border-theme-default
 `
 
 /**

--- a/packages/ui-components/src/components/DataGridHeadCell/DataGridHeadCell.component.tsx
+++ b/packages/ui-components/src/components/DataGridHeadCell/DataGridHeadCell.component.tsx
@@ -19,17 +19,7 @@ const headCellBaseStyles = `
  * @see {@link DataGridHeadCellProps}
  */
 export const DataGridHeadCell = forwardRef<HTMLDivElement, DataGridHeadCellProps>(
-  (
-    {
-      // sortable,
-      colSpan,
-      nowrap = false,
-      className = "",
-      children,
-      ...props
-    },
-    ref
-  ) => {
+  ({ colSpan, nowrap = false, className = "", children, ...props }, ref) => {
     return (
       <DataGridCell
         colSpan={colSpan}
@@ -41,13 +31,6 @@ export const DataGridHeadCell = forwardRef<HTMLDivElement, DataGridHeadCellProps
       >
         {children}
       </DataGridCell>
-      // <div
-      // 	className={`juno-datagrid-head-cell ${headCellBaseStyles} ${className}`}
-      // 	role="columnheader"
-      // 	{...props}>
-      // 	{children}
-      // 	{/* { sortable ? <Icon size={'1rem'} className={`${sortIconStyles}`}/> : ''} */}
-      // </div>
     )
   }
 )
@@ -55,8 +38,6 @@ export const DataGridHeadCell = forwardRef<HTMLDivElement, DataGridHeadCellProps
 DataGridHeadCell.displayName = "DataGridHeadCell"
 
 export interface DataGridHeadCellProps extends HTMLAttributes<HTMLElement> {
-  /** Whether the DataGrid should be sortable by this column */
-  // sortable: PropTypes.bool,
   /** Add a col span to the cell. This works like a colspan in a normal html table, so you have to take care not to place too many cells in a row if some of them have a colspan.  */
   colSpan?: number
   /** Set nowrap to true if the cell content shouldn't wrap (this is achieved by adding white-space: nowrap;) */

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
@@ -6,14 +6,14 @@
 import React, { HTMLAttributes, ReactNode } from "react"
 
 const baseToolbarStyles = `
+	jn:bg-theme-background-lvl-1
 	jn:py-3
 	jn:px-6
 	jn:mb-px
 `
 
 /**
- * `DataGridToolbar` is a spacing wrapper for a `DataGrid` header row. It provides consistent padding and separation
- * from the grid below. Use `Stack` inside to compose and position toolbar content.
+ * `DataGridToolbar` is a styled wrapper for the filter, search, and state zone (Zones 2+3) of a DataGrid header. It provides a background, consistent padding, and separation from the grid below. Use `Stack` inside to compose and position content. Zone 1 content (primary actions, bulk actions, sorting) does not use this component — use a plain `Stack` there instead.
  * @see https://cloudoperators.github.io/juno/?path=/docs/components-datagrid-datagridtoolbar--docs
  * @see {@link DataGridToolbarProps}
  */

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
@@ -6,7 +6,7 @@
 import React, { HTMLAttributes, ReactNode } from "react"
 
 const baseToolbarStyles = `
-	jn:bg-theme-background-lvl-1
+	jn:bg-theme-datagridtoolbar
   jn:border-b
   jn:border-theme-default
 	jn:py-2

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
@@ -12,22 +12,15 @@ const baseToolbarStyles = `
 `
 
 /**
- * `DataGridToolbar` provides an action bar for a `DataGrid`, designed to hold controls like buttons and search inputs
- * for performing group operations and interfacing with the grid content.
+ * `DataGridToolbar` is a spacing wrapper for a `DataGrid` header row. It provides consistent padding and separation
+ * from the grid below. Use `Stack` inside to compose and position toolbar content.
  * @see https://cloudoperators.github.io/juno/?path=/docs/components-datagrid-datagridtoolbar--docs
  * @see {@link DataGridToolbarProps}
  */
-export const DataGridToolbar = ({
-  className = "",
-  children,
-  alignRight = true,
-  ...props
-}: DataGridToolbarProps): ReactNode => {
-  const childrenWrapperStyles = alignRight ? "jn:ml-auto" : ""
-  const alignmentToolbarStyles = alignRight ? "jn:flex jn:items-center" : ""
+export const DataGridToolbar = ({ className = "", children, ...props }: DataGridToolbarProps): ReactNode => {
   return (
-    <div className={`juno-datagrid-toolbar ${baseToolbarStyles} ${alignmentToolbarStyles} ${className}`} {...props}>
-      <div className={childrenWrapperStyles}>{children}</div>
+    <div className={`juno-datagrid-toolbar ${baseToolbarStyles} ${className}`} {...props}>
+      {children}
     </div>
   )
 }
@@ -43,12 +36,4 @@ export interface DataGridToolbarProps extends HTMLAttributes<HTMLDivElement> {
    * @default ""
    */
   className?: string
-
-  /**
-   * Determines whether the children are automatically aligned to the right side within the toolbar.
-   * When true, applies `ml-auto` to the children wrapper, pushing content right.
-   * When false, no automatic alignment is applied, allowing for custom layouts.
-   * @default true
-   */
-  alignRight?: boolean
 }

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
@@ -6,7 +6,6 @@
 import React, { HTMLAttributes, ReactNode } from "react"
 
 const baseToolbarStyles = `
-	jn:bg-theme-background-lvl-1
 	jn:py-3
 	jn:px-6
 	jn:mb-px

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
@@ -7,9 +7,8 @@ import React, { HTMLAttributes, ReactNode } from "react"
 
 const baseToolbarStyles = `
 	jn:bg-theme-background-lvl-1
-	jn:py-3
-	jn:px-6
-	jn:mb-px
+	jn:py-2
+	jn:px-3
 `
 
 /**

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
@@ -7,12 +7,16 @@ import React, { HTMLAttributes, ReactNode } from "react"
 
 const baseToolbarStyles = `
 	jn:bg-theme-background-lvl-1
+  jn:border-b
+  jn:border-theme-default
 	jn:py-2
 	jn:px-3
 `
 
 /**
- * `DataGridToolbar` is a styled wrapper for the filter, search, and state zone (Zones 2+3) of a DataGrid header. It provides a background, consistent padding, and separation from the grid below. Use `Stack` inside to compose and position content. Zone 1 content (primary actions, bulk actions, sorting) does not use this component — use a plain `Stack` there instead.
+ * `DataGridToolbar` is a styled wrapper for the filter, search, and state zone (Zones 2+3) of a DataGrid header.
+ * It provides a background, consistent padding, and separation from the grid below. Use `Stack` inside to compose and position content.
+ * Zone 1 content (primary actions, bulk actions, sorting) does not use this component — use a plain `Stack` there instead.
  * @see https://cloudoperators.github.io/juno/?path=/docs/components-datagrid-datagridtoolbar--docs
  * @see {@link DataGridToolbarProps}
  */

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.component.tsx
@@ -16,7 +16,7 @@ const baseToolbarStyles = `
 /**
  * `DataGridToolbar` is a styled wrapper for the filter, search, and state zone (Zones 2+3) of a DataGrid header.
  * It provides a background, consistent padding, and separation from the grid below. Use `Stack` inside to compose and position content.
- * Zone 1 content (primary actions, bulk actions, sorting) does not use this component — use a plain `Stack` there instead.
+ * Zone 1 content (primary actions and sorting) does not use this component — use a plain `Stack` there instead.
  * @see https://cloudoperators.github.io/juno/?path=/docs/components-datagrid-datagridtoolbar--docs
  * @see {@link DataGridToolbarProps}
  */

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
@@ -32,6 +32,9 @@ const meta: Meta<typeof DataGridToolbar> = {
       control: false,
       table: { type: { summary: "ReactNode" } },
     },
+    className: {
+      control: "text",
+    },
   },
 }
 
@@ -46,12 +49,17 @@ const servers = [
 ]
 
 export const MinimalToolbar: Story = {
+    decorators: [
+    (Story) => (
+      <PortalProvider>
+        <Story />
+      </PortalProvider>
+    ),
+  ],
   render: () => (
-    <DataGridToolbar>
-      <Stack distribution="end">
+      <Stack distribution="end" className="jn:pb-2">
         <Button label="Create Server" variant="primary" />
       </Stack>
-    </DataGridToolbar>
   ),
   parameters: {
     docs: {
@@ -72,6 +80,11 @@ export const WithFiltersSearchAndState: Story = {
     ),
   ],
   render: () => (
+    <Stack direction="vertical">
+    {/* Zone 1: Actions — no background */}
+    <Stack distribution="end" className="jn:pb-2">
+      <Button label="Create Server" variant="primary" />
+    </Stack>
     <DataGridToolbar className="jn:bg-theme-background-lvl-1">
       <Stack direction="vertical" gap="2">
         {/* Zone 2: Filters + Search */}
@@ -108,6 +121,7 @@ export const WithFiltersSearchAndState: Story = {
         </Stack>
       </Stack>
     </DataGridToolbar>
+    </Stack>
   ),
   parameters: {
     docs: {
@@ -134,8 +148,7 @@ export const FullToolbar: Story = {
       <>
         <Stack direction="vertical">
           {/* Zone 1: Actions — no background */}
-          <DataGridToolbar>
-            <Stack distribution="between" alignment="center">
+          <Stack distribution="between" alignment="center" className="jn:pb-2">
               <Stack gap="2" alignment="center">
                 <Checkbox label="Select all" />
                 <PopupMenu>
@@ -158,10 +171,9 @@ export const FullToolbar: Story = {
                     <PopupMenuItem label="Refresh all" />
                   </PopupMenuOptions>
                 </PopupMenu>
-                <Button label="Create Server" variant="primary" />
+                <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
               </Stack>
             </Stack>
-          </DataGridToolbar>
 
           {/* Zones 2+3: View config — background via className */}
           <DataGridToolbar className="jn:bg-theme-background-lvl-1">

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
@@ -29,9 +29,9 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   render: (args) => (
     <DataGridToolbar {...args}>
-      <Stack distribution="between" alignment="center">
-        <span>Showing 4 of 10 servers</span>
-        <Button label="Update" size="small" />
+      <Stack distribution="between" alignment="center" className="jn:text-sm">
+        <span className="jn:theme-color-text-light">Showing 4 of 10 servers</span>
+        <Button label="Update" size="xs" />
       </Stack>
     </DataGridToolbar>
   ),

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
@@ -3,26 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState } from "react"
+import React from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { DataGridToolbar } from "./index"
-import { DataGrid } from "../DataGrid"
-import { DataGridRow } from "../DataGridRow"
-import { DataGridCell } from "../DataGridCell"
-import { DataGridHeadCell } from "../DataGridHeadCell"
-import { Stack } from "../Stack"
 import { Button } from "../Button"
-import { Checkbox } from "../Checkbox"
-import { Select } from "../Select"
-import { SelectOption } from "../SelectOption"
-import { SortButton } from "../SortButton"
-import { PopupMenu, PopupMenuOptions, PopupMenuItem } from "../PopupMenu"
-import { InputGroup } from "../InputGroup"
-import { ComboBox } from "../ComboBox"
-import { ComboBoxOption } from "../ComboBoxOption"
-import { SearchInput } from "../SearchInput"
-import { Pill } from "../Pill"
-import { PortalProvider } from "../PortalProvider"
+import { Stack } from "../Stack"
 
 const meta: Meta<typeof DataGridToolbar> = {
   title: "Components/DataGrid/DataGridToolbar",
@@ -41,203 +26,20 @@ const meta: Meta<typeof DataGridToolbar> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const servers = [
-  { id: "1", name: "node-prod-01", region: "eu-west-1", status: "Running", az: "AZ-1" },
-  { id: "2", name: "node-prod-02", region: "eu-west-1", status: "Stopped", az: "AZ-2" },
-  { id: "3", name: "node-staging-01", region: "us-east-1", status: "Running", az: "AZ-1" },
-  { id: "4", name: "node-dev-01", region: "ap-south-1", status: "Error", az: "AZ-3" },
-]
-
-export const MinimalToolbar: Story = {
-    decorators: [
-    (Story) => (
-      <PortalProvider>
-        <Story />
-      </PortalProvider>
-    ),
-  ],
-  render: () => (
-      <Stack distribution="end" className="jn:pb-2">
-        <Button label="Create Server" variant="primary" />
-      </Stack>
-  ),
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "The simplest real-world toolbar: a single primary action. Use this when no filtering, sorting, or bulk actions are needed.",
-      },
-    },
-  },
-}
-
-export const WithFiltersSearchAndState: Story = {
-  decorators: [
-    (Story) => (
-      <PortalProvider>
-        <Story />
-      </PortalProvider>
-    ),
-  ],
-  render: () => (
-    <Stack direction="vertical">
-    {/* Zone 1: Actions — no background */}
-    <Stack distribution="end" className="jn:pb-2">
-      <Button label="Create Server" variant="primary" />
-    </Stack>
-    <DataGridToolbar className="jn:bg-theme-background-lvl-1">
-      <Stack direction="vertical" gap="2">
-        {/* Zone 2: Filters + Search */}
-        <Stack distribution="between" alignment="center">
-          <InputGroup>
-            <Select>
-              <SelectOption value="region" label="Region" />
-              <SelectOption value="status" label="Status" />
-              <SelectOption value="az" label="Availability Zone" />
-            </Select>
-            <ComboBox>
-              <ComboBoxOption value="eu-west-1" label="eu-west-1" />
-              <ComboBoxOption value="us-east-1" label="us-east-1" />
-              <ComboBoxOption value="ap-south-1" label="ap-south-1" />
-            </ComboBox>
-          </InputGroup>
-          <SearchInput placeholder="Search servers…" />
-        </Stack>
-
-        {/* Zone 2 cont: Active filter pills */}
-        <Stack gap="2" wrap>
-          <Pill pillKey="Region" pillValue="eu-west-1" closeable />
-          <Pill pillKey="Status" pillValue="Running" closeable />
-          <Button label="Clear filters" variant="subdued" size="xs" />
-        </Stack>
-
-        {/* Zone 3: Item count + Refresh */}
-        <Stack distribution="between" alignment="center">
-          <span>Showing 2 of 4 servers</span>
-          <Stack gap="2" alignment="center">
-            <span>Last update: 19.05.2026 @09:41</span>
-            <Button label="Update" size="small" />
-          </Stack>
-        </Stack>
+export const Default: Story = {
+  render: (args) => (
+    <DataGridToolbar {...args}>
+      <Stack distribution="between" alignment="center">
+        <span>Showing 4 of 10 servers</span>
+        <Button label="Update" size="small" />
       </Stack>
     </DataGridToolbar>
-    </Stack>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "Toolbar covering Zones 2 and 3: filter controls, active filter pills, search, item count, and a refresh button. The background is applied via `className`. Zone 1 is not needed here — no bulk actions or primary action are required for this view.",
-      },
-    },
-  },
-}
-
-export const FullToolbar: Story = {
-  decorators: [
-    (Story) => (
-      <PortalProvider>
-        <Story />
-      </PortalProvider>
-    ),
-  ],
-  render: () => {
-    const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc")
-
-    return (
-      <>
-        <Stack direction="vertical">
-          {/* Zone 1: Actions — no background */}
-          <Stack distribution="between" alignment="center" className="jn:pb-2">
-              <Stack gap="2" alignment="center">
-                <Checkbox label="Select all" />
-                <PopupMenu>
-                  <PopupMenuOptions>
-                    <PopupMenuItem label="Download" />
-                    <PopupMenuItem label="Delete" />
-                  </PopupMenuOptions>
-                </PopupMenu>
-              </Stack>
-              <Stack gap="2" alignment="center">
-                <Select>
-                  <SelectOption value="name" label="Name" />
-                  <SelectOption value="status" label="Status" />
-                  <SelectOption value="region" label="Region" />
-                </Select>
-                <SortButton order={sortOrder} onChange={setSortOrder} />
-                <PopupMenu>
-                  <PopupMenuOptions>
-                    <PopupMenuItem label="Export CSV" />
-                    <PopupMenuItem label="Refresh all" />
-                  </PopupMenuOptions>
-                </PopupMenu>
-                <Button label="Create Server" variant="primary" className="jn:whitespace-nowrap" />
-              </Stack>
-            </Stack>
-
-          {/* Zones 2+3: View config — background via className */}
-          <DataGridToolbar className="jn:bg-theme-background-lvl-1">
-            <Stack direction="vertical" gap="2">
-              {/* Zone 2: Filters + Search */}
-              <Stack distribution="between" alignment="center">
-                <InputGroup>
-                  <Select>
-                    <SelectOption value="region" label="Region" />
-                    <SelectOption value="status" label="Status" />
-                    <SelectOption value="az" label="Availability Zone" />
-                  </Select>
-                  <ComboBox>
-                    <ComboBoxOption value="eu-west-1" label="eu-west-1" />
-                    <ComboBoxOption value="us-east-1" label="us-east-1" />
-                    <ComboBoxOption value="ap-south-1" label="ap-south-1" />
-                  </ComboBox>
-                </InputGroup>
-                <SearchInput placeholder="Search servers…" />
-              </Stack>
-
-              {/* Zone 2 cont: Active filter pills */}
-              <Stack gap="2" wrap>
-                <Pill pillKey="Region" pillValue="eu-west-1" closeable />
-                <Pill pillKey="Status" pillValue="Running" closeable />
-                <Button label="Clear filters" variant="subdued" size="xs" />
-              </Stack>
-
-              {/* Zone 3: Item count + Refresh */}
-              <Stack distribution="between" alignment="center">
-                <span>Showing 2 of 4 servers</span>
-                <Stack gap="2" alignment="center">
-                  <span>Last update: 19.05.2026 @09:41</span>
-                  <Button label="Update" size="small" />
-                </Stack>
-              </Stack>
-            </Stack>
-          </DataGridToolbar>
-        </Stack>
-
-        <DataGrid columns={4}>
-          <DataGridRow>
-            <DataGridHeadCell>Name</DataGridHeadCell>
-            <DataGridHeadCell>Region</DataGridHeadCell>
-            <DataGridHeadCell>Status</DataGridHeadCell>
-            <DataGridHeadCell>Availability Zone</DataGridHeadCell>
-          </DataGridRow>
-          {servers.map((s) => (
-            <DataGridRow key={s.id}>
-              <DataGridCell>{s.name}</DataGridCell>
-              <DataGridCell>{s.region}</DataGridCell>
-              <DataGridCell>{s.status}</DataGridCell>
-              <DataGridCell>{s.az}</DataGridCell>
-            </DataGridRow>
-          ))}
-        </DataGrid>
-      </>
-    )
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Fully featured toolbar with all three zones and a DataGrid below — the golden-path reference. Zone 1 (no background): bulk action controls left, sort + overflow + primary action right. Zones 2+3 (with background): filters, active filter pills, search, item count, and refresh. Each zone and every element within it is optional — include only what the specific DataGrid needs.",
+          "A spacing wrapper for Zone 2+3 content — filter controls, DataGrid state, and refresh. Use `className` to apply the background and `Stack` inside to position content. Zone 1 (primary actions, bulk actions, sorting) does not use `DataGridToolbar` — it is a plain `Stack`. See DataGrid Header stories for full composition examples.",
       },
     },
   },

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
@@ -39,7 +39,7 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          "A spacing wrapper for Zone 2+3 content — filter controls, DataGrid state, and refresh. Use `className` to apply the background and `Stack` inside to position content. Zone 1 (primary actions, bulk actions, sorting) does not use `DataGridToolbar` — it is a plain `Stack`. See DataGrid Header stories for full composition examples.",
+          "A spacing wrapper for Zone 2+3 content — filter controls, DataGrid state, and refresh. Use `Stack` inside to position content. Zone 1 (sorting and primary actions) does not use `DataGridToolbar` — it is a plain `Stack`. See DataGrid Header stories for full composition examples.",
       },
     },
   },

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.stories.tsx
@@ -3,18 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react"
+import React, { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
-import { DataGridToolbar, DataGridToolbarProps } from "./index"
-import { Pill } from "../Pill"
+import { DataGridToolbar } from "./index"
+import { DataGrid } from "../DataGrid"
+import { DataGridRow } from "../DataGridRow"
+import { DataGridCell } from "../DataGridCell"
+import { DataGridHeadCell } from "../DataGridHeadCell"
 import { Stack } from "../Stack"
-import { SearchInput } from "../SearchInput"
+import { Button } from "../Button"
+import { Checkbox } from "../Checkbox"
+import { Select } from "../Select"
+import { SelectOption } from "../SelectOption"
+import { SortButton } from "../SortButton"
+import { PopupMenu, PopupMenuOptions, PopupMenuItem } from "../PopupMenu"
+import { InputGroup } from "../InputGroup"
 import { ComboBox } from "../ComboBox"
 import { ComboBoxOption } from "../ComboBoxOption"
-import { Button } from "../Button"
-import { NativeSelectOption } from "../NativeSelectOption"
-import { NativeSelect } from "../NativeSelect"
-import { InputGroup } from "../InputGroup"
+import { SearchInput } from "../SearchInput"
+import { Pill } from "../Pill"
 import { PortalProvider } from "../PortalProvider"
 
 const meta: Meta<typeof DataGridToolbar> = {
@@ -23,9 +30,7 @@ const meta: Meta<typeof DataGridToolbar> = {
   argTypes: {
     children: {
       control: false,
-      table: {
-        type: { summary: "ReactNode" },
-      },
+      table: { type: { summary: "ReactNode" } },
     },
   },
 }
@@ -33,23 +38,32 @@ const meta: Meta<typeof DataGridToolbar> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
-  render: (args: DataGridToolbarProps) => (
-    <DataGridToolbar {...args}>
-      <Button label="Create" />
+const servers = [
+  { id: "1", name: "node-prod-01", region: "eu-west-1", status: "Running", az: "AZ-1" },
+  { id: "2", name: "node-prod-02", region: "eu-west-1", status: "Stopped", az: "AZ-2" },
+  { id: "3", name: "node-staging-01", region: "us-east-1", status: "Running", az: "AZ-1" },
+  { id: "4", name: "node-dev-01", region: "ap-south-1", status: "Error", az: "AZ-3" },
+]
+
+export const MinimalToolbar: Story = {
+  render: () => (
+    <DataGridToolbar>
+      <Stack distribution="end">
+        <Button label="Create Server" variant="primary" />
+      </Stack>
     </DataGridToolbar>
   ),
   parameters: {
     docs: {
       description: {
         story:
-          "Demonstrates a simple toolbar layout with children right-aligned by default. Use ButtonRow for multiple buttons.",
+          "The simplest real-world toolbar: a single primary action. Use this when no filtering, sorting, or bulk actions are needed.",
       },
     },
   },
 }
 
-export const ComplexCustomLayout: Story = {
+export const WithFiltersSearchAndState: Story = {
   decorators: [
     (Story) => (
       <PortalProvider>
@@ -57,41 +71,161 @@ export const ComplexCustomLayout: Story = {
       </PortalProvider>
     ),
   ],
-  render: (args: DataGridToolbarProps) => (
-    <DataGridToolbar {...args}>
-      <Stack direction="horizontal" distribution="between">
-        <Stack direction="vertical" gap="4">
+  render: () => (
+    <DataGridToolbar className="jn:bg-theme-background-lvl-1">
+      <Stack direction="vertical" gap="2">
+        {/* Zone 2: Filters + Search */}
+        <Stack distribution="between" alignment="center">
           <InputGroup>
-            <NativeSelect name="Filter" value="category" wrapperClassName="jn:w-full">
-              <NativeSelectOption value="category" label="Category" />
-              <NativeSelectOption value="status" label="Status" />
-              <NativeSelectOption value="priority" label="Priority" />
-            </NativeSelect>
+            <Select>
+              <SelectOption value="region" label="Region" />
+              <SelectOption value="status" label="Status" />
+              <SelectOption value="az" label="Availability Zone" />
+            </Select>
             <ComboBox>
-              <ComboBoxOption value="Electronics" />
-              <ComboBoxOption value="Clothing" />
-              <ComboBoxOption value="Furniture" />
+              <ComboBoxOption value="eu-west-1" label="eu-west-1" />
+              <ComboBoxOption value="us-east-1" label="us-east-1" />
+              <ComboBoxOption value="ap-south-1" label="ap-south-1" />
             </ComboBox>
           </InputGroup>
-          <Stack gap="2" wrap>
-            <Pill pillKey="category" pillValue="electronics" closeable />
-            <Pill pillKey="status" pillValue="active" closeable />
-            <Pill pillKey="priority" pillValue="high" closeable />
-            <Button label="Clear Filters" variant="subdued" size="xs" />
+          <SearchInput placeholder="Search servers…" />
+        </Stack>
+
+        {/* Zone 2 cont: Active filter pills */}
+        <Stack gap="2" wrap>
+          <Pill pillKey="Region" pillValue="eu-west-1" closeable />
+          <Pill pillKey="Status" pillValue="Running" closeable />
+          <Button label="Clear filters" variant="subdued" size="xs" />
+        </Stack>
+
+        {/* Zone 3: Item count + Refresh */}
+        <Stack distribution="between" alignment="center">
+          <span>Showing 2 of 4 servers</span>
+          <Stack gap="2" alignment="center">
+            <span>Last update: 19.05.2026 @09:41</span>
+            <Button label="Update" size="small" />
           </Stack>
         </Stack>
-        <SearchInput placeholder="Search items..." />
       </Stack>
     </DataGridToolbar>
   ),
-  args: {
-    alignRight: false,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Toolbar covering Zones 2 and 3: filter controls, active filter pills, search, item count, and a refresh button. The background is applied via `className`. Zone 1 is not needed here — no bulk actions or primary action are required for this view.",
+      },
+    },
+  },
+}
+
+export const FullToolbar: Story = {
+  decorators: [
+    (Story) => (
+      <PortalProvider>
+        <Story />
+      </PortalProvider>
+    ),
+  ],
+  render: () => {
+    const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc")
+
+    return (
+      <>
+        <Stack direction="vertical">
+          {/* Zone 1: Actions — no background */}
+          <DataGridToolbar>
+            <Stack distribution="between" alignment="center">
+              <Stack gap="2" alignment="center">
+                <Checkbox label="Select all" />
+                <PopupMenu>
+                  <PopupMenuOptions>
+                    <PopupMenuItem label="Download" />
+                    <PopupMenuItem label="Delete" />
+                  </PopupMenuOptions>
+                </PopupMenu>
+              </Stack>
+              <Stack gap="2" alignment="center">
+                <Select>
+                  <SelectOption value="name" label="Name" />
+                  <SelectOption value="status" label="Status" />
+                  <SelectOption value="region" label="Region" />
+                </Select>
+                <SortButton order={sortOrder} onChange={setSortOrder} />
+                <PopupMenu>
+                  <PopupMenuOptions>
+                    <PopupMenuItem label="Export CSV" />
+                    <PopupMenuItem label="Refresh all" />
+                  </PopupMenuOptions>
+                </PopupMenu>
+                <Button label="Create Server" variant="primary" />
+              </Stack>
+            </Stack>
+          </DataGridToolbar>
+
+          {/* Zones 2+3: View config — background via className */}
+          <DataGridToolbar className="jn:bg-theme-background-lvl-1">
+            <Stack direction="vertical" gap="2">
+              {/* Zone 2: Filters + Search */}
+              <Stack distribution="between" alignment="center">
+                <InputGroup>
+                  <Select>
+                    <SelectOption value="region" label="Region" />
+                    <SelectOption value="status" label="Status" />
+                    <SelectOption value="az" label="Availability Zone" />
+                  </Select>
+                  <ComboBox>
+                    <ComboBoxOption value="eu-west-1" label="eu-west-1" />
+                    <ComboBoxOption value="us-east-1" label="us-east-1" />
+                    <ComboBoxOption value="ap-south-1" label="ap-south-1" />
+                  </ComboBox>
+                </InputGroup>
+                <SearchInput placeholder="Search servers…" />
+              </Stack>
+
+              {/* Zone 2 cont: Active filter pills */}
+              <Stack gap="2" wrap>
+                <Pill pillKey="Region" pillValue="eu-west-1" closeable />
+                <Pill pillKey="Status" pillValue="Running" closeable />
+                <Button label="Clear filters" variant="subdued" size="xs" />
+              </Stack>
+
+              {/* Zone 3: Item count + Refresh */}
+              <Stack distribution="between" alignment="center">
+                <span>Showing 2 of 4 servers</span>
+                <Stack gap="2" alignment="center">
+                  <span>Last update: 19.05.2026 @09:41</span>
+                  <Button label="Update" size="small" />
+                </Stack>
+              </Stack>
+            </Stack>
+          </DataGridToolbar>
+        </Stack>
+
+        <DataGrid columns={4}>
+          <DataGridRow>
+            <DataGridHeadCell>Name</DataGridHeadCell>
+            <DataGridHeadCell>Region</DataGridHeadCell>
+            <DataGridHeadCell>Status</DataGridHeadCell>
+            <DataGridHeadCell>Availability Zone</DataGridHeadCell>
+          </DataGridRow>
+          {servers.map((s) => (
+            <DataGridRow key={s.id}>
+              <DataGridCell>{s.name}</DataGridCell>
+              <DataGridCell>{s.region}</DataGridCell>
+              <DataGridCell>{s.status}</DataGridCell>
+              <DataGridCell>{s.az}</DataGridCell>
+            </DataGridRow>
+          ))}
+        </DataGrid>
+      </>
+    )
   },
   parameters: {
     docs: {
       description: {
         story:
-          "Demonstrates a complex toolbar layout with custom styling - children aligned left and search aligned right. The xs 'Clear Filters' button sits inline with the filter pills.",
+          "Fully featured toolbar with all three zones and a DataGrid below — the golden-path reference. Zone 1 (no background): bulk action controls left, sort + overflow + primary action right. Zones 2+3 (with background): filters, active filter pills, search, item count, and refresh. Each zone and every element within it is optional — include only what the specific DataGrid needs.",
       },
     },
   },

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.test.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.test.tsx
@@ -24,16 +24,4 @@ describe("DataGridToolbar", () => {
     expect(screen.getByTestId("23")).toBeInTheDocument()
     expect(screen.getByTestId("23")).toHaveAttribute("data-lolol")
   })
-
-  test("applies jn:ml-auto correctly when alignRight true", () => {
-    render(<DataGridToolbar data-testid="my-datagridtoolbar" />)
-    expect(screen.getByTestId("my-datagridtoolbar")).toBeInTheDocument()
-    expect(screen.getByTestId("my-datagridtoolbar").firstChild).toHaveClass("jn:ml-auto")
-  })
-
-  test("doesn't apply jn:ml-auto correctly when alignRight false", () => {
-    render(<DataGridToolbar data-testid="my-datagridtoolbar" alignRight={false} />)
-    expect(screen.getByTestId("my-datagridtoolbar")).toBeInTheDocument()
-    expect(screen.getByTestId("my-datagridtoolbar").firstChild).not.toHaveClass("jn:ml-auto")
-  })
 })

--- a/packages/ui-components/src/global.css
+++ b/packages/ui-components/src/global.css
@@ -359,6 +359,7 @@
 
   --background-color-theme-content-area-bg: var(--color-content-area-bg);
 
+  --background-color-theme-datagridtoolbar: var(--color-datagridtoolbar-bg);
   --background-color-theme-datagridrow-selected: var(--color-datagridrow-selected);
   --background-color-theme-datalistrow-selected: var(--color-datalistrow-selected);
 
@@ -594,6 +595,10 @@
   --color-button-primary-danger-active-text: var(--color-white);
   --color-button-primary-danger-active-bg: var(--color-juno-primary-danger-5);
 
+   /* LT DataGrid */
+  --color-datagridtoolbar-bg: var(--color-background-lvl-1);
+  --color-datagridrow-selected: var(--color-accent);
+
   /* LT Divider */
   --color-divider-border: var(--color-border-default);
 
@@ -677,8 +682,6 @@
   --color-syntax-highlight-base0E: var(--color-juno-blue-4);
   /* LT bool + collapsed icon */
   --color-syntax-highlight-base0F: var(--color-juno-blue-4); /*  integer value */
-  /* LT DataGrid */
-  --color-datagridrow-selected: var(--color-accent);
   /* LT DataList */
   --color-datalist-row-border: var(--color-background-lvl-1);
   --color-datalistrow-selected: var(--color-accent);
@@ -845,7 +848,9 @@
   /* |-- DT Primary Danger Button :active */
   --color-button-primary-danger-active-text: var(--color-white);
   --color-button-primary-danger-active-bg: var(--color-juno-primary-danger-5);
-
+  /* DT DataGrid */
+  --color-datagridtoolbar-bg: var(--color-background-lvl-1);
+  --color-datagridrow-selected: var(--color-accent);
   /* DT Divider */
   --color-divider-border: var(--color-border-default);
 
@@ -928,8 +933,7 @@
   --color-syntax-highlight-base0D: var(--color-sap-gold); /* DT expanded icon */
   --color-syntax-highlight-base0E: var(--color-juno-blue-4); /* DT bool + collapsed icon */
   --color-syntax-highlight-base0F: var(--color-juno-blue-4); /* integer value */
-  /* DT DataGrid */
-  --color-datagridrow-selected: var(--color-accent);
+
   /* DT DataList */
   --color-datalist-row-border: var(--color-background-lvl-1);
   --color-datalistrow-selected: var(--color-accent);

--- a/packages/ui-components/src/theme.css
+++ b/packages/ui-components/src/theme.css
@@ -347,6 +347,7 @@
 
   --background-color-theme-content-area-bg: var(--color-content-area-bg);
 
+  --background-color-theme-datagridtoolbar: var(--color-datagridtoolbar-bg);
   --background-color-theme-datagridrow-selected: var(--color-datagridrow-selected);
   --background-color-theme-datalistrow-selected: var(--color-datalistrow-selected);
 
@@ -919,7 +920,7 @@
   --color-syntax-highlight-base0D: var(--color-sap-gold); /* DT expanded icon */
   --color-syntax-highlight-base0E: var(--color-juno-blue-4); /* DT bool + collapsed icon */
   --color-syntax-highlight-base0F: var(--color-juno-blue-4); /* integer value */
-   /* DT DataGrid */
+  /* DT DataGrid */
   --color-datagridtoolbar-bg: var(--color-background-lvl-1);
   --color-datagridrow-selected: var(--color-accent);
   /* DT DataList */

--- a/packages/ui-components/src/theme.css
+++ b/packages/ui-components/src/theme.css
@@ -667,6 +667,7 @@
   /* LT bool + collapsed icon */
   --color-syntax-highlight-base0F: var(--color-juno-blue-4); /*  integer value */
   /* LT DataGrid */
+  --color-datagridtoolbar-bg: var(--color-background-lvl-1);
   --color-datagridrow-selected: var(--color-accent);
   /* LT DataList */
   --color-datalist-row-border: var(--color-background-lvl-1);
@@ -918,7 +919,8 @@
   --color-syntax-highlight-base0D: var(--color-sap-gold); /* DT expanded icon */
   --color-syntax-highlight-base0E: var(--color-juno-blue-4); /* DT bool + collapsed icon */
   --color-syntax-highlight-base0F: var(--color-juno-blue-4); /* integer value */
-  /* DT DataGrid */
+   /* DT DataGrid */
+  --color-datagridtoolbar-bg: var(--color-background-lvl-1);
   --color-datagridrow-selected: var(--color-accent);
   /* DT DataList */
   --color-datalist-row-border: var(--color-background-lvl-1);


### PR DESCRIPTION
Adds stories / recipes in order to showcase the updated `DataGrid` Header pattern / composition principles:

DataGrid headers are now to be composed from at max 3 zones:

- Sorting and Actions
- Filter and Search
- Bulk Actions, meta data, last update / refresh

All of these are optional, even though there will hardly ever be a DataGrid without any of these.

Also adds some minor fixes:
- tighter padding and bottom border for `DataGridToolbar`
- remove drop shadow from Button

### Todo

- [x] tokenize `DataGridToolbar` bg color
- [ ] ~~fix vertical alingment of elements that are next to teach other (Checkboxes etc.)~~ -> out of scope as it is a global problem, will create separate issue.

Closes #1688 
