### PR TITLE
chore(ci): comment minimum-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 save-exact=true
 # Requiring packages to be at least 7 days old
-minimum-release-age=604800
+# minimum-release-age=604800


### PR DESCRIPTION
# Summary

Temporarily disables the `minimum-release-age` check in `.npmrc` to work around a critical pnpm bug that prevents security updates and dependency upgrades.

# Changes Made

- Commented out `minimum-release-age=604800` in `.npmrc`

# Related Issues

- pnpm bug: https://github.com/pnpm/pnpm/issues/11982
- Commented out already for fix alert #1731 (turbo CSRF vulnerability fix)
- Blocks Renovate PR #1728 (patch dependency updates)

# Why This Is Needed

## The Problem

pnpm has a bug ([#11982](https://github.com/pnpm/pnpm/issues/11982)) where `minimumReleaseAge` incorrectly validates against the **latest version on the registry** instead of the **pinned version in
package.json**.

**Example:**
- We want to install `turbo@2.9.14` (released 15 days ago, meets 7-day requirement)
- pnpm checks `turbo@2.9.16` (latest, released 1 day ago)
- Installation fails with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` even though our pinned version is old enough

This affects:
- **Security updates**: Can't upgrade turbo to fix CSRF vulnerability (Dependabot #212)
- **Renovate PRs**: PR #1728 has mismatched lockfile because dependencies couldn't be updated
- **Any dependency upgrade**: If a package has a newer release within 7 days, we can't install older versions

## The Bug Details

- **Reported**: May 27, 2026
- **Status**: Open, no fix available
- **Affected versions**: pnpm 10.33.0+ (including 10.34.1)
- **Root cause**: Age validation checks latest registry tag instead of requested version

## When Can We Re-enable?

Once pnpm issue #11982 is resolved and released, we can uncomment this line and restore the 7-day safety check.

# Screenshots (if applicable)

N/A

# Testing Instructions

1. `pnpm i` - should complete without minimum-release-age errors
2. Verify security updates can be installed (e.g., turbo upgrade)
3. Verify Renovate PRs can update lockfiles properly

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.