### PR TITLE
chore(ci): scope secrets to GitHub Environments and add npm supply chain protection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: npm-publish
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}

--- a/.github/workflows/shared-slack-notification.yaml
+++ b/.github/workflows/shared-slack-notification.yaml
@@ -13,6 +13,10 @@ on:
         required: false
         type: boolean
         default: false
+      environment:
+        required: false
+        type: string
+        default: notifications
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
@@ -20,6 +24,7 @@ on:
 jobs:
   notify:
     runs-on: [ ubuntu-latest ]
+    environment: ${{ inputs.environment }}
     steps:
       - name: Set Slack Payload
         env:

--- a/.github/workflows/shared-slack-notification.yaml
+++ b/.github/workflows/shared-slack-notification.yaml
@@ -14,8 +14,9 @@ on:
         type: boolean
         default: false
       environment:
-        required: true
+        required: false
         type: string
+        default: notifications
         description: GitHub Environment name containing SLACK_WEBHOOK_URL secret
     secrets:
       SLACK_WEBHOOK_URL:

--- a/.github/workflows/shared-slack-notification.yaml
+++ b/.github/workflows/shared-slack-notification.yaml
@@ -13,10 +13,6 @@ on:
         required: false
         type: boolean
         default: false
-      environment:
-        required: false
-        type: string
-        default: notifications
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
@@ -24,7 +20,7 @@ on:
 jobs:
   notify:
     runs-on: [ ubuntu-latest ]
-    environment: ${{ inputs.environment }}
+    environment: notifications
     steps:
       - name: Set Slack Payload
         env:

--- a/.github/workflows/shared-slack-notification.yaml
+++ b/.github/workflows/shared-slack-notification.yaml
@@ -13,6 +13,10 @@ on:
         required: false
         type: boolean
         default: false
+      environment:
+        required: true
+        type: string
+        description: GitHub Environment name containing SLACK_WEBHOOK_URL secret
     secrets:
       SLACK_WEBHOOK_URL:
         required: true
@@ -20,7 +24,7 @@ on:
 jobs:
   notify:
     runs-on: [ ubuntu-latest ]
-    environment: notifications
+    environment: ${{ inputs.environment }}
     steps:
       - name: Set Slack Payload
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 save-exact=true
+# Requiring packages to be at least 7 days old
+minimum-release-age=604800


### PR DESCRIPTION
# Summary

This PR implements GitHub security hardening controls by scoping workflow SLACK_WEBHOOK_URL secret to GitHub Environments and adds npm supply chain attack protection via minimum-release-age configuration.

# Changes Made

- Update `shared-slack-notification.yaml` to support `notifications` environment (default) for `SLACK_WEBHOOK_URL` secret
- Add `minimum-release-age=604800` (7 days) to `.npmrc` to prevent installation of recently published packages

# Screenshots (if applicable)

N/A - Infrastructure/configuration changes only

# Testing Instructions

## GitHub Environments Setup (Required)

This will be tested on a subsequent PR when the Workflow references are also updated.

## Testing Workflows

Test npm supply chain protection:
   ```bash
   pnpm install
   # Should succeed (existing packages are > 7 days old)
```
Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. (N/A - infrastructure/config changes)
- [ ] New and existing unit tests pass locally with my changes. (N/A - no code changes)
- [ ] I have made corresponding changes to the documentation (if applicable). (N/A - configuration only)
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
