### PR TITLE
fix(docs): fix static code example for fully-featured DataGrid story

### DIFF
--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -338,7 +338,9 @@ export const FullyFeatured: Story = {
       <Stack gap="2" alignment="center">
         <Checkbox />
         <PopupMenu className="flex items-center">
-          <PopupMenuToggle {...({ as: Button, size: "xs", icon: "moreVert", label: "Actions" } as any)} />
+          <PopupMenuToggle as={React.Fragment}>
+            <Button icon="moreVert" title="More actions" />
+          </PopupMenuToggle>
           <PopupMenuOptions>
             <PopupMenuItem label="Download" />
             <PopupMenuItem label="Delete" />

--- a/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
+++ b/packages/ui-components/src/components/DataGrid/DataGridHeader.stories.tsx
@@ -339,7 +339,7 @@ export const FullyFeatured: Story = {
         <Checkbox />
         <PopupMenu className="flex items-center">
           <PopupMenuToggle as={React.Fragment}>
-            <Button icon="moreVert" title="More actions" />
+            <Button size="xs" icon="moreVert" label="Actions" />
           </PopupMenuToggle>
           <PopupMenuOptions>
             <PopupMenuItem label="Download" />


### PR DESCRIPTION
Fix static code example for the fully-featured `DataGrid`Header story with regards to not using  `as any` casting for the `PopupMenuToggle`.

Closes #1715 