### PR TITLE
fix(ui): fix and improve Checkbox and Radio layout, markup, and props routing

### DIFF
--- a/.changeset/little-shoes-tan.md
+++ b/.changeset/little-shoes-tan.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+fix(ui): fix and improve Checkbox and Radio layout, markup, and props routing

--- a/packages/ui-components/src/components/Checkbox/Checkbox.component.tsx
+++ b/packages/ui-components/src/components/Checkbox/Checkbox.component.tsx
@@ -12,7 +12,7 @@ import React, {
   ReactNode,
   ChangeEvent,
   MouseEvent,
-  HTMLAttributes,
+  InputHTMLAttributes,
   ChangeEventHandler,
   MouseEventHandler,
 } from "react"
@@ -28,8 +28,8 @@ const wrapperStyles = `
 
 const inputstyles = (disabled: boolean): string => {
   return `
-    jn:w-4
-    jn:h-4
+    jn:absolute
+    jn:inset-0
     jn:opacity-0
     jn:z-50
     ${disabled ? "jn:cursor-not-allowed" : "jn:cursor-pointer"}
@@ -132,13 +132,14 @@ export const Checkbox = ({
   successtext = "",
   valid = false,
   value = "",
+  wrapperClassName = "",
   ...props
 }: CheckboxProps): ReactNode => {
   const isNotEmptyString = (str: ReactNode) => {
     return !(typeof str === "string" && str.trim().length === 0)
   }
 
-  const uniqueId = () => "juno-checkbox-" + useId()
+  const generatedId = "juno-checkbox-" + useId()
 
   // Consume and deconstruct the context so we won't get errors but 'undefined' when trying to access a group context property in case there is none:
   const checkboxGroupContext = useContext(CheckboxGroupContext)
@@ -232,23 +233,22 @@ export const Checkbox = ({
     }
   }
 
-  const theId = id || uniqueId()
+  const theId = id || generatedId
 
   return (
     <div className="jn-checkbox-outer">
       <div className={`jn-checkbox-wrapper ${wrapperStyles}`}>
         <div
           className={`
-            juno-checkbox 
-            ${mockcheckboxstyles} 
-            ${hasFocus ? mockfocusstyles : ""} 
-            ${groupDisabled || disabled ? mockdisabledstyles : ""} 
-            ${isInvalid ? errorstyles : ""} 
-            ${isValid ? successstyles : ""} 
+            juno-checkbox
+            ${mockcheckboxstyles}
+            ${hasFocus ? mockfocusstyles : ""}
+            ${groupDisabled || disabled ? mockdisabledstyles : ""}
+            ${isInvalid ? errorstyles : ""}
+            ${isValid ? successstyles : ""}
             ${isInvalid || isValid ? "" : noBorderStyles}
-            ${className}
+            ${wrapperClassName}
           `}
-          {...props}
         >
           {determineChecked() ? (
             <svg
@@ -266,9 +266,10 @@ export const Checkbox = ({
           <input
             checked={determineChecked()}
             className={`
-              ${inputstyles(groupDisabled || disabled)} 
-              ${isInvalid ? "juno-checkbox-invalid" : ""} 
-              ${isValid ? "juno-checkbox-valid" : ""} 
+              ${inputstyles(groupDisabled || disabled)}
+              ${isInvalid ? "juno-checkbox-invalid" : ""}
+              ${isValid ? "juno-checkbox-valid" : ""}
+              ${className}
             `}
             disabled={groupDisabled || disabled}
             id={theId}
@@ -279,6 +280,7 @@ export const Checkbox = ({
             onFocus={handleFocus}
             type="checkbox"
             value={value}
+            {...props}
           />
           {isIndeterminate && !determineChecked() ? <div className={`${mockindeterminatestyles}`}></div> : ""}
         </div>
@@ -337,7 +339,7 @@ export const Checkbox = ({
   )
 }
 
-export interface CheckboxProps extends HTMLAttributes<HTMLDivElement> {
+export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "value"> {
   /**
    * Specifies if the Checkbox is checked.
    * @default false
@@ -345,7 +347,7 @@ export interface CheckboxProps extends HTMLAttributes<HTMLDivElement> {
   checked?: boolean
 
   /**
-   * Custom CSS class for styling the Checkbox.
+   * Custom CSS class forwarded to the native checkbox input.
    * @default ""
    */
   className?: string
@@ -424,4 +426,10 @@ export interface CheckboxProps extends HTMLAttributes<HTMLDivElement> {
    * The value attribute of the Checkbox.
    */
   value?: string
+
+  /**
+   * Custom CSS class for styling the outer wrapper element.
+   * @default ""
+   */
+  wrapperClassName?: string
 }

--- a/packages/ui-components/src/components/Checkbox/Checkbox.component.tsx
+++ b/packages/ui-components/src/components/Checkbox/Checkbox.component.tsx
@@ -28,6 +28,10 @@ const wrapperStyles = `
 `
 
 const inputstyles = (disabled: boolean): string => {
+  // absolute + inset-0: overlays the native input exactly over the mock checkbox (same 16x16 area).
+  // This removes it from normal flow so it cannot inflate the wrapper height, while still
+  // receiving all pointer and keyboard events. opacity-0 hides it visually; z-50 keeps it
+  // on top so clicks always hit the real input.
   return `
     jn:absolute
     jn:inset-0
@@ -35,10 +39,6 @@ const inputstyles = (disabled: boolean): string => {
     jn:z-50
     ${disabled ? "jn:cursor-not-allowed" : "jn:cursor-pointer"}
   `
-  // absolute + inset-0: overlays the native input exactly over the mock checkbox (same 16x16 area).
-  // This removes it from normal flow so it cannot inflate the wrapper height, while still
-  // receiving all pointer and keyboard events. opacity-0 hides it visually; z-50 keeps it
-  // on top so clicks always hit the real input.
 }
 
 // relative establishes the positioning context for the absolutely placed native input,
@@ -245,12 +245,12 @@ export const Checkbox = ({
 
   const theId = id || generatedId
 
-  // leading-[0] on the outer div collapses its line box to zero, preventing inherited
+  // leading-0 on the outer div collapses its line box to zero, preventing inherited
   // line-height from the parent context from adding implicit height around the inline-flex
   // wrapper inside. Without this, the checkbox can appear shifted upward in flex containers
   // (e.g. items-center rows in a DataGrid).
   return (
-    <div className="jn-checkbox-outer jn:leading-[0]">
+    <div className="jn-checkbox-outer jn:leading-0">
       <div className={`jn-checkbox-wrapper ${wrapperStyles}`}>
         <div
           className={`

--- a/packages/ui-components/src/components/Checkbox/Checkbox.component.tsx
+++ b/packages/ui-components/src/components/Checkbox/Checkbox.component.tsx
@@ -21,6 +21,7 @@ import { Label } from "../Label/index"
 import { Icon } from "../Icon/index"
 import { FormHint } from "../FormHint/index"
 
+// inline-flex to sit the mock checkbox and label side by side; items-center vertically centers them.
 const wrapperStyles = `
   jn:inline-flex
   jn:items-center
@@ -34,8 +35,14 @@ const inputstyles = (disabled: boolean): string => {
     jn:z-50
     ${disabled ? "jn:cursor-not-allowed" : "jn:cursor-pointer"}
   `
+  // absolute + inset-0: overlays the native input exactly over the mock checkbox (same 16x16 area).
+  // This removes it from normal flow so it cannot inflate the wrapper height, while still
+  // receiving all pointer and keyboard events. opacity-0 hides it visually; z-50 keeps it
+  // on top so clicks always hit the real input.
 }
 
+// relative establishes the positioning context for the absolutely placed native input,
+// checkmark SVG, and indeterminate bar. Explicit w-4 h-4 locks the mock to exactly 16x16.
 const mockcheckboxstyles = `
   jn:relative
   jn:w-4
@@ -53,6 +60,7 @@ const mockfocusstyles = `
   jn:ring-theme-focus
 `
 
+// absolute positions the SVG over the mock; top-0 left-0 anchors it to the mock's top-left corner.
 const mockcheckmarkstyles = `
   jn:absolute
   jn:top-0
@@ -61,6 +69,7 @@ const mockcheckmarkstyles = `
   jn:fill-current
 `
 
+// absolute positions the bar within the mock. top-1.5 / left-[.2rem] centres it visually.
 const mockindeterminatestyles = `
   jn:absolute
   jn:w-2
@@ -92,8 +101,9 @@ const successstyles = `
   jn:border-theme-success
 `
 
+// No leading override here: the label must retain its natural line-height so that the
+// required marker (a small absolutely-offset dot rendered inside Label) positions correctly.
 const labelStyles = `
-  jn:leading-0
   jn:ml-2
 `
 
@@ -235,8 +245,12 @@ export const Checkbox = ({
 
   const theId = id || generatedId
 
+  // leading-[0] on the outer div collapses its line box to zero, preventing inherited
+  // line-height from the parent context from adding implicit height around the inline-flex
+  // wrapper inside. Without this, the checkbox can appear shifted upward in flex containers
+  // (e.g. items-center rows in a DataGrid).
   return (
-    <div className="jn-checkbox-outer">
+    <div className="jn-checkbox-outer jn:leading-[0]">
       <div className={`jn-checkbox-wrapper ${wrapperStyles}`}>
         <div
           className={`

--- a/packages/ui-components/src/components/Checkbox/Checkbox.component.tsx
+++ b/packages/ui-components/src/components/Checkbox/Checkbox.component.tsx
@@ -28,13 +28,13 @@ const wrapperStyles = `
 `
 
 const inputstyles = (disabled: boolean): string => {
-  // absolute + inset-0: overlays the native input exactly over the mock checkbox (same 16x16 area).
-  // This removes it from normal flow so it cannot inflate the wrapper height, while still
-  // receiving all pointer and keyboard events. opacity-0 hides it visually; z-50 keeps it
-  // on top so clicks always hit the real input.
+  // absolute + -inset-px: overlays the native input exactly over the mock checkbox (full 16x16 area).
+  // inset-0 would only fill the padding box (14x14 when a 1px border is present); -inset-px
+  // extends by 1px on each side to reach the border edge, matching the full visual size.
+  // opacity-0 hides it visually; z-50 keeps it on top so clicks always hit the real input.
   return `
     jn:absolute
-    jn:inset-0
+    jn:-inset-px
     jn:opacity-0
     jn:z-50
     ${disabled ? "jn:cursor-not-allowed" : "jn:cursor-pointer"}

--- a/packages/ui-components/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/ui-components/src/components/Checkbox/Checkbox.test.tsx
@@ -156,15 +156,24 @@ describe("Checkbox", () => {
     expect(onClickSpy).not.toHaveBeenCalled()
   })
 
-  test("renders a custom className as passed", () => {
-    render(<Checkbox data-testid="23" className="my-custom-classname" />)
-    expect(screen.getByTestId("23")).toBeInTheDocument()
-    expect(screen.getByTestId("23")).toHaveClass("my-custom-classname")
+  test("renders a custom className on the native input as passed", () => {
+    render(<Checkbox className="my-custom-classname" />)
+    expect(screen.getByRole("checkbox")).toHaveClass("my-custom-classname")
   })
 
-  test("renders all props as passed", () => {
-    render(<Checkbox id="check-1" data-testid="23" data-lolol={true} />)
+  test("renders a wrapperClassName on the outer wrapper as passed", () => {
+    render(<Checkbox wrapperClassName="my-wrapper-classname" />)
+    expect(document.querySelector(".juno-checkbox")).toHaveClass("my-wrapper-classname")
+  })
+
+  test("forwards arbitrary props to the native input", () => {
+    render(<Checkbox data-testid="23" data-lolol={true} />)
     expect(screen.getByTestId("23")).toBeInTheDocument()
     expect(screen.getByTestId("23")).toHaveAttribute("data-lolol")
+  })
+
+  test("forwards aria-label to the native input", () => {
+    render(<Checkbox aria-label="my-aria-label" />)
+    expect(screen.getByRole("checkbox")).toHaveAttribute("aria-label", "my-aria-label")
   })
 })

--- a/packages/ui-components/src/components/Radio/Radio.component.tsx
+++ b/packages/ui-components/src/components/Radio/Radio.component.tsx
@@ -26,6 +26,10 @@ const wrapperStyles = `
 `
 
 const inputstyles = (disabled: boolean): string => {
+  // absolute + inset-0: overlays the native input exactly over the mock radio (same 16x16 area).
+  // This removes it from normal flow so it cannot inflate the wrapper height, while still
+  // receiving all pointer and keyboard events. opacity-0 hides it visually; z-50 keeps it
+  // on top so clicks always hit the real input.
   return `
     jn:absolute
     jn:inset-0
@@ -33,10 +37,6 @@ const inputstyles = (disabled: boolean): string => {
     jn:z-50
     ${disabled ? "jn:cursor-not-allowed" : "jn:cursor-pointer"}
   `
-  // absolute + inset-0: overlays the native input exactly over the mock radio (same 16x16 area).
-  // This removes it from normal flow so it cannot inflate the wrapper height, while still
-  // receiving all pointer and keyboard events. opacity-0 hides it visually; z-50 keeps it
-  // on top so clicks always hit the real input.
 }
 
 // relative establishes the positioning context for the absolutely placed native input and
@@ -49,7 +49,7 @@ const mockradiostyles = `
   jn:bg-theme-radio
 `
 
-// absolute positions the checked dot within the mock. top/left of 1px insets it from the border.
+// absolute positions the checked dot within the mock. top-px / left-px insets it from the border.
 const checkedstyles = `
   jn:absolute
   jn:block
@@ -57,8 +57,8 @@ const checkedstyles = `
   jn:rounded-full
   jn:w-3
   jn:h-3
-  jn:top-[1px]
-  jn:left-[1px]
+  jn:top-px
+  jn:left-px
 `
 
 const mockfocusradiostyles = `
@@ -230,12 +230,12 @@ export const Radio = ({
 
   const theId = id || generatedId
 
-  // leading-[0] on the outer div collapses its line box to zero, preventing inherited
+  // leading-0 on the outer div collapses its line box to zero, preventing inherited
   // line-height from the parent context from adding implicit height around the inline-flex
   // wrapper inside. Without this, the radio can appear shifted upward in flex containers
   // (e.g. items-center rows in a DataGrid).
   return (
-    <div className={`jn-radio-outer jn:leading-[0]`}>
+    <div className="jn-radio-outer jn:leading-0">
       <div className={`juno-radio-wrapper ${wrapperStyles}`}>
         <div
           className={`

--- a/packages/ui-components/src/components/Radio/Radio.component.tsx
+++ b/packages/ui-components/src/components/Radio/Radio.component.tsx
@@ -26,13 +26,13 @@ const wrapperStyles = `
 `
 
 const inputstyles = (disabled: boolean): string => {
-  // absolute + inset-0: overlays the native input exactly over the mock radio (same 16x16 area).
-  // This removes it from normal flow so it cannot inflate the wrapper height, while still
-  // receiving all pointer and keyboard events. opacity-0 hides it visually; z-50 keeps it
-  // on top so clicks always hit the real input.
+  // absolute + -inset-px: overlays the native input exactly over the mock radio (full 16x16 area).
+  // inset-0 would only fill the padding box (14x14 when a 1px border is present); -inset-px
+  // extends by 1px on each side to reach the border edge, matching the full visual size.
+  // opacity-0 hides it visually; z-50 keeps it on top so clicks always hit the real input.
   return `
     jn:absolute
-    jn:inset-0
+    jn:-inset-px
     jn:opacity-0
     jn:z-50
     ${disabled ? "jn:cursor-not-allowed" : "jn:cursor-pointer"}

--- a/packages/ui-components/src/components/Radio/Radio.component.tsx
+++ b/packages/ui-components/src/components/Radio/Radio.component.tsx
@@ -11,7 +11,7 @@ import React, {
   useContext,
   MouseEventHandler,
   ReactNode,
-  HTMLAttributes,
+  InputHTMLAttributes,
   MouseEvent,
 } from "react"
 import { RadioGroupContext, RadioGroupContextProps } from "../RadioGroup/RadioGroup.component"
@@ -26,8 +26,8 @@ const wrapperStyles = `
 
 const inputstyles = (disabled: boolean): string => {
   return `
-    jn:w-4
-    jn:h-4
+    jn:absolute
+    jn:inset-0
     jn:opacity-0
     jn:z-50
     ${disabled ? "jn:cursor-not-allowed" : "jn:cursor-pointer"}
@@ -114,6 +114,7 @@ export const Radio = ({
   successtext = "",
   valid = false,
   value = "",
+  wrapperClassName = "",
   ...props
 }: RadioProps): ReactNode => {
   // Utility
@@ -121,7 +122,7 @@ export const Radio = ({
     return !(typeof str === "string" && str.trim().length === 0)
   }
 
-  const uniqueId = () => "juno-radio-" + useId()
+  const generatedId = "juno-radio-" + useId()
 
   // Consume and deconstruct the context so we won't get errors but 'undefined' when trying to access a group context in case there is none:
   const radioGroupContext = useContext<RadioGroupContextProps>(RadioGroupContext)
@@ -218,30 +219,30 @@ export const Radio = ({
     setHasFocus(false)
   }
 
-  const theId = id || uniqueId()
+  const theId = id || generatedId
 
   return (
     <div className={`jn-radio-outer`}>
       <div className={`juno-radio-wrapper ${wrapperStyles}`}>
         <div
           className={`
-             juno-radio 
-             ${mockradiostyles} 
-             ${hasFocus ? mockfocusradiostyles : ""} 
-             ${disabled ? mockdisabledradiostyles : ""} 
-             ${isInvalid ? errorstyles : ""} 
-             ${isValid ? successstyles : ""} 
+             juno-radio
+             ${mockradiostyles}
+             ${hasFocus ? mockfocusradiostyles : ""}
+             ${disabled ? mockdisabledradiostyles : ""}
+             ${isInvalid ? errorstyles : ""}
+             ${isValid ? successstyles : ""}
              ${isInvalid || isValid ? "" : noBorderStyles}
-             ${className}
+             ${wrapperClassName}
            `}
-          {...props}
         >
           <input
             checked={determineChecked()}
             className={`
-              ${inputstyles(groupDisabled || disabled)} 
-              ${isInvalid ? "juno-radio-invalid" : ""} 
+              ${inputstyles(groupDisabled || disabled)}
+              ${isInvalid ? "juno-radio-invalid" : ""}
               ${isValid ? "juno-radio-valid" : ""}
+              ${className}
             `}
             disabled={groupDisabled || disabled}
             id={theId}
@@ -252,6 +253,7 @@ export const Radio = ({
             name={groupName || name}
             type="radio"
             value={value}
+            {...props}
           />
           {determineChecked() ? <span className={`${checkedstyles}`}></span> : ""}
         </div>
@@ -310,10 +312,10 @@ export const Radio = ({
   )
 }
 
-export interface RadioProps extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+export interface RadioProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "onChange"> {
   /** Whether the Radio is checked */
   checked?: boolean
-  /** Pass a custom className */
+  /** Custom CSS class forwarded to the native radio input */
   className?: string
   /** Whether the Radio is disabled */
   disabled?: boolean
@@ -342,4 +344,6 @@ export interface RadioProps extends Omit<HTMLAttributes<HTMLDivElement>, "onChan
   valid?: boolean
   /** The value of the Radio */
   value?: string
+  /** Custom CSS class for styling the outer wrapper element */
+  wrapperClassName?: string
 }

--- a/packages/ui-components/src/components/Radio/Radio.component.tsx
+++ b/packages/ui-components/src/components/Radio/Radio.component.tsx
@@ -19,6 +19,7 @@ import { Label } from "../Label/index"
 import { Icon } from "../Icon/Icon.component"
 import { FormHint } from "../FormHint/FormHint.component"
 
+// inline-flex to sit the mock radio and label side by side; items-center vertically centers them.
 const wrapperStyles = `
   jn:inline-flex
   jn:items-center
@@ -32,8 +33,14 @@ const inputstyles = (disabled: boolean): string => {
     jn:z-50
     ${disabled ? "jn:cursor-not-allowed" : "jn:cursor-pointer"}
   `
+  // absolute + inset-0: overlays the native input exactly over the mock radio (same 16x16 area).
+  // This removes it from normal flow so it cannot inflate the wrapper height, while still
+  // receiving all pointer and keyboard events. opacity-0 hides it visually; z-50 keeps it
+  // on top so clicks always hit the real input.
 }
 
+// relative establishes the positioning context for the absolutely placed native input and
+// checked indicator span. Explicit w-4 h-4 locks the mock to exactly 16x16.
 const mockradiostyles = `
   jn:relative
   jn:w-4
@@ -42,6 +49,7 @@ const mockradiostyles = `
   jn:bg-theme-radio
 `
 
+// absolute positions the checked dot within the mock. top/left of 1px insets it from the border.
 const checkedstyles = `
   jn:absolute
   jn:block
@@ -79,8 +87,9 @@ const successstyles = `
   jn:border-theme-success
 `
 
+// No leading override here: the label must retain its natural line-height so that the
+// required marker (a small absolutely-offset dot rendered inside Label) positions correctly.
 const labelStyles = `
-  jn:leading-0
   jn:ml-2
 `
 
@@ -221,8 +230,12 @@ export const Radio = ({
 
   const theId = id || generatedId
 
+  // leading-[0] on the outer div collapses its line box to zero, preventing inherited
+  // line-height from the parent context from adding implicit height around the inline-flex
+  // wrapper inside. Without this, the radio can appear shifted upward in flex containers
+  // (e.g. items-center rows in a DataGrid).
   return (
-    <div className={`jn-radio-outer`}>
+    <div className={`jn-radio-outer jn:leading-[0]`}>
       <div className={`juno-radio-wrapper ${wrapperStyles}`}>
         <div
           className={`

--- a/packages/ui-components/src/components/Radio/Radio.test.tsx
+++ b/packages/ui-components/src/components/Radio/Radio.test.tsx
@@ -164,15 +164,24 @@ describe("Radio", () => {
     expect(onClickSpy).not.toHaveBeenCalled()
   })
 
-  test("renders a custom className as passed", () => {
-    render(<Radio data-testid="23" className="my-custom-class" />)
-    expect(screen.getByTestId("23")).toBeInTheDocument()
-    expect(screen.getByTestId("23")).toHaveClass("my-custom-class")
+  test("renders a custom className on the native input as passed", () => {
+    render(<Radio className="my-custom-class" />)
+    expect(screen.getByRole("radio")).toHaveClass("my-custom-class")
   })
 
-  test("renders all props as passed", () => {
-    render(<Radio id="check-1" data-testid="23" data-lolol={true} />)
+  test("renders a wrapperClassName on the outer wrapper as passed", () => {
+    render(<Radio wrapperClassName="my-wrapper-classname" />)
+    expect(document.querySelector(".juno-radio")).toHaveClass("my-wrapper-classname")
+  })
+
+  test("forwards arbitrary props to the native input", () => {
+    render(<Radio data-testid="23" data-lolol={true} />)
     expect(screen.getByTestId("23")).toBeInTheDocument()
     expect(screen.getByTestId("23")).toHaveAttribute("data-lolol")
+  })
+
+  test("forwards aria-label to the native input", () => {
+    render(<Radio aria-label="my-aria-label" />)
+    expect(screen.getByRole("radio")).toHaveAttribute("aria-label", "my-aria-label")
   })
 })

--- a/packages/ui-components/src/components/RadioGroup/RadioGroup.component.tsx
+++ b/packages/ui-components/src/components/RadioGroup/RadioGroup.component.tsx
@@ -175,7 +175,7 @@ export const RadioGroup = ({
         )}
         <div
           className={`
-            juno-checkbox-group-options 
+            juno-radio-group-options
             ${groupstyles} 
             ${isValid ? validgroupstyles : ""} 
             ${isInvalid ? invalidgroupstyles : ""} 


### PR DESCRIPTION
## Summary

Addresses layout, markup, and API issues in the Checkbox and Radio components.

## Changes Made

### Layout & alignment
The native `<input>` element in both `Checkbox` and `Radio` components was in normal flow inside the mock wrapper `<div>`, causing the wrapper to exceed the intended 16x16 size due to browser-implied inline-block rendering and line-height. This resulted in the components appearing visually shifted upward in items-center flex contexts (e.g. DataGrid rows).

- Native `<input>` is now positioned `absolute inset-1`, making it an overlay on the mock with the same dimensions (even if we change them at some point in the future), but not influencing/disturbing element flow. (We use `inset-1` to compensate for the border of the parent, as absolute positioning refers to the padding box of an element) 
- `leading-0` added to the outer container `<div>` to eliminate inherited line-height from parent contexts, which was the remaining source of implicit height

### Props routing
Arbitrary `...props` were spread onto the decorative mock div (`div.juno-checkbox` / `div.juno-radio`) rather than the native `<input>` element before. Attributes like `aria-label`, `aria-describedby`, and `data-*` therefore landed on the wrong element – semantically incorrect and broken for accessibility tooling. Arbitrary props are now re-routed to the actual `<input>` element:

- `...props` and `className` are now forwarded to the native `<input>` element
- `CheckboxProps` updated from `HTMLAttributes<HTMLDivElement>` to `InputHTMLAttributes<HTMLInputElement>`
- `RadioProps` updated from `Omit<HTMLAttributes<HTMLDivElement>, "onChange"`> to `Omit<InputHTMLAttributes<HTMLInputElement>, "onChange">`, preserving the custom `onChange` signature
- New `wrapperClassName` prop introduced on both components for styling the outer container, consistent with the pattern used across the library (`TextInput`, `Switch`, `Select`, `Textarea`, `ComboBox`, etc.)

### Additional fixes
- `useId` was called inside a nested helper function before, in effect _violating **Rules of Hooks**_ , the `useId` call now lives in an unconditional top-level call in both `Checkbox` and `Radio` (this is a problem spread across our components)
- Copy-paste bug in `RadioGroup` corrected: inner options container was incorrectly classed `juno-checkbox-group-options` instead of `juno-radio-group-options`, this is fixed now
- Explanatory comments added to style constants in both components to document the non-obvious CSS layout decisions

### Tests
Existing tests updated to reflect the new `className` forwarding target; new tests added for `wrapperClassName`, `aria-label` forwarding, and arbitrary prop forwarding.

# Related Issues

Fixes #1714, closes #1753, closes #1754.

## Screenshots

### Checkbox Alignment Before:
<img width="235" height="402" alt="Bildschirmfoto 2026-06-17 um 12 11 39" src="https://github.com/user-attachments/assets/733012e3-93b5-4c91-9875-4313ea2feb58" />


### Checkbox Alignment After:
<img width="255" height="411" alt="Bildschirmfoto 2026-06-17 um 12 10 30" src="https://github.com/user-attachments/assets/09441f56-679c-4706-acc4-f7ed29b540dc" />


## Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test Checkbox CheckboxGroup Radio RadioGroup`

## Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
