### PR TITLE
chore(ci): fix workflow

### DIFF
--- a/.github/workflows/build-push-greenhouse-image.yaml
+++ b/.github/workflows/build-push-greenhouse-image.yaml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       failed: ${{ steps.set-failure-output.outputs.failed }}
     permissions:
-      contents: read
+      contents: write
       packages: write
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.


### PR DESCRIPTION
# Summary

Get failure on main :

```
! [remote rejected] HEAD -> changeset-release/main (refusing to allow a GitHub App to create or update workflow `.github/workflows/build-push-greenhouse-image.yaml` without `workflows` permission)
https://github.com/cloudoperators/juno/actions/runs/27536063888/job/81385682844
```

**Workflows** is not an actual permission but seems like **write** is missing.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
