### PR TITLE
feat(ui): add border and shadow to floating menu components

### DIFF
--- a/.changeset/menu-background-distinction.md
+++ b/.changeset/menu-background-distinction.md
@@ -8,6 +8,6 @@ Add `border-theme-default` and `shadow-theme-default` to floating menu and overl
 - `ComboBox`, `PopupMenu`: border and shadow added to menu panel
 - `TooltipContent`: replaced custom `drop-shadow` with consistent `shadow-theme-default`; border added
 - `Toast`: border and shadow added
-- `DateTimePicker`: border and shadow added to flatpickr calendar popup
+- `DateTimePicker`: border and shadow added to flatpickr calendar popup; switched from low-level tokens (`--color-border-default`, `--box-shadow-default`) to theme-level tokens (`--border-color-theme-default`, `--shadow-theme-default`) for consistency with the rest of the PR
 - `Select`, `ComboBox`: added `box-border` to floating container so the 1px border is included in the Floating UI computed width, preventing subtle misalignment with the toggle
 - `Select`: added `overflow-hidden` to outer floating container so option hover backgrounds are clipped by the rounded corners

--- a/.changeset/menu-background-distinction.md
+++ b/.changeset/menu-background-distinction.md
@@ -8,6 +8,6 @@ Add `border-theme-default` and `shadow-theme-default` to floating menu and overl
 - `ComboBox`, `PopupMenu`: border and shadow added to menu panel
 - `TooltipContent`: replaced custom `drop-shadow` with consistent `shadow-theme-default`; border added
 - `Toast`: border and shadow added
-- `DateTimePicker`: border and shadow added to flatpickr calendar popup using `--color-border-default` and `--box-shadow-default`; theme-level tokens were reverted as the flatpickr popup renders outside the Juno theme wrapper and cannot access them
+- `DateTimePicker`: border and shadow added to flatpickr calendar popup using `--border-color-theme-default` and `--shadow-theme-default`
 - `Select`, `ComboBox`: added `box-border` to floating container so the 1px border is included in the Floating UI computed width, preventing subtle misalignment with the toggle
 - `Select`: added `overflow-hidden` to outer floating container so option hover backgrounds are clipped by the rounded corners

--- a/.changeset/menu-background-distinction.md
+++ b/.changeset/menu-background-distinction.md
@@ -2,12 +2,5 @@
 "@cloudoperators/juno-ui-components": patch
 ---
 
-Add `border-theme-default` and `shadow-theme-default` to floating menu and overlay components to ensure they are always visually distinct from the page background.
+Add `border-theme-default` and `shadow-theme-default` to floating menu and overlay components to ensure they are always visually distinct from the page background. This affects the following components: Select, ComboBox, PopupMenu, Tooltip, Toast, DateTimePicker
 
-- `Select`: border and shadow applied on the outer floating container to prevent shadow clipping; duplicate surface styles removed from inner menu container
-- `ComboBox`, `PopupMenu`: border and shadow added to menu panel
-- `TooltipContent`: replaced custom `drop-shadow` with consistent `shadow-theme-default`; border added
-- `Toast`: border and shadow added
-- `DateTimePicker`: border and shadow added to flatpickr calendar popup; scoped under `.juno-datetimepicker-wrapper` for higher specificity to override flatpickr's own `border: 0` reset; uses `--color-border-default` and `--box-shadow-default` as these are the tokens available in the inherited CSS variable scope
-- `Select`, `ComboBox`: added `box-border` to floating container so the 1px border is included in the Floating UI computed width, preventing subtle misalignment with the toggle
-- `Select`: added `overflow-hidden` to outer floating container so option hover backgrounds are clipped by the rounded corners

--- a/.changeset/menu-background-distinction.md
+++ b/.changeset/menu-background-distinction.md
@@ -8,6 +8,6 @@ Add `border-theme-default` and `shadow-theme-default` to floating menu and overl
 - `ComboBox`, `PopupMenu`: border and shadow added to menu panel
 - `TooltipContent`: replaced custom `drop-shadow` with consistent `shadow-theme-default`; border added
 - `Toast`: border and shadow added
-- `DateTimePicker`: border and shadow added to flatpickr calendar popup; switched from low-level tokens (`--color-border-default`, `--box-shadow-default`) to theme-level tokens (`--border-color-theme-default`, `--shadow-theme-default`) for consistency with the rest of the PR
+- `DateTimePicker`: border and shadow added to flatpickr calendar popup using `--color-border-default` and `--box-shadow-default`; theme-level tokens were reverted as the flatpickr popup renders outside the Juno theme wrapper and cannot access them
 - `Select`, `ComboBox`: added `box-border` to floating container so the 1px border is included in the Floating UI computed width, preventing subtle misalignment with the toggle
 - `Select`: added `overflow-hidden` to outer floating container so option hover backgrounds are clipped by the rounded corners

--- a/.changeset/menu-background-distinction.md
+++ b/.changeset/menu-background-distinction.md
@@ -2,9 +2,10 @@
 "@cloudoperators/juno-ui-components": patch
 ---
 
-Add `border-theme-default` and `shadow-theme-default` to floating menu components (Select, ComboBox, PopupMenu, TooltipContent, Toast) to ensure menus and overlays are always visually distinct from the page background.
+Add `border-theme-default` and `shadow-theme-default` to floating menu and overlay components to ensure they are always visually distinct from the page background.
 
 - `Select`: border and shadow applied on the outer floating container to prevent shadow clipping; duplicate surface styles removed from inner menu container
 - `ComboBox`, `PopupMenu`: border and shadow added to menu panel
 - `TooltipContent`: replaced custom `drop-shadow` with consistent `shadow-theme-default`; border added
 - `Toast`: border and shadow added
+- `DateTimePicker`: border and shadow added to flatpickr calendar popup

--- a/.changeset/menu-background-distinction.md
+++ b/.changeset/menu-background-distinction.md
@@ -1,0 +1,10 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+Add `border-theme-default` and `shadow-theme-default` to floating menu components (Select, ComboBox, PopupMenu, TooltipContent, Toast) to ensure menus and overlays are always visually distinct from the page background.
+
+- `Select`: border and shadow applied on the outer floating container to prevent shadow clipping; duplicate surface styles removed from inner menu container
+- `ComboBox`, `PopupMenu`: border and shadow added to menu panel
+- `TooltipContent`: replaced custom `drop-shadow` with consistent `shadow-theme-default`; border added
+- `Toast`: border and shadow added

--- a/.changeset/menu-background-distinction.md
+++ b/.changeset/menu-background-distinction.md
@@ -8,6 +8,6 @@ Add `border-theme-default` and `shadow-theme-default` to floating menu and overl
 - `ComboBox`, `PopupMenu`: border and shadow added to menu panel
 - `TooltipContent`: replaced custom `drop-shadow` with consistent `shadow-theme-default`; border added
 - `Toast`: border and shadow added
-- `DateTimePicker`: border and shadow added to flatpickr calendar popup using `--border-color-theme-default` and `--shadow-theme-default`
+- `DateTimePicker`: border and shadow added to flatpickr calendar popup; scoped under `.juno-datetimepicker-wrapper` for higher specificity to override flatpickr's own `border: 0` reset; uses `--color-border-default` and `--box-shadow-default` as these are the tokens available in the inherited CSS variable scope
 - `Select`, `ComboBox`: added `box-border` to floating container so the 1px border is included in the Floating UI computed width, preventing subtle misalignment with the toggle
 - `Select`: added `overflow-hidden` to outer floating container so option hover backgrounds are clipped by the rounded corners

--- a/.changeset/menu-background-distinction.md
+++ b/.changeset/menu-background-distinction.md
@@ -9,3 +9,4 @@ Add `border-theme-default` and `shadow-theme-default` to floating menu and overl
 - `TooltipContent`: replaced custom `drop-shadow` with consistent `shadow-theme-default`; border added
 - `Toast`: border and shadow added
 - `DateTimePicker`: border and shadow added to flatpickr calendar popup
+- `Select`, `ComboBox`: added `box-border` to floating container so the 1px border is included in the Floating UI computed width, preventing subtle misalignment with the toggle

--- a/.changeset/menu-background-distinction.md
+++ b/.changeset/menu-background-distinction.md
@@ -10,3 +10,4 @@ Add `border-theme-default` and `shadow-theme-default` to floating menu and overl
 - `Toast`: border and shadow added
 - `DateTimePicker`: border and shadow added to flatpickr calendar popup
 - `Select`, `ComboBox`: added `box-border` to floating container so the 1px border is included in the Floating UI computed width, preventing subtle misalignment with the toggle
+- `Select`: added `overflow-hidden` to outer floating container so option hover backgrounds are clipped by the rounded corners

--- a/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
+++ b/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
@@ -136,6 +136,9 @@ const menuStyles = `
   jn:bg-theme-background-lvl-1
   jn:w-full
   jn:overflow-y-auto
+  jn:border
+  jn:border-theme-default
+  jn:shadow-theme-default
 `
 
 const iconContainerStyles = `

--- a/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
+++ b/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
@@ -139,6 +139,7 @@ const menuStyles = `
   jn:border
   jn:border-theme-default
   jn:shadow-theme-default
+  jn:box-border
 `
 
 const iconContainerStyles = `

--- a/packages/ui-components/src/components/DateTimePicker/datetimepicker.css
+++ b/packages/ui-components/src/components/DateTimePicker/datetimepicker.css
@@ -42,8 +42,8 @@
   -ms-touch-action: manipulation;
   touch-action: manipulation;
   background: var(--color-datetimepicker-calendar-bg);
-  border: 1px solid var(--color-border-default);
-  box-shadow: var(--box-shadow-default);
+  border: 1px solid var(--border-color-theme-default);
+  box-shadow: var(--shadow-theme-default);
   /* -webkit-box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c, 0 3px 13px rgba(0,0,0,0.08); */
   /* box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c, 0 3px 13px rgba(0,0,0,0.08); */
 }

--- a/packages/ui-components/src/components/DateTimePicker/datetimepicker.css
+++ b/packages/ui-components/src/components/DateTimePicker/datetimepicker.css
@@ -42,6 +42,8 @@
   -ms-touch-action: manipulation;
   touch-action: manipulation;
   background: var(--color-datetimepicker-calendar-bg);
+  border: 1px solid var(--color-border-default);
+  box-shadow: var(--box-shadow-default);
   /* -webkit-box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c, 0 3px 13px rgba(0,0,0,0.08); */
   /* box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c, 0 3px 13px rgba(0,0,0,0.08); */
 }

--- a/packages/ui-components/src/components/DateTimePicker/datetimepicker.css
+++ b/packages/ui-components/src/components/DateTimePicker/datetimepicker.css
@@ -42,8 +42,11 @@
   -ms-touch-action: manipulation;
   touch-action: manipulation;
   background: var(--color-datetimepicker-calendar-bg);
-  border: 1px solid var(--border-color-theme-default);
-  box-shadow: var(--shadow-theme-default);
+}
+
+.juno-datetimepicker-wrapper .flatpickr-calendar {
+  border: 1px solid var(--color-border-default);
+  box-shadow: var(--box-shadow-default);
   /* -webkit-box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c, 0 3px 13px rgba(0,0,0,0.08); */
   /* box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c, 0 3px 13px rgba(0,0,0,0.08); */
 }

--- a/packages/ui-components/src/components/DateTimePicker/datetimepicker.css
+++ b/packages/ui-components/src/components/DateTimePicker/datetimepicker.css
@@ -42,8 +42,8 @@
   -ms-touch-action: manipulation;
   touch-action: manipulation;
   background: var(--color-datetimepicker-calendar-bg);
-  border: 1px solid var(--border-color-theme-default);
-  box-shadow: var(--shadow-theme-default);
+  border: 1px solid var(--color-border-default);
+  box-shadow: var(--box-shadow-default);
   /* -webkit-box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c, 0 3px 13px rgba(0,0,0,0.08); */
   /* box-shadow: 1px 0 0 #20222c, -1px 0 0 #20222c, 0 1px 0 #20222c, 0 -1px 0 #20222c, 0 3px 13px rgba(0,0,0,0.08); */
 }

--- a/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
+++ b/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
@@ -42,6 +42,9 @@ const menuStyles = `
   jn:w-max
   jn:rounded
   jn:bg-theme-background-lvl-1
+  jn:border
+  jn:border-theme-default
+  jn:shadow-theme-default
 `
 
 const itemStyles = `

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -63,15 +63,19 @@ const centeredIconStyles = `
   jn:translate-y-[-50%]
   jn:translate-x-[-0.75rem]
 `
+const menuStylesContainer = `
+  jn:rounded
+  jn:bg-theme-background-lvl-1
+  jn:border
+  jn:border-theme-default
+  jn:shadow-theme-default
+`
 
 const menuStyles = `
   jn:rounded
   jn:bg-theme-background-lvl-1
   jn:w-full
   jn:overflow-y-auto
-  jn:border
-  jn:border-theme-default
-  jn:shadow-theme-default
 `
 
 const truncateStyles = `
@@ -414,6 +418,10 @@ export const Select = ({
                   {createPortal(
                     <div
                       ref={refs.setFloating}
+                      className={`
+                          juno-select-menu-container
+                          ${menuStylesContainer}
+                        `}
                       style={{
                         position: strategy,
                         top: y ?? 0,

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -69,6 +69,9 @@ const menuStyles = `
   jn:bg-theme-background-lvl-1
   jn:w-full
   jn:overflow-y-auto
+  jn:border
+  jn:border-theme-default
+  jn:shadow-theme-default
 `
 
 const truncateStyles = `

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -69,6 +69,7 @@ const menuStylesContainer = `
   jn:border
   jn:border-theme-default
   jn:shadow-theme-default
+  jn:box-border
 `
 
 const menuStyles = `

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -70,6 +70,7 @@ const menuStylesContainer = `
   jn:border-theme-default
   jn:shadow-theme-default
   jn:box-border
+  jn:overflow-hidden
 `
 
 const menuStyles = `

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -72,8 +72,6 @@ const menuStylesContainer = `
 `
 
 const menuStyles = `
-  jn:rounded
-  jn:bg-theme-background-lvl-1
   jn:w-full
   jn:overflow-y-auto
 `

--- a/packages/ui-components/src/components/Select/Select.test.tsx
+++ b/packages/ui-components/src/components/Select/Select.test.tsx
@@ -431,7 +431,7 @@ describe("Select", () => {
     expect(screen.getAllByRole("option")[0]).toHaveTextContent("Option 1")
     expect(screen.getAllByRole("option")[1]).toHaveTextContent("Option 2")
     expect(screen.getAllByRole("option")[2]).toHaveTextContent("Option 3")
-    const menuContainer = document.querySelector(".juno-select-menu-container")
+    const menuContainer = screen.getByRole("listbox").closest(".juno-select-menu-container")
     expect(menuContainer).toBeInTheDocument()
     expect(menuContainer).toHaveClass("jn:border", "jn:border-theme-default", "jn:shadow-theme-default")
   })

--- a/packages/ui-components/src/components/Select/Select.test.tsx
+++ b/packages/ui-components/src/components/Select/Select.test.tsx
@@ -431,6 +431,10 @@ describe("Select", () => {
     expect(screen.getAllByRole("option")[0]).toHaveTextContent("Option 1")
     expect(screen.getAllByRole("option")[1]).toHaveTextContent("Option 2")
     expect(screen.getAllByRole("option")[2]).toHaveTextContent("Option 3")
+    const menuContainer = document.querySelector(".juno-select-menu-container")
+    expect(menuContainer).toHaveClass("jn:border")
+    expect(menuContainer).toHaveClass("jn:border-theme-default")
+    expect(menuContainer).toHaveClass("jn:shadow-theme-default")
   })
 
   test("changes the selected value as clicked by a user", async () => {

--- a/packages/ui-components/src/components/Select/Select.test.tsx
+++ b/packages/ui-components/src/components/Select/Select.test.tsx
@@ -432,9 +432,8 @@ describe("Select", () => {
     expect(screen.getAllByRole("option")[1]).toHaveTextContent("Option 2")
     expect(screen.getAllByRole("option")[2]).toHaveTextContent("Option 3")
     const menuContainer = document.querySelector(".juno-select-menu-container")
-    expect(menuContainer).toHaveClass("jn:border")
-    expect(menuContainer).toHaveClass("jn:border-theme-default")
-    expect(menuContainer).toHaveClass("jn:shadow-theme-default")
+    expect(menuContainer).toBeInTheDocument()
+    expect(menuContainer).toHaveClass("jn:border", "jn:border-theme-default", "jn:shadow-theme-default")
   })
 
   test("changes the selected value as clicked by a user", async () => {

--- a/packages/ui-components/src/components/Toast/Toast.component.tsx
+++ b/packages/ui-components/src/components/Toast/Toast.component.tsx
@@ -13,6 +13,9 @@ const toastStyles = `
     jn:items-start
     jn:p-2
     jn:rounded
+    jn:border
+    jn:border-theme-default
+    jn:shadow-theme-default
 `
 const toastStylesText = `
     jn:mx-4

--- a/packages/ui-components/src/components/TooltipContent/TooltipContent.component.tsx
+++ b/packages/ui-components/src/components/TooltipContent/TooltipContent.component.tsx
@@ -12,12 +12,14 @@ import { ToolTipVariant } from "../Tooltip/ToolTip.types"
 
 const popoverStyles = `
     jn:bg-theme-background-lvl-1
-    jn:text-theme-high 
-    jn:inline-flex	
+    jn:text-theme-high
+    jn:inline-flex
   jn:items-center
     jn:p-2
     jn:rounded
-    jn:drop-shadow-[0_0_4px_rgba(0,0,0,0.15)]
+    jn:border
+    jn:border-theme-default
+    jn:shadow-theme-default
 `
 
 const popoverTextStyles = `


### PR DESCRIPTION
## Summary

Add `border-theme-default` and `shadow-theme-default` to floating menu and overlay components to ensure they are always visually distinct from the page background.

## Affected components

- **Select** — border and shadow applied on the outer floating container to prevent shadow clipping; duplicate surface styles (`jn:rounded`, `jn:bg-theme-background-lvl-1`) removed from inner menu container
- **ComboBox** — border and shadow added to dropdown menu panel
- **PopupMenu** — border and shadow added to floating menu panel
- **TooltipContent** — replaced custom `drop-shadow-[0_0_4px_rgba(0,0,0,0.15)]` with consistent `shadow-theme-default`; border added
- **Toast** — border and shadow added
- **DateTimePicker** — border and shadow added to flatpickr calendar popup

Closes #1738