### PR TITLE
fix(ui): collapse Icon line-box to fix baseline misalignment

### DIFF
--- a/.changeset/icon-baseline-alignment.md
+++ b/.changeset/icon-baseline-alignment.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+fix(ui): collapse Icon line-box so icons align reliably inside flex containers, with follow-up fixes in PopupMenu, ComboBox, and Select

--- a/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
+++ b/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
@@ -102,6 +102,10 @@ const buttonStyles = `
   jn:pr-2
   jn:h-textinput
   jn:w-8
+  jn:inline-flex
+  jn:items-center
+  jn:justify-end
+  jn:leading-none
   jn:border-l-0
   jn:border-y
   jn:border-r
@@ -144,14 +148,19 @@ const menuStyles = `
 
 const iconContainerStyles = `
   jn:absolute
-  jn:top-[.4rem]
+  jn:top-1/2
   jn:right-8
+  jn:inline-flex
+  jn:leading-none
+  jn:translate-y-[-50%]
 `
 
 const centeredIconStyles = `
   jn:absolute
   jn:top-1/2
   jn:left-1/2
+  jn:inline-flex
+  jn:leading-none
   jn:translate-y-[-50%]
   jn:translate-x-[-0.75rem]
 `

--- a/packages/ui-components/src/components/Icon/Icon.component.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.component.tsx
@@ -71,8 +71,10 @@ Generic Icon component.
 // hover style needs to be revisited. only works if no icon color was passed
 const anchorIconStyles = `
 	jn:text-current
+	jn:inline-flex
+	jn:leading-none
   jn:hover:text-theme-high
-  jn:focus:outline-hidden 
+  jn:focus:outline-hidden
   jn:focus-visible:ring-2
   jn:focus-visible:ring-theme-focus
   jn:focus-visible:ring-offset-1
@@ -83,8 +85,10 @@ const anchorIconStyles = `
 
 // hover style needs to be revisited. only works if no icon color was passed
 const buttonIconStyles = `
+  jn:inline-flex
+  jn:leading-none
   jn:hover:text-theme-high
-  jn:focus:outline-hidden 
+  jn:focus:outline-hidden
   jn:focus-visible:ring-2
   jn:focus-visible:ring-theme-focus
   jn:focus-visible:ring-offset-1
@@ -998,7 +1002,7 @@ export const Icon = forwardRef<HTMLAnchorElement | HTMLButtonElement, IconProps>
 
   /* render an <a> if href was passed, otherwise render button if onClick was passes, otherwise render plain icon: */
   /* if plain icon, add ref to the icon. In the other cases the ref goes on the anchor or button */
-  return href ? anchor : onClick ? button : <span ref={ref}>{icn}</span>
+  return href ? anchor : onClick ? button : <span ref={ref} className="jn:inline-flex jn:leading-none">{icn}</span>
 })
 
 export interface IconProps extends Omit<HTMLProps<HTMLAnchorElement> | HTMLProps<HTMLButtonElement>, "size"> {

--- a/packages/ui-components/src/components/Icon/Icon.component.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.component.tsx
@@ -1002,7 +1002,7 @@ export const Icon = forwardRef<HTMLAnchorElement | HTMLButtonElement, IconProps>
 
   /* render an <a> if href was passed, otherwise render button if onClick was passes, otherwise render plain icon: */
   /* if plain icon, add ref to the icon. In the other cases the ref goes on the anchor or button */
-  return href ? anchor : onClick ? button : <span ref={ref} className="jn:inline-flex jn:leading-none">{icn}</span>
+  return href ? anchor : onClick ? button : <span className="jn:inline-flex jn:leading-none">{icn}</span>
 })
 
 export interface IconProps extends Omit<HTMLProps<HTMLAnchorElement> | HTMLProps<HTMLButtonElement>, "size"> {

--- a/packages/ui-components/src/components/PageHeader/PageHeader.stories.tsx
+++ b/packages/ui-components/src/components/PageHeader/PageHeader.stories.tsx
@@ -13,6 +13,8 @@ import CustomLogoPortraitPNG from "./custom-logo-placeholders/custom-logo-portra
 import CustomLogoSquarePNG from "./custom-logo-placeholders/custom-logo-square.png"
 import { PageHeader } from "./index"
 import { Button } from "../Button/"
+import { ThemeToggle } from "../ThemeToggle/"
+import { PopupMenu, PopupMenuOptions, PopupMenuItem } from "../PopupMenu/"
 
 type Story = StoryObj<typeof meta>
 
@@ -184,6 +186,32 @@ export const WithWrappedLogo: Story = {
         <span>Jane Doe</span>
         <Button size="small">Log Out</Button>
       </>
+    ),
+  },
+}
+
+export const WithThemeToggleAndUserMenu: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Visual test for icon alignment: a `ThemeToggle` next to a `PopupMenu` (default icon toggle using `accountCircle`) inside a flex container with `align-items: center`. Both icons should appear vertically centered with no extra space below the user-menu icon.",
+      },
+    },
+  },
+  args: {
+    applicationName: "My Awesome App",
+    children: (
+      <div className="jn:flex jn:items-center jn:gap-2">
+        <ThemeToggle />
+        <PopupMenu icon="accountCircle">
+          <PopupMenuOptions>
+            <PopupMenuItem label="Profile" icon="manageAccounts" />
+            <PopupMenuItem label="Settings" icon="edit" />
+            <PopupMenuItem label="Log Out" icon="exitToApp" />
+          </PopupMenuOptions>
+        </PopupMenu>
+      </div>
     ),
   },
 }

--- a/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
+++ b/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
@@ -25,6 +25,15 @@ import { PortalProvider } from "../PortalProvider/"
 
 // ----- Styles -----
 
+// Base styles applied to every toggle (default and custom).
+// inline-flex + leading-none collapse the button's line box to its content,
+// so an Icon child sits without descender space below it.
+const baseToggleStyles = `
+  jn:inline-flex
+  jn:items-center
+  jn:leading-none
+`
+
 const defaultToggleStyles = `
   jn:hover:text-theme-accent
   jn:active:text-theme-accent
@@ -107,12 +116,19 @@ const sectionTitleStyles = `
 `
 
 const sectionSeparatorStyles = `
-  jn:h-
+  jn:h-px
   jn:bg-theme-background-lvl-3
 `
 
 // Make sure the floating reference wrapper element around the toggle fits snug around the toggle, so the positioning of the menu is correct relative to the visible toggle:
 const floatingReferenceWrapperStyles = `
+  jn:inline-flex
+`
+
+// The outer wrapper must also be a flex container (rather than a default block element),
+// otherwise its inline-flex child sits in an anonymous line box and inherits line-height,
+// reintroducing descender space below the toggle.
+const popupMenuWrapperStyles = `
   jn:inline-flex
 `
 
@@ -256,7 +272,7 @@ const PopupMenu = ({
   const menu = childrenArray.find((child) => isValidElement(child) && child.type === PopupMenuOptions)
 
   return (
-    <HeadlessMenu as="div" className={`juno-popupmenu ${className}`} {...props}>
+    <HeadlessMenu as="div" className={`juno-popupmenu ${popupMenuWrapperStyles} ${className}`} {...props}>
       {/* Update our open state when the open render prop from headless ui menu changes, so we can run the handlers when our tracking state changes: */}
       {({ open, close }) => {
         // Set our tracking open state outside of rendering cycle. Trying to set the state during render will cause an error:
@@ -322,7 +338,7 @@ export const PopupMenuToggle = ({
 }: PopupMenuToggleProps): ReactNode => (
   <MenuButton
     as={as}
-    className={`juno-popupmenu-toggle ${disabled && disabledToggleStyles} ${className}`}
+    className={`juno-popupmenu-toggle ${baseToggleStyles} ${disabled && disabledToggleStyles} ${className}`}
     disabled={disabled}
     {...props}
   >

--- a/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
+++ b/packages/ui-components/src/components/PopupMenu/PopupMenu.component.tsx
@@ -338,7 +338,7 @@ export const PopupMenuToggle = ({
 }: PopupMenuToggleProps): ReactNode => (
   <MenuButton
     as={as}
-    className={`juno-popupmenu-toggle ${baseToggleStyles} ${disabled && disabledToggleStyles} ${className}`}
+    className={`juno-popupmenu-toggle ${baseToggleStyles} ${disabled ? disabledToggleStyles : ""} ${className}`}
     disabled={disabled}
     {...props}
   >

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -60,6 +60,8 @@ const centeredIconStyles = `
   jn:absolute
   jn:top-1/2
   jn:left-1/2
+  jn:inline-flex
+  jn:leading-none
   jn:translate-y-[-50%]
   jn:translate-x-[-0.75rem]
 `
@@ -395,10 +397,10 @@ export const Select = ({
                           >
                             {getDisplayValue(value)}
                           </span>
-                          <span className="jn:flex">
+                          <span className="jn:flex jn:items-center">
                             {isValid ? <Icon icon="checkCircle" color="jn:text-theme-success" /> : ""}
                             {isInvalid ? <Icon icon="dangerous" color="jn:text-theme-error" /> : ""}
-                            <span>
+                            <span className="jn:inline-flex jn:leading-none">
                               <Icon icon={open ? "expandLess" : "expandMore"} />
                             </span>
                           </span>


### PR DESCRIPTION
# Summary

Fixes a baseline-alignment bug where `Icon` rendered with descender space below the SVG, shifting icons above the visual centerline of flex layouts. Collapses the icon's containment chain to its content via `inline-flex` + `leading-none`, and applies the same treatment to `PopupMenu`, `ComboBox`, and `Select` — components that visibly relied on the prior (coincidental) alignment.

# Changes Made

- **Icon** (`Icon.component.tsx`): plain-icon wrapper `<span>`, `buttonIconStyles`, and `anchorIconStyles` now use `inline-flex` + `leading-none` so the wrapper hugs the SVG.
- **PopupMenu** (`PopupMenu.component.tsx`):
  - Outer `HeadlessMenu` wrapper switched to `inline-flex`.
  - Default toggle gets `inline-flex items-center leading-none`.
  - Custom toggles passed via `<PopupMenu.Toggle>` get the same alignment via shared `baseToggleStyles` applied in `PopupMenuToggle`.
  - Drive-by: fixed incomplete utility class `jn:h-` → `jn:h-px` on `PopupMenuSectionSeparator` (matches `Divider` / `SelectDivider` convention; pre-existing typo).
- **ComboBox** (`ComboBox.component.tsx`):
  - Toggle button: added `inline-flex items-center justify-end leading-none` so the chevron is centered vertically inside the `h-textinput` toggle.
  - Valid/invalid icon container: replaced magic-number `top-[.4rem]` with `top-1/2 + translate-y-[-50%]` so positioning is independent of icon height / line-height.
  - `centeredIconStyles` (error/loading icon): added `inline-flex leading-none` so the translate-50% centering operates on the SVG box.
- **Select** (`Select.component.tsx`):
  - `centeredIconStyles`: same treatment as ComboBox.
  - Outer flex span around chevron/validation icons: added `items-center`; bare wrapper span around the chevron now uses `inline-flex leading-none`.
- **PageHeader** (`PageHeader.stories.tsx`): new `WithThemeToggleAndUserMenu` story as a visual-regression target for icon alignment in a flex row.

# Related Issues

- Closes #1788

# Screenshots (if applicable)
Before:
<img width="126" height="53" alt="Screenshot 2026-06-22 at 18 20 53" src="https://github.com/user-attachments/assets/fcd913df-a2a3-48a6-a5a2-6314fd015325" />

After:
<img width="158" height="64" alt="Screenshot 2026-06-22 at 18 19 08" src="https://github.com/user-attachments/assets/86588631-db1d-451f-9d97-d3007a2f6147" />

<!-- Visual diff is most easily seen in the new Storybook story `Layout/PageHeader → With Theme Toggle And User Menu` and in the ComboBox/Select toggle stories. -->

# Testing Instructions

1. `pnpm i`
2. `pnpm --filter @cloudoperators/juno-ui-components test` — confirm Icon, PopupMenu, ComboBox, and Select tests pass.
3. `cd packages/ui-components && pnpm storybook` — then visually inspect:
   - `Layout/PageHeader → With Theme Toggle And User Menu` (new story; both icons should be centered in the flex row).
   - `Components/PopupMenu` stories: default toggle, custom toggles, and items with icons.
   - `Forms/ComboBox` stories: default, valid, invalid, loading, error states.
   - `Forms/Select` stories: default, valid, invalid, loading, error states.
   - `Components/Icon` button and anchor variants.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works. (Added Storybook story for visual regression; no new unit tests since this is a CSS-only behavioral change.)
- [x] New and existing unit tests pass locally with my changes. (170 tests across Icon, PopupMenu, ComboBox, Select.)
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.