### PR TITLE
feat(ui): improve DataGridToolbar tests

### DIFF
--- a/docs/ux/datagrid.md
+++ b/docs/ux/datagrid.md
@@ -40,7 +40,7 @@ The DataGrid Toolbar holds all the tools necessary for users to modify and custo
 
 More specifically, these are any combination of the following elements. Each element has a designated space in the DataGrid header structure. If an element is not needed, its space remains empty/unused. If none of the elements of a given zone is needed, don't render the zone / empty area at all.
 
-![Juno DataGrid Header zones](images/Datagrid-header-zones.png)
+![Juno DataGrid Header zones](images/DataGrid-header-zones.png)
 
 ### Zone 1: Sorting, Action(s)
 
@@ -100,7 +100,7 @@ A DataGrid may have a Reload/Refresh-button in the Header in order to make sure 
 
 When rendering elements in the DataGrid, keep permissions of the user in mind:
 For users that are not allowed to perform any of the available bulk actions for the elements of a given DataGrid, do not render Bulk action elements at all.
-The same goes for the checkboxes on the individual items: If a user has no permission to perform any of the avilable bulk actions, do not render any checkboxes (and the surrounding cells) for the items.
+The same goes for the checkboxes on the individual items: If a user has no permission to perform any of the available bulk actions, do not render any checkboxes (and the surrounding cells) for the items.
 If a user is not allowed to create any new items, do not render a "Create […]" button.
 
 ## DataGrid Content and Writing

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -84,7 +84,7 @@ export const WithPrimaryAction: Story = {
 
 export const WithFiltersSearchAndState: Story = {
   render: () => (
-    <>
+    <Stack direction="vertical">
       <DataGridToolbar>
         <Stack direction="vertical" gap="2">
           {/* Zone 2: Filters + Search */}
@@ -122,7 +122,7 @@ export const WithFiltersSearchAndState: Story = {
           </Stack>
         </Stack>
       </DataGridToolbar>
-    </>
+    </Stack>
   ),
   parameters: {
     docs: {

--- a/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.test.tsx
+++ b/packages/ui-components/src/components/DataGridToolbar/DataGridToolbar.test.tsx
@@ -11,6 +11,18 @@ describe("DataGridToolbar", () => {
   test("renders a DataGridToolbar", () => {
     render(<DataGridToolbar data-testid="my-datagridtoolbar" />)
     expect(screen.getByTestId("my-datagridtoolbar")).toBeInTheDocument()
+    expect(screen.getByTestId("my-datagridtoolbar")).toHaveClass("juno-datagrid-toolbar")
+  })
+
+  test("renders children as passed", () => {
+    render(
+      <DataGridToolbar data-testid="my-datagridtoolbar">
+        <button id="my-test-button"></button>
+      </DataGridToolbar>
+    )
+    expect(screen.getByTestId("my-datagridtoolbar")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toBeInTheDocument()
+    expect(screen.getByRole("button")).toHaveAttribute("id", "my-test-button")
   })
 
   test("renders a custom className", () => {


### PR DESCRIPTION
- improve `DataGridToolbar` tests
- fix some more typos in `DataGrid` ux docs
- update a `DataGrid` Header story to use `<Stack>` as a wrapping element, not a Fragment (`<>`)  (more sensible and consistent)

Closes #1724 

