### PR TITLE
fix(ui): improve AppShell layout

### DIFF
--- a/.changeset/fix-appshell-sidenav-squashing.md
+++ b/.changeset/fix-appshell-sidenav-squashing.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+Fix SideNavigation being squashed by oversized content in ContentContainer. SideNavigation now keeps its 16rem width and ContentContainer's wide children overflow inside the container instead of expanding the page row.

--- a/.changeset/fix-appshell-sidenav-squashing.md
+++ b/.changeset/fix-appshell-sidenav-squashing.md
@@ -6,3 +6,4 @@ AppShell layout fixes:
 
 - Fix SideNavigation being squashed by oversized content in ContentContainer. SideNavigation now keeps its 16rem width and ContentContainer's wide children overflow inside the container instead of expanding the page row.
 - Remove the top margin from `MainContainerInner` in non-embedded mode. The `HeaderContainer` is sticky (in flow), so the extra margin was over-compensating; content now sits directly below the header. Apps relying on the previous spacing may see a small upward shift.
+- Increase `SideNavigation` vertical padding from `1rem` to `1.25rem` so it matches the horizontal padding.

--- a/.changeset/fix-appshell-sidenav-squashing.md
+++ b/.changeset/fix-appshell-sidenav-squashing.md
@@ -2,4 +2,7 @@
 "@cloudoperators/juno-ui-components": patch
 ---
 
-Fix SideNavigation being squashed by oversized content in ContentContainer. SideNavigation now keeps its 16rem width and ContentContainer's wide children overflow inside the container instead of expanding the page row.
+AppShell layout fixes:
+
+- Fix SideNavigation being squashed by oversized content in ContentContainer. SideNavigation now keeps its 16rem width and ContentContainer's wide children overflow inside the container instead of expanding the page row.
+- Remove the top margin from `MainContainerInner` in non-embedded mode. The `HeaderContainer` is sticky (in flow), so the extra margin was over-compensating; content now sits directly below the header. Apps relying on the previous spacing may see a small upward shift.

--- a/packages/ui-components/src/components/AppShell/AppShell.component.tsx
+++ b/packages/ui-components/src/components/AppShell/AppShell.component.tsx
@@ -41,7 +41,7 @@ export const AppShell = ({
         <>
           {topNavigation && <HeaderContainer fullWidth={fullWidthOrDefault}>{topNavigation}</HeaderContainer>}
           <MainContainer>
-            <MainContainerInner fullWidth={fullWidthOrDefault} className={`${topNavigation ? "jn:mt-15.5" : ""}`}>
+            <MainContainerInner fullWidth={fullWidthOrDefault}>
               {sideNavigation}
               <ContentContainer>{children}</ContentContainer>
             </MainContainerInner>
@@ -55,7 +55,7 @@ export const AppShell = ({
           </HeaderContainer>
           {/* Wrap everything except page header and footer and navigations in a main container. Add top margin to MainContainerInner as we are not in embedded mode here. */}
           <MainContainer>
-            <MainContainerInner fullWidth={fullWidthOrDefault} className="jn:mt-15.5">
+            <MainContainerInner fullWidth={fullWidthOrDefault}>
               {sideNavigation}
               <ContentContainer>{children}</ContentContainer>
             </MainContainerInner>

--- a/packages/ui-components/src/components/AppShell/AppShell.component.tsx
+++ b/packages/ui-components/src/components/AppShell/AppShell.component.tsx
@@ -53,7 +53,7 @@ export const AppShell = ({
             {pageHeader && typeof pageHeader === "string" ? <PageHeader applicationName={pageHeader} /> : pageHeader}
             {topNavigation}
           </HeaderContainer>
-          {/* Wrap everything except page header and footer and navigations in a main container. Add top margin to MainContainerInner as we are not in embedded mode here. */}
+          {/* Wrap everything except page header and footer and navigations in a main container. */}
           <MainContainer>
             <MainContainerInner fullWidth={fullWidthOrDefault}>
               {sideNavigation}

--- a/packages/ui-components/src/components/ContentContainer/ContentContainer.component.tsx
+++ b/packages/ui-components/src/components/ContentContainer/ContentContainer.component.tsx
@@ -8,6 +8,7 @@ import React, { HTMLAttributes, ReactNode } from "react"
 const baseContainerStyles = `
   jn:flex-col
   jn:grow
+  jn:min-w-0
   jn:bg-[right_top_1rem]
   jn:bg-no-repeat
   jn:bg-theme-content-area-bg

--- a/packages/ui-components/src/components/ContentContainer/ContentContainer.test.tsx
+++ b/packages/ui-components/src/components/ContentContainer/ContentContainer.test.tsx
@@ -28,6 +28,12 @@ describe("ContentContainer", () => {
     expect(screen.getByTestId("content-container")).toHaveClass("jn:grow")
   })
 
+  test("renders a content container with min-w-0 so flex children can shrink correctly", () => {
+    render(<ContentContainer data-testid="content-container" />)
+    expect(screen.getByTestId("content-container")).toBeInTheDocument()
+    expect(screen.getByTestId("content-container")).toHaveClass("jn:min-w-0")
+  })
+
   test("renders without any props", () => {
     render(<ContentContainer data-testid="content-container" />)
     expect(screen.getByTestId("content-container")).toBeInTheDocument()

--- a/packages/ui-components/src/components/SideNavigation/SideNavigation.component.tsx
+++ b/packages/ui-components/src/components/SideNavigation/SideNavigation.component.tsx
@@ -11,6 +11,7 @@ const sideNavStyles = `
   jn:px-[1.25rem]
   jn:py-[1rem]
   jn:w-[16rem]
+  jn:shrink-0
   jn:bg-theme-sidenav
   jn:border-r
   jn:border-theme-sidenav

--- a/packages/ui-components/src/components/SideNavigation/SideNavigation.component.tsx
+++ b/packages/ui-components/src/components/SideNavigation/SideNavigation.component.tsx
@@ -9,7 +9,7 @@ import { SideNavigationListProps } from "../SideNavigationList"
 
 const sideNavStyles = `
   jn:px-[1.25rem]
-  jn:py-[1rem]
+  jn:py-[1.25rem]
   jn:w-[16rem]
   jn:shrink-0
   jn:bg-theme-sidenav

--- a/packages/ui-components/src/components/SideNavigation/SideNavigation.test.tsx
+++ b/packages/ui-components/src/components/SideNavigation/SideNavigation.test.tsx
@@ -39,6 +39,12 @@ describe("SideNavigation", () => {
     expect(navigationElement).toHaveClass("custom-class")
   })
 
+  it("does not shrink in a flex row (has jn:shrink-0)", () => {
+    render(<SideNavigation ariaLabel="Test Navigation" />)
+    const navigationElement = screen.getByRole("navigation")
+    expect(navigationElement).toHaveClass("jn:shrink-0")
+  })
+
   it("detects item clicks with onClick handlers on navigation items", () => {
     const handleClick1 = vi.fn()
     const handleClick2 = vi.fn()


### PR DESCRIPTION
# Summary

Four small layout improvements to the shared `AppShell` and its child layout primitives in `@cloudoperators/juno-ui-components`.

# Changes Made

- `SideNavigation` — added `jn:shrink-0` so it keeps its 16rem width regardless of sibling content (previously oversized siblings could squash it).
- `ContentContainer` — added `jn:min-w-0` so wide children scroll inside the container instead of expanding the page row.
- `AppShell` — removed the redundant `jn:mt-15.5` top margin from `MainContainerInner` in the non-embedded code path. `HeaderContainer` is `position: sticky` (in flow), so the margin was over-compensating and wasting vertical space. Stale inline comment removed too.
- `SideNavigation` — bumped vertical padding from `1rem` to `1.25rem` so it matches the existing `1.25rem` horizontal padding.
- Added class-presence regression tests for `jn:shrink-0` on `SideNavigation` and `jn:min-w-0` on `ContentContainer`.
- Added a `patch` changeset for `@cloudoperators/juno-ui-components`.

# Related Issues

- Closes #1743

# Screenshots (if applicable)

N/A — no visual API change. Layout behavior validated locally in Storybook.

# Testing Instructions

1. `pnpm i`
2. `pnpm --filter @cloudoperators/juno-ui-components test` — full suite, including the two new regression tests.
3. `pnpm pre:push` — lint + typecheck.
4. Optional Storybook visual check: `cd packages/ui-components && pnpm storybook` and view the `AppShell` `WithSideNavigation` story; confirm `SideNavigation` stays 16rem with wide content and the content area sits flush under `HeaderContainer`.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.