### PR TITLE
fix(ui): fix focus styles for Select and ComboBox

### DIFF
--- a/.changeset/tired-spies-invite.md
+++ b/.changeset/tired-spies-invite.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+fix(ui): fix focus styles for Select and ComboBox

--- a/packages/ui-components/src/components/ComboBoxOption/ComboBoxOption.component.tsx
+++ b/packages/ui-components/src/components/ComboBoxOption/ComboBoxOption.component.tsx
@@ -14,11 +14,11 @@ const optionStyles = `
   jn:pb-[0.5rem]
   jn:pr-[0.875rem]
   jn:select-none
-  jn:hover:outline-hidden
-  jn:hover:ring-2
-  jn:hover:ring-inset
-  jn:hover:ring-theme-focus
-  jn:hover:bg-theme-background-lvl-3
+  jn:data-[active]:outline-hidden
+  jn:data-[active]:ring-2
+  jn:data-[active]:ring-inset
+  jn:data-[active]:ring-theme-focus
+  jn:data-[active]:bg-theme-background-lvl-3
 `
 
 const unselectedOptionStyles = `

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -76,6 +76,7 @@ const menuStylesContainer = `
 const menuStyles = `
   jn:w-full
   jn:overflow-y-auto
+  jn:focus:outline-hidden
 `
 
 const truncateStyles = `

--- a/packages/ui-components/src/components/SelectOption/SelectOption.component.tsx
+++ b/packages/ui-components/src/components/SelectOption/SelectOption.component.tsx
@@ -14,11 +14,11 @@ const optionStyles = `
   jn:pb-[0.5rem]
   jn:pr-3.5
   jn:select-none
-  jn:hover:outline-hidden
-  jn:hover:ring-2
-  jn:hover:ring-inset
-  jn:hover:ring-theme-focus
-  jn:hover:bg-theme-background-lvl-3
+  jn:data-[active]:outline-hidden
+  jn:data-[active]:ring-2
+  jn:data-[active]:ring-inset
+  jn:data-[active]:ring-theme-focus
+  jn:data-[active]:bg-theme-background-lvl-3
 `
 
 const unselectedOptionStyles = `
@@ -91,7 +91,7 @@ export const SelectOption = ({
 
   return (
     <ListboxOption as={Fragment} disabled={disabled} value={value || children}>
-      {({ /*active,*/ selected }) => (
+      {({ selected }) => (
         <li
           className={`
           juno-select-option 


### PR DESCRIPTION


## Summary

Fix the focus styles of menu items for both `Select` and `ComboBox` to be visible when using them via keyboard, too (previously, keyboard users could not see which item currently was focussed and would be selected making using these elements a guessing game for them).

## Changes Made

- replace `hover:` with `data-[active]:` on `SelectOption` and `ComboBoxOption`  item styles so the focus ring fires on both mouse hover and keyboard navigation via Headless UI's data-active attribute,  relying on the internal Headless mechanism rather than mouse interaction
- remove dead commented-out `active` render prop in `SelectOption`
- suppress browser default outline on the `ListboxOptions` container;
- focus styles are handled at item level via `data-[active]:`

## New Issue/Follow-up
Now, with focus on the item visible, it appears that on the Select it takes several hits on the arrow-down/-up keys before an item is focussed. This will be adressed in a follow-up issue (#1781), as it does not affect or is caused by the focus styles per se. ComboBox is not affected.

## Related Issues

Closes #1774 
Follow-up: #1781


## Screenshots (if applicable)

### Before


#### Select

The menu container has a default browser focus style applied. Not intended, not our design.

<img width="340" height="230" alt="Bildschirmfoto 2026-06-18 um 09 40 58" src="https://github.com/user-attachments/assets/ce2dd349-b496-4f26-966a-b7a1e3c7d9aa" />

When navigating the items with the mouse, the focus style is applied ok…
<img width="348" height="221" alt="Bildschirmfoto 2026-06-18 um 09 41 03" src="https://github.com/user-attachments/assets/312eed08-19ca-4937-9c44-8e1d00516410" />

… however when navigating using the keyboard (arrow-up/-down), the currently focussed item has no focus style applied:
<img width="343" height="215" alt="Bildschirmfoto 2026-06-18 um 09 41 29" src="https://github.com/user-attachments/assets/1bcde9b5-4826-4d00-88a3-34892c31c1f0" />

#### ComboBox
When navigating the ComboBox with the mouse, items are properly focussed visibly.
<img width="370" height="256" alt="Bildschirmfoto 2026-06-18 um 09 42 11" src="https://github.com/user-attachments/assets/05eb7132-9ff2-499e-9378-8989d2d1aa86" />

When navigating using the keyboard, item focus is invisible:
<img width="360" height="301" alt="Bildschirmfoto 2026-06-18 um 09 42 06" src="https://github.com/user-attachments/assets/cdf2ac08-7fc0-45f2-a3af-dcbdb8055ef8" />

The default focus style problem on the container doesn't exist on ComboBox.

### After

#### Select

When opening the Select, there is no focus style applied to the menu container anymore.
<img width="424" height="207" alt="Bildschirmfoto 2026-06-18 um 09 44 26" src="https://github.com/user-attachments/assets/b22136e9-eed0-4717-8099-c587a54767a9" />

The item focus style is applied when navigating using the mouse AND using the keyboard:
<img width="433" height="214" alt="Bildschirmfoto 2026-06-18 um 09 44 32" src="https://github.com/user-attachments/assets/4f3c8d71-3254-4b4b-b633-01b3ef02d05b" />
<img width="442" height="228" alt="Bildschirmfoto 2026-06-18 um 09 44 48" src="https://github.com/user-attachments/assets/caf8e70d-4dc4-4a55-a54c-4477b2dc34fa" />


#### ComboBox
The item focus style is applied when navigating using the mouse AND using the keyboard on ComboBox, too:
<img width="431" height="259" alt="Bildschirmfoto 2026-06-18 um 09 48 44" src="https://github.com/user-attachments/assets/b0e0768d-6250-4d8a-84ce-46fccde3f7c5" />
<img width="437" height="226" alt="Bildschirmfoto 2026-06-18 um 09 48 52" src="https://github.com/user-attachments/assets/9828d045-0a72-4f65-b18b-8f50e499f7c5" />

## Testing Instructions

1. `pnpm i`
2. `pnpm run test`


## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

## PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
