### PR TITLE
chore(ui): add changeset for SideNavigation list semantics fix

### DIFF
--- a/.changeset/sidenav-semantics.md
+++ b/.changeset/sidenav-semantics.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+fix(ui): emit valid HTML in SideNavigation by rendering items/groups as `<li>` and wrapping nested children in `<ul>`. `SideNavigationGroup` is now first-level only and no longer participates in `LevelContext`.


### PR DESCRIPTION
## Summary
- Adds the missing changeset for PR #1792, which fixed invalid HTML structure in `SideNavigation`/`SideNavigationItem`/`SideNavigationGroup` and was merged without one.
- Patch bump for `@cloudoperators/juno-ui-components`.

## Test plan
- [ ] Changesets bot picks up `.changeset/sidenav-semantics.md` and updates the release PR #1790.