### PR TITLE
fix(ui): fix NaN input in Pagination

### DIFF
--- a/.changeset/eleven-buses-bet.md
+++ b/.changeset/eleven-buses-bet.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+Fix NaN input in Pagination

--- a/packages/ui-components/src/components/Pagination/Pagination.component.tsx
+++ b/packages/ui-components/src/components/Pagination/Pagination.component.tsx
@@ -184,7 +184,7 @@ export const Pagination = ({
       // Enforce minimum and maximum limits
       if (inputValue < 1) {
         inputValue = 1
-      } else if (controlTotalPage !== undefined && inputValue > controlTotalPage) {
+      } else if (isNaN(inputValue) || (controlTotalPage !== undefined && inputValue > controlTotalPage)) {
         inputValue = controlTotalPage
       }
     }

--- a/packages/ui-components/src/components/Pagination/Pagination.test.tsx
+++ b/packages/ui-components/src/components/Pagination/Pagination.test.tsx
@@ -486,4 +486,18 @@ describe("Pagination", () => {
     expect(screen.getByTestId("my-pagination")).toBeInTheDocument()
     expect(screen.getByTestId("my-pagination")).toHaveAttribute("data-lolol", "123-456")
   })
+
+  test("sets inputValue to controlTotalPage on symbol or non-numeric input", async () => {
+    const onInputChangeMock = vi.fn()
+    render(<Pagination variant="input" totalPages={5} onInputChange={onInputChangeMock} />)
+
+    const textInput = screen.getByRole("textbox")
+    fireEvent.change(textInput, { target: { value: "$" } }) // Non-numeric input
+    fireEvent.blur(textInput)
+
+    await waitFor(() => {
+      // Check that controlTotalPage was set after invalid input
+      expect(onInputChangeMock).toHaveBeenCalledWith(5)
+    })
+  })
 })

--- a/packages/ui-components/src/components/Pagination/Pagination.test.tsx
+++ b/packages/ui-components/src/components/Pagination/Pagination.test.tsx
@@ -487,17 +487,14 @@ describe("Pagination", () => {
     expect(screen.getByTestId("my-pagination")).toHaveAttribute("data-lolol", "123-456")
   })
 
-  test("sets inputValue to controlTotalPage on symbol or non-numeric input", async () => {
+  test("defaults to last page on non-numeric input", () => {
     const onInputChangeMock = vi.fn()
     render(<Pagination variant="input" totalPages={5} onInputChange={onInputChangeMock} />)
 
     const textInput = screen.getByRole("textbox")
-    fireEvent.change(textInput, { target: { value: "$" } }) // Non-numeric input
-    fireEvent.blur(textInput)
+    fireEvent.change(textInput, { target: { value: "$" } })
 
-    await waitFor(() => {
-      // Check that controlTotalPage was set after invalid input
-      expect(onInputChangeMock).toHaveBeenCalledWith(5)
-    })
+    expect(textInput).toHaveValue("5")
+    expect(onInputChangeMock).toHaveBeenCalledWith(5)
   })
 })


### PR DESCRIPTION
# Summary

When NaN input is entered, instead of printing `NaN`, the last available page is defaulted to.

# Related Issues

Closes https://github.com/cloudoperators/juno/issues/1793

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
