### PR TITLE
feat(greenhouse): add release name to plugin instance detail page

### DIFF
--- a/.changeset/giant-shrimps-happen.md
+++ b/.changeset/giant-shrimps-happen.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-app-greenhouse": minor
+---
+
+Show release name in plugin instance detail page

--- a/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/Details.test.tsx
+++ b/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/Details.test.tsx
@@ -23,6 +23,7 @@ describe("Details", () => {
         pluginDefinition: "test-plugin-def",
         pluginDefinitionRef: { name: "test-plugin-def" },
         deletionPolicy: "Delete",
+        releaseName: "Release",
       },
     }
 
@@ -34,5 +35,6 @@ describe("Details", () => {
     expect(screen.getByText("test-plugin-def")).toBeInTheDocument()
     expect(screen.getAllByText("test-team").length).toBeGreaterThan(0)
     expect(screen.getByText("test-cluster")).toBeInTheDocument()
+    expect(screen.getByText("Release")).toBeInTheDocument()
   })
 })

--- a/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/Details.tsx
+++ b/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/Details.tsx
@@ -41,21 +41,25 @@ export const Details: React.FC<DetailsProps> = ({ plugin }) => {
           </DataGridRow>
           <DataGridRow>
             <DataGridHeadCell nowrap>PluginPreset</DataGridHeadCell>
-            <DataGridCell>{plugin.metadata?.labels?.["greenhouse.sap/pluginpreset"]}</DataGridCell>
+            <DataGridCell>{plugin.metadata?.labels?.["greenhouse.sap/pluginpreset"] ?? "--"}</DataGridCell>
           </DataGridRow>
           <DataGridRow>
             <DataGridHeadCell nowrap>Plugin Definition</DataGridHeadCell>
-            <DataGridCell>{plugin.spec?.pluginDefinitionRef?.name}</DataGridCell>
+            <DataGridCell>{plugin.spec?.pluginDefinitionRef?.name ?? "--"}</DataGridCell>
+          </DataGridRow>
+          <DataGridRow>
+            <DataGridHeadCell nowrap>Release Name</DataGridHeadCell>
+            <DataGridCell>{plugin?.spec?.releaseName ?? "--"}</DataGridCell>
           </DataGridRow>
           <DataGridRow>
             <DataGridHeadCell nowrap>Owning Team</DataGridHeadCell>
-            <DataGridCell>{plugin.metadata?.labels?.[SUPPORT_GROUP_LABEL]}</DataGridCell>
+            <DataGridCell>{plugin.metadata?.labels?.[SUPPORT_GROUP_LABEL] ?? "--"}</DataGridCell>
           </DataGridRow>
         </DataGrid>
         <DataGrid columns={2} minContentColumns={[0]} className="flex-1">
           <DataGridRow>
             <DataGridHeadCell nowrap>Cluster</DataGridHeadCell>
-            <DataGridCell>{plugin.spec?.clusterName}</DataGridCell>
+            <DataGridCell>{plugin.spec?.clusterName ?? "--"}</DataGridCell>
           </DataGridRow>
           {plugin.metadata?.labels && Object.keys(plugin.metadata.labels).length > 0 && (
             <DataGridRow>

--- a/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/Details.tsx
+++ b/apps/greenhouse/src/components/admin/PluginInstanceDetail/Overview/Details.tsx
@@ -14,7 +14,7 @@ import {
   ContentHeading,
 } from "@cloudoperators/juno-ui-components"
 import { Plugin } from "../../types/k8sTypes"
-import { SUPPORT_GROUP_LABEL } from "../../constants"
+import { SUPPORT_GROUP_LABEL, NO_VALUE_DEFAULT } from "../../constants"
 import { ExternalLink } from "../../common/ExternalLink"
 
 interface DetailsProps {
@@ -41,25 +41,25 @@ export const Details: React.FC<DetailsProps> = ({ plugin }) => {
           </DataGridRow>
           <DataGridRow>
             <DataGridHeadCell nowrap>PluginPreset</DataGridHeadCell>
-            <DataGridCell>{plugin.metadata?.labels?.["greenhouse.sap/pluginpreset"] ?? "--"}</DataGridCell>
+            <DataGridCell>{plugin.metadata?.labels?.["greenhouse.sap/pluginpreset"] ?? NO_VALUE_DEFAULT}</DataGridCell>
           </DataGridRow>
           <DataGridRow>
             <DataGridHeadCell nowrap>Plugin Definition</DataGridHeadCell>
-            <DataGridCell>{plugin.spec?.pluginDefinitionRef?.name ?? "--"}</DataGridCell>
+            <DataGridCell>{plugin.spec?.pluginDefinitionRef?.name ?? NO_VALUE_DEFAULT}</DataGridCell>
           </DataGridRow>
           <DataGridRow>
             <DataGridHeadCell nowrap>Release Name</DataGridHeadCell>
-            <DataGridCell>{plugin?.spec?.releaseName ?? "--"}</DataGridCell>
+            <DataGridCell>{plugin.spec?.releaseName ?? NO_VALUE_DEFAULT}</DataGridCell>
           </DataGridRow>
           <DataGridRow>
             <DataGridHeadCell nowrap>Owning Team</DataGridHeadCell>
-            <DataGridCell>{plugin.metadata?.labels?.[SUPPORT_GROUP_LABEL] ?? "--"}</DataGridCell>
+            <DataGridCell>{plugin.metadata?.labels?.[SUPPORT_GROUP_LABEL] ?? NO_VALUE_DEFAULT}</DataGridCell>
           </DataGridRow>
         </DataGrid>
         <DataGrid columns={2} minContentColumns={[0]} className="flex-1">
           <DataGridRow>
             <DataGridHeadCell nowrap>Cluster</DataGridHeadCell>
-            <DataGridCell>{plugin.spec?.clusterName ?? "--"}</DataGridCell>
+            <DataGridCell>{plugin.spec?.clusterName ?? NO_VALUE_DEFAULT}</DataGridCell>
           </DataGridRow>
           {plugin.metadata?.labels && Object.keys(plugin.metadata.labels).length > 0 && (
             <DataGridRow>
@@ -75,7 +75,7 @@ export const Details: React.FC<DetailsProps> = ({ plugin }) => {
           )}
           <DataGridRow>
             <DataGridHeadCell>Exposed Services</DataGridHeadCell>
-            <DataGridCell>{exposedServicesLinks.length > 0 ? exposedServicesLinks : "--"}</DataGridCell>
+            <DataGridCell>{exposedServicesLinks.length > 0 ? exposedServicesLinks : NO_VALUE_DEFAULT}</DataGridCell>
           </DataGridRow>
         </DataGrid>
       </Stack>


### PR DESCRIPTION
# Summary

Added release name to plugin instance detail page, as in ACs.

<img width="834" height="676" alt="Screenshot 2026-06-01 at 08 23 07" src="https://github.com/user-attachments/assets/c678a5df-d40d-472b-982c-1574cd5ad6f7" />

# Related Issues

Fixes https://github.com/cloudoperators/juno/issues/1608

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
