### PR TITLE
chore(deps): remove unused postcss and fix husky hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,19 @@
+#!/bin/sh
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
 # SPDX-License-Identifier: Apache-2.0
-# .husky/commit
+# .husky/commit-msg
+
+# Load nvm to get node/npx in PATH
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  . "$NVM_DIR/nvm.sh"
+  # Use the node version from .nvmrc if it exists
+  if [ -f ".nvmrc" ]; then
+    nvm use
+  fi
+fi
+
+# Fallback: add common installation paths
+export PATH="$PATH:/usr/local/bin:$HOME/.local/share/pnpm"
 
 npx --no-install commitlint --edit "$1"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
 # SPDX-License-Identifier: Apache-2.0
 # .husky/commit-msg
 
 # Load nvm to get node/npx in PATH
-export NVM_DIR="$HOME/.nvm"
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 if [ -s "$NVM_DIR/nvm.sh" ]; then
   . "$NVM_DIR/nvm.sh"
   # Use the node version from .nvmrc if it exists

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
 
 # SPDX-License-Identifier: Apache-2.0
@@ -6,7 +6,7 @@
 # .husky/pre-commit
 
 # Load nvm to get node/pnpm in PATH
-export NVM_DIR="$HOME/.nvm"
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 if [ -s "$NVM_DIR/nvm.sh" ]; then
   . "$NVM_DIR/nvm.sh"
   # Use the node version from .nvmrc if it exists

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,12 +1,24 @@
+#!/bin/sh
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
 
 # SPDX-License-Identifier: Apache-2.0
 
 # .husky/pre-commit
 
-# Now you can use pnpm or any Node.js commands
+# Load nvm to get node/pnpm in PATH
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  . "$NVM_DIR/nvm.sh"
+  # Use the node version from .nvmrc if it exists
+  if [ -f ".nvmrc" ]; then
+    nvm use
+  fi
+fi
 
-# pnpm lint
+# Fallback: add common installation paths
+export PATH="$PATH:/usr/local/bin:$HOME/.local/share/pnpm"
+
+# Now you can use pnpm or any Node.js commands
 
 pnpm lint
 pnpm format

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -23,7 +23,6 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "jsdom": "29.1.1",
-    "postcss": "8.5.14",
     "shadow-dom-testing-library": "1.13.1",
     "tailwindcss": "4.3.0",
     "vite": "8.0.14",

--- a/apps/heureka/package.json
+++ b/apps/heureka/package.json
@@ -67,7 +67,6 @@
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-tailwindcss": "3.18.3",
     "jsdom": "29.1.1",
-    "postcss": "8.5.14",
     "prettier": "3.8.3",
     "react-error-boundary": "6.1.1",
     "tailwindcss": "4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,9 +279,6 @@ importers:
       jsdom:
         specifier: 29.1.1
         version: 29.1.1
-      postcss:
-        specifier: 8.5.14
-        version: 8.5.14
       shadow-dom-testing-library:
         specifier: 1.13.1
         version: 1.13.1(@testing-library/dom@10.4.1)
@@ -514,7 +511,7 @@ importers:
         version: 4.1.6(vitest@4.1.6)
       autoprefixer:
         specifier: 10.5.0
-        version: 10.5.0(postcss@8.5.14)
+        version: 10.5.0(postcss@8.5.15)
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -539,9 +536,6 @@ importers:
       jsdom:
         specifier: 29.1.1
         version: 29.1.1
-      postcss:
-        specifier: 8.5.14
-        version: 8.5.14
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -10400,15 +10394,6 @@ snapshots:
   async-function@1.0.0: {}
 
   auto-bind@4.0.0: {}
-
-  autoprefixer@10.5.0(postcss@8.5.14):
-    dependencies:
-      browserslist: 4.28.2
-      caniuse-lite: 1.0.30001791
-      fraction.js: 5.3.4
-      picocolors: 1.1.1
-      postcss: 8.5.14
-      postcss-value-parser: 4.2.0
 
   autoprefixer@10.5.0(postcss@8.5.15):
     dependencies:


### PR DESCRIPTION
# Summary

This PR makes two improvements to the project configuration:
1. Removes explicit `postcss` dependency from `apps/example` and `apps/heureka` as it's already provided transitively by Tailwind CSS and is not directly used by these applications
2. Fixes Husky git hooks to properly load nvm environment, ensuring `pnpm` and `npx` are available when running pre-commit and commit-msg hooks

# Changes Made

- Removed `postcss@8.5.14` from `apps/example/package.json` devDependencies
- Removed `postcss@8.5.14` from `apps/heureka/package.json` devDependencies
- Added nvm environment loading to `.husky/pre-commit` hook
- Added nvm environment loading to `.husky/commit-msg` hook
- Added shebang (`#!/bin/sh`) to both hooks for proper execution
- Updated lock file to reflect changes

# Related Issues

- N/A

# Screenshots (if applicable)

N/A

# Testing Instructions

1. `pnpm i` - Verify installation completes without errors
2. `pnpm build` - Verify all apps build successfully
3. `pnpm dev` - Verify development servers start correctly for both example and heureka apps
4. Make a test change and commit - Verify Husky hooks (lint, format, commitlint) run successfully
5. Verify Tailwind CSS still processes styles correctly (postcss is still available via tailwindcss dependency)

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.