### PR TITLE
fix(ui): fix focus styles for PopupMenu

### DIFF
--- a/.changeset/plenty-berries-return.md
+++ b/.changeset/plenty-berries-return.md
@@ -2,4 +2,4 @@
 "@cloudoperators/juno-ui-components": patch
 ---
 
-fix(ui): fix focus styles for PopupMenu: remove browser default focus outline on menu parent, handle on item level via Headless UI's `data-active` attribute
+fix(ui): fix focus styles for PopupMenu: remove browser default focus outline on the menu panel container (MenuItems), handle focus styles on the item level via Headless UI's `data-active` attribute

--- a/.changeset/plenty-berries-return.md
+++ b/.changeset/plenty-berries-return.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+fix(ui): fix focus styles for PopupMenu: remove browser default focus outline on menu parent, handle on item level via Headless UI's `data-active` attribute

--- a/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
+++ b/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
@@ -45,7 +45,9 @@ const menuStyles = `
   jn:border
   jn:border-theme-default
   jn:shadow-theme-default
+  jn:focus:outline-hidden
 `
+// prevent browser default focus styles on the oparent menu element, we handle these on the item level via data-[active]:
 
 const itemStyles = `
   jn:text-base
@@ -72,7 +74,11 @@ const smallItemStyles = `
 `
 
 const actionableItemStyles = `
-  jn:hover:bg-theme-background-lvl-3
+  jn:data-[active]:outline-hidden
+  jn:data-[active]:ring-2
+  jn:data-[active]:ring-inset
+  jn:data-[active]:ring-theme-focus
+  jn:data-[active]:bg-theme-background-lvl-3
   jn:cursor-pointer
 `
 

--- a/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
+++ b/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
@@ -47,7 +47,7 @@ const menuStyles = `
   jn:shadow-theme-default
   jn:focus:outline-hidden
 `
-// prevent browser default focus styles on the oparent menu element, we handle these on the item level via data-[active]:
+// Prevent browser default focus outline on the menu panel container (MenuItems). Focus styles are applied at the item level via `data-[active]`.
 
 const itemStyles = `
   jn:text-base

--- a/packages/ui-components/src/components/PopupMenu/PopupMenu.stories.tsx
+++ b/packages/ui-components/src/components/PopupMenu/PopupMenu.stories.tsx
@@ -21,7 +21,7 @@ import { PortalProvider } from "../PortalProvider/PortalProvider.component"
 import { Button, ButtonProps } from "../Button/"
 
 const meta: Meta<typeof PopupMenu> = {
-  title: "WiP/PopupMenu",
+  title: "Components/PopupMenu",
   component: PopupMenu,
   subcomponents: {
     PopupMenuToggle: PopupMenuToggle as React.ComponentType<unknown>,


### PR DESCRIPTION
## Summary
Fix focus issues as outlined in #1748 and #1775


## Changes Made

- Fixes missing keyboard focus indicator on `PopupMenuItem` elements — items now show a focus ring when navigated via keyboard or hovered with the mouse, using Headless UI's `data-[active]:` attribute instead of CSS `:hover` only
- Suppresses the browser default outline on the `MenuItems` panel container; focus styles are handled at the individual item level instead


## Related Issues

Closes #1775



## Screenshots (if applicable)
### Before
Focus on menu container when opening via keyboard:
<img width="271" height="324" alt="Bildschirmfoto 2026-06-17 um 17 35 18" src="https://github.com/user-attachments/assets/03725d2c-934e-4cf7-a1f7-7e51fe80b1db" />

### After
No more focus on the menu element, but on the item level:

<img width="261" height="337" alt="Bildschirmfoto 2026-06-17 um 17 40 25" src="https://github.com/user-attachments/assets/71de67ba-5f81-49c7-a015-83662eb1dc1f" />


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test PopupMenu`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
