### PR TITLE
fix(ci): add workflows permission to GitHub App token in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
           private-key: ${{ secrets.CLOUDOPERATOR_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
       - name: Checkout Repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 


### PR DESCRIPTION
## Summary

- Adds `permission-workflows: write` to the `create-github-app-token` step in the release workflow
- Fixes the release workflow failure caused by the Changesets action attempting to push changes to `.github/workflows/` files on the `changeset-release/main` branch without the required `workflows` permission

## Root Cause

When Changesets creates/updates the release PR, it commits any workflow file changes (e.g. `.github/workflows/build-push-greenhouse-image.yaml`) to the `changeset-release/main` branch. GitHub rejects this push unless the token has the `workflows` permission.

## Test Plan

- [ ] Merge this PR to main
- [ ] Verify the next release workflow run successfully pushes the `changeset-release/main` branch without the `refusing to allow a GitHub App to create or update workflow` error