### PR TITLE
chore(ci): use pnpm/action-setup with caching in PR preview workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yaml
+++ b/.github/workflows/deploy-pr-preview.yaml
@@ -65,11 +65,30 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install pnpm
+        if: github.event.action != 'closed'
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        with:
+          version: 10.32.1
+
+      - name: Get pnpm store directory
+        if: github.event.action != 'closed'
+        id: pnpm-cache
+        run: |
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: github.event.action != 'closed'
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Install dependencies
         if: github.event.action != 'closed'
-        run: |
-          npm install -g pnpm
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Create a folder with all compiled apps and pkgs
         if: github.event.action != 'closed'

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -1,4 +1,4 @@
-# Juno UI Components Library
+# Juno UI Components Library test
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -1,4 +1,4 @@
-# Juno UI Components Library test
+# Juno UI Components Library
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 


### PR DESCRIPTION
# Summary

Replace the legacy `npm install -g pnpm` installation method in the PR preview deployment workflow with the official `pnpm/action-setup` GitHub Action, aligning with the security and caching best practices already used in `ci-checks.yaml`.

# Changes Made

- Replaced `npm install -g pnpm` with `pnpm/action-setup@v6.0.5` (SHA-pinned)
- Added pnpm store directory detection step
- Added pnpm store caching configuration using `actions/cache@v5`
- Pinned pnpm version to `10.32.1` (matching `package.json` packageManager field)
- Applied `if: github.event.action != 'closed'` condition to all new steps for consistency

# Related Issues

- N/A (Internal workflow improvement)

# Screenshots (if applicable)

N/A (Workflow changes only - no visual changes)

# Testing Instructions

This change will be automatically tested on the next PR that modifies:
- `packages/ui-components/**`
- `apps/example/**`

Added test changes to verify it and afterwards removed.

To verify manually:
1. Create a test PR that modifies files in `packages/ui-components/` or `apps/example/`
2. Push a commit to trigger the `PR Preview Deployment 🚀` workflow
3. Check workflow logs to confirm:
   - `Install pnpm` step uses `pnpm/action-setup` action
   - `Setup pnpm cache` step shows cache hit or miss
   - `Install dependencies` completes successfully
4. Verify the PR preview deploys correctly

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works. (N/A - workflow change, tested by CI)
- [ ] New and existing unit tests pass locally with my changes. (N/A - workflow change only)
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
