### PR TITLE
feat(ui): add hover and active states for Card component

### DIFF
--- a/.changeset/card-hover-active-states.md
+++ b/.changeset/card-hover-active-states.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": minor
+---
+
+feat(Card): add hover and active states for interactive cards. When rendered as `<a>` or `<button>`, the Card now shows an elevated border on hover (`border-theme-card-hover`) with an enhanced shadow, and an accent border on active. Adds `--color-border-high` and `--color-card-border-hover` CSS variables.

--- a/packages/ui-components/src/components/Card/Card.component.tsx
+++ b/packages/ui-components/src/components/Card/Card.component.tsx
@@ -14,6 +14,13 @@ const cardStyles = `
   jn:shadow-theme-default
 `
 
+const cardInteractiveStyles = `
+  jn:cursor-pointer
+  jn:hover:border-theme-card-hover
+  jn:hover:shadow-theme-default-hover
+  jn:active:border-theme-accent
+`
+
 const cardPadding = "jn:p-4"
 
 export interface CardProps extends HTMLAttributes<HTMLElement> {
@@ -60,7 +67,8 @@ export interface CardProps extends HTMLAttributes<HTMLElement> {
  */
 export const Card = forwardRef<HTMLElement, CardProps>(
   ({ children, padding = false, className = "", href, onClick, disabled = false, ...props }, ref) => {
-    const combinedClassName = `juno-card ${cardStyles} ${padding ? cardPadding : ""} ${className} ${disabled ? "jn:cursor-not-allowed" : ""}`
+    const isInteractive = (!!href || !!onClick) && !disabled
+    const combinedClassName = `juno-card ${cardStyles} ${isInteractive ? cardInteractiveStyles : ""} ${padding ? cardPadding : ""} ${className} ${disabled ? "jn:cursor-not-allowed" : ""}`
 
     // Handle click event when disabled
     const handleClick: MouseEventHandler<HTMLElement> = (event) => {

--- a/packages/ui-components/src/components/Card/Card.component.tsx
+++ b/packages/ui-components/src/components/Card/Card.component.tsx
@@ -19,6 +19,11 @@ const cardInteractiveStyles = `
   jn:hover:border-theme-card-hover
   jn:hover:shadow-theme-default-hover
   jn:active:border-theme-accent
+  jn:focus:outline-hidden
+  jn:focus-visible:ring-2
+  jn:focus-visible:ring-theme-focus
+  jn:focus-visible:ring-offset-1
+  jn:focus-visible:ring-offset-theme-focus
 `
 
 const cardPadding = "jn:p-4"
@@ -68,7 +73,7 @@ export interface CardProps extends HTMLAttributes<HTMLElement> {
 export const Card = forwardRef<HTMLElement, CardProps>(
   ({ children, padding = false, className = "", href, onClick, disabled = false, ...props }, ref) => {
     const isInteractive = (!!href || !!onClick) && !disabled
-    const combinedClassName = `juno-card ${cardStyles} ${isInteractive ? cardInteractiveStyles : ""} ${padding ? cardPadding : ""} ${className} ${disabled ? "jn:cursor-not-allowed" : ""}`
+    const combinedClassName = `juno-card ${isInteractive ? "juno-card-interactive" : ""} ${cardStyles} ${isInteractive ? cardInteractiveStyles : ""} ${padding ? cardPadding : ""} ${className} ${disabled ? "jn:cursor-not-allowed" : ""}`
 
     // Handle click event when disabled
     const handleClick: MouseEventHandler<HTMLElement> = (event) => {

--- a/packages/ui-components/src/components/Card/Card.stories.tsx
+++ b/packages/ui-components/src/components/Card/Card.stories.tsx
@@ -66,3 +66,11 @@ export const WithoutPadding: Story = {
     onClick: undefined,
   },
 }
+
+export const InteractiveHover: Story = {
+  args: {
+    children: "Hover or click me to see the interactive states.",
+    padding: true,
+    onClick: () => {},
+  },
+}

--- a/packages/ui-components/src/components/Card/Card.stories.tsx
+++ b/packages/ui-components/src/components/Card/Card.stories.tsx
@@ -66,11 +66,3 @@ export const WithoutPadding: Story = {
     onClick: undefined,
   },
 }
-
-export const InteractiveHover: Story = {
-  args: {
-    children: "Hover or click me to see the interactive states.",
-    padding: true,
-    onClick: () => {},
-  },
-}

--- a/packages/ui-components/src/components/Card/Card.test.tsx
+++ b/packages/ui-components/src/components/Card/Card.test.tsx
@@ -129,6 +129,7 @@ describe("Card Component", () => {
       const element = screen.getByTestId("card")
       expect(element).toHaveClass("jn:cursor-pointer")
       expect(element).toHaveClass("jn:hover:border-theme-card-hover")
+      expect(element).toHaveClass("jn:hover:shadow-theme-default-hover")
       expect(element).toHaveClass("jn:active:border-theme-accent")
     })
 
@@ -141,6 +142,7 @@ describe("Card Component", () => {
       const element = screen.getByTestId("card")
       expect(element).toHaveClass("jn:cursor-pointer")
       expect(element).toHaveClass("jn:hover:border-theme-card-hover")
+      expect(element).toHaveClass("jn:hover:shadow-theme-default-hover")
       expect(element).toHaveClass("jn:active:border-theme-accent")
     })
 

--- a/packages/ui-components/src/components/Card/Card.test.tsx
+++ b/packages/ui-components/src/components/Card/Card.test.tsx
@@ -126,11 +126,7 @@ describe("Card Component", () => {
           Button
         </Card>
       )
-      const element = screen.getByTestId("card")
-      expect(element).toHaveClass("jn:cursor-pointer")
-      expect(element).toHaveClass("jn:hover:border-theme-card-hover")
-      expect(element).toHaveClass("jn:hover:shadow-theme-default-hover")
-      expect(element).toHaveClass("jn:active:border-theme-accent")
+      expect(screen.getByTestId("card")).toHaveClass("juno-card-interactive")
     })
 
     test("applies interactive styles when href is provided", () => {
@@ -139,19 +135,12 @@ describe("Card Component", () => {
           Link
         </Card>
       )
-      const element = screen.getByTestId("card")
-      expect(element).toHaveClass("jn:cursor-pointer")
-      expect(element).toHaveClass("jn:hover:border-theme-card-hover")
-      expect(element).toHaveClass("jn:hover:shadow-theme-default-hover")
-      expect(element).toHaveClass("jn:active:border-theme-accent")
+      expect(screen.getByTestId("card")).toHaveClass("juno-card-interactive")
     })
 
     test("does not apply interactive styles when neither href nor onClick are provided", () => {
       render(<Card data-testid="card">Div</Card>)
-      const element = screen.getByTestId("card")
-      expect(element).not.toHaveClass("jn:cursor-pointer")
-      expect(element).not.toHaveClass("jn:hover:border-theme-card-hover")
-      expect(element).not.toHaveClass("jn:active:border-theme-accent")
+      expect(screen.getByTestId("card")).not.toHaveClass("juno-card-interactive")
     })
 
     test("does not apply interactive styles when disabled", () => {
@@ -161,8 +150,7 @@ describe("Card Component", () => {
         </Card>
       )
       const element = screen.getByTestId("card")
-      expect(element).not.toHaveClass("jn:cursor-pointer")
-      expect(element).not.toHaveClass("jn:hover:border-theme-card-hover")
+      expect(element).not.toHaveClass("juno-card-interactive")
       expect(element).toHaveClass("jn:cursor-not-allowed")
     })
   })

--- a/packages/ui-components/src/components/Card/Card.test.tsx
+++ b/packages/ui-components/src/components/Card/Card.test.tsx
@@ -121,7 +121,11 @@ describe("Card Component", () => {
 
   describe("Interactive Styles", () => {
     test("applies interactive styles when onClick is provided", () => {
-      render(<Card data-testid="card" onClick={() => {}}>Button</Card>)
+      render(
+        <Card data-testid="card" onClick={() => {}}>
+          Button
+        </Card>
+      )
       const element = screen.getByTestId("card")
       expect(element).toHaveClass("jn:cursor-pointer")
       expect(element).toHaveClass("jn:hover:border-theme-card-hover")
@@ -129,7 +133,11 @@ describe("Card Component", () => {
     })
 
     test("applies interactive styles when href is provided", () => {
-      render(<Card data-testid="card" href="https://example.com">Link</Card>)
+      render(
+        <Card data-testid="card" href="https://example.com">
+          Link
+        </Card>
+      )
       const element = screen.getByTestId("card")
       expect(element).toHaveClass("jn:cursor-pointer")
       expect(element).toHaveClass("jn:hover:border-theme-card-hover")
@@ -145,7 +153,11 @@ describe("Card Component", () => {
     })
 
     test("does not apply interactive styles when disabled", () => {
-      render(<Card data-testid="card" onClick={() => {}} disabled>Disabled</Card>)
+      render(
+        <Card data-testid="card" onClick={() => {}} disabled>
+          Disabled
+        </Card>
+      )
       const element = screen.getByTestId("card")
       expect(element).not.toHaveClass("jn:cursor-pointer")
       expect(element).not.toHaveClass("jn:hover:border-theme-card-hover")

--- a/packages/ui-components/src/components/Card/Card.test.tsx
+++ b/packages/ui-components/src/components/Card/Card.test.tsx
@@ -118,4 +118,38 @@ describe("Card Component", () => {
       expect(handleClick).not.toHaveBeenCalled()
     })
   })
+
+  describe("Interactive Styles", () => {
+    test("applies interactive styles when onClick is provided", () => {
+      render(<Card data-testid="card" onClick={() => {}}>Button</Card>)
+      const element = screen.getByTestId("card")
+      expect(element).toHaveClass("jn:cursor-pointer")
+      expect(element).toHaveClass("jn:hover:border-theme-card-hover")
+      expect(element).toHaveClass("jn:active:border-theme-accent")
+    })
+
+    test("applies interactive styles when href is provided", () => {
+      render(<Card data-testid="card" href="https://example.com">Link</Card>)
+      const element = screen.getByTestId("card")
+      expect(element).toHaveClass("jn:cursor-pointer")
+      expect(element).toHaveClass("jn:hover:border-theme-card-hover")
+      expect(element).toHaveClass("jn:active:border-theme-accent")
+    })
+
+    test("does not apply interactive styles when neither href nor onClick are provided", () => {
+      render(<Card data-testid="card">Div</Card>)
+      const element = screen.getByTestId("card")
+      expect(element).not.toHaveClass("jn:cursor-pointer")
+      expect(element).not.toHaveClass("jn:hover:border-theme-card-hover")
+      expect(element).not.toHaveClass("jn:active:border-theme-accent")
+    })
+
+    test("does not apply interactive styles when disabled", () => {
+      render(<Card data-testid="card" onClick={() => {}} disabled>Disabled</Card>)
+      const element = screen.getByTestId("card")
+      expect(element).not.toHaveClass("jn:cursor-pointer")
+      expect(element).not.toHaveClass("jn:hover:border-theme-card-hover")
+      expect(element).toHaveClass("jn:cursor-not-allowed")
+    })
+  })
 })

--- a/packages/ui-components/src/global.css
+++ b/packages/ui-components/src/global.css
@@ -421,6 +421,7 @@
   --border-color-theme-box-default: var(--color-box-border);
 
   --border-color-theme-card-default: var(--color-card-border-default);
+  --border-color-theme-card-hover: var(--color-card-border-hover);
 
   --border-color-theme-codeblock-bar: var(--color-codeblock-bar-border);
   --border-color-theme-codeblock-tab-active: var(--color-text-default);
@@ -532,6 +533,7 @@
   /* LT Global */
   --color-global-bg: var(--color-juno-grey-light-1);
   --color-border-default: var(--color-juno-grey-light-7);
+  --color-border-high: var(--color-juno-grey-light-9);
   --color-global-text: var(--color-juno-text-default);
   --color-content-area-bg: var(--color-background-lvl-0);
   /* LT FOCUS */
@@ -595,7 +597,7 @@
   --color-button-primary-danger-active-text: var(--color-white);
   --color-button-primary-danger-active-bg: var(--color-juno-primary-danger-5);
 
-   /* LT DataGrid */
+  /* LT DataGrid */
   --color-datagridtoolbar-bg: var(--color-background-lvl-1);
   --color-datagridrow-selected: var(--color-accent);
 
@@ -650,6 +652,7 @@
   /* LT Card */
   --color-card-background-default: var(--color-white);
   --color-card-border-default: var(--color-border-default);
+  --color-card-border-hover: var(--color-border-high);
   /* LT Checkbox */
   --color-checkbox-bg: var(--color-background-lvl-5);
   --color-checkbox-checked-color: var(--color-accent);
@@ -742,7 +745,7 @@
   ); /* Dark Theme DateTimePicker range background. We need to use a synthetisized solid value based on the current theme's accent color, the way that flatpickr is built here forbids using translucent colors. */
   /* LT Box Shadow */
   --box-shadow-default: 0 1px 2px 0 rgba(34, 54, 73, 0.3);
-  --box-shadow-hover: 0 0 0 1px var(--color-color-shadow, rgba(79, 79, 79, 0.3)), 0 2px 8px 0 rgba(0, 0, 0, 0.3);
+  --box-shadow-hover: 0 0 0 1px var(--color-color-shadow, rgba(79, 79, 79, 0.2)), 0 2px 8px 0 rgba(0, 0, 0, 0.2);
   /* LT PageFooter */
   --color-pagefooter-text: var(--color-text-light);
   --color-pagefooter-background: var(--color-white);
@@ -783,6 +786,7 @@
   /* DT Global */
   --color-global-bg: var(--color-juno-grey-blue-10);
   --color-border-default: var(--color-juno-grey-blue-3);
+  --color-border-high: var(--color-juno-grey-blue-1);
   --color-global-text: var(--color-juno-text-default);
   --color-content-area-bg: var(--color-background-lvl-0);
 
@@ -901,6 +905,7 @@
   /* DT Card */
   --color-card-background-default: var(--color-juno-grey-blue-10);
   --color-card-border-default: var(--color-border-default);
+  --color-card-border-hover: var(--color-border-high);
   /* DT Checkbox */
   --color-checkbox-bg: var(--color-background-lvl-5);
   --color-checkbox-checked-color: var(--color-accent);
@@ -1052,41 +1057,53 @@
     @apply jn:text-theme-link;
   }
 
-  h1, .juno-h1,
-  h2, .juno-h2,
-  h3, .juno-h3,
-  h4, .juno-h4,
-  h5, .juno-h5,
-  h6, .juno-h6 {
+  h1,
+  .juno-h1,
+  h2,
+  .juno-h2,
+  h3,
+  .juno-h3,
+  h4,
+  .juno-h4,
+  h5,
+  .juno-h5,
+  h6,
+  .juno-h6 {
     @apply jn:font-sans jn:font-bold;
   }
 
-  h1, .juno-h1 {
+  h1,
+  .juno-h1 {
     font-size: 1.69rem;
     line-height: 1.375;
   }
 
-  h2, .juno-h2 {
+  h2,
+  .juno-h2 {
     font-size: 1.56rem;
     line-height: 1.375;
   }
 
-  h3, .juno-h3 {
+  h3,
+  .juno-h3 {
     font-size: 1.44rem;
     line-height: 1.375;
   }
 
-  h4, .juno-h4 {
+  h4,
+  .juno-h4 {
     font-size: 1.28rem;
     line-height: 1.625;
   }
 
-  h5, .juno-h5 {
+  h5,
+  .juno-h5 {
     font-size: 1.125rem;
     line-height: 1.625;
   }
 
-  h6, .juno-h6 {
+  h6,
+  .juno-h6 {
     font-size: 1rem;
     line-height: 1.5;
   }

--- a/packages/ui-components/src/theme.css
+++ b/packages/ui-components/src/theme.css
@@ -409,6 +409,7 @@
   --border-color-theme-box-default: var(--color-box-border);
 
   --border-color-theme-card-default: var(--color-card-border-default);
+  --border-color-theme-card-hover: var(--color-card-border-hover);
 
   --border-color-theme-codeblock-bar: var(--color-codeblock-bar-border);
   --border-color-theme-codeblock-tab-active: var(--color-text-default);
@@ -521,6 +522,7 @@
   /* LT Global */
   --color-global-bg: var(--color-juno-grey-light-1);
   --color-border-default: var(--color-juno-grey-light-7);
+  --color-border-high: var(--color-juno-grey-light-9);
   --color-global-text: var(--color-juno-text-default);
   --color-content-area-bg: var(--color-background-lvl-0);
   /* LT FOCUS */
@@ -635,6 +637,7 @@
   /* LT Card */
   --color-card-background-default: var(--color-white);
   --color-card-border-default: var(--color-border-default);
+  --color-card-border-hover: var(--color-border-high);
   /* LT Checkbox */
   --color-checkbox-bg: var(--color-background-lvl-5);
   --color-checkbox-checked-color: var(--color-accent);
@@ -730,7 +733,7 @@
   ); /* Light Theme DateTimePicker range background. We need to use a synthetisized solid value based on the current theme's accent color, the way that flatpickr is built here forbids using translucent colors. */
   /* LT Box Shadow */
   --box-shadow-default: 0 1px 2px 0 rgba(34, 54, 73, 0.3);
-  --box-shadow-hover: 0 0 0 1px var(--color-color-shadow, rgba(79, 79, 79, 0.3)), 0 2px 8px 0 rgba(0, 0, 0, 0.3);
+  --box-shadow-hover: 0 0 0 1px var(--color-color-shadow, rgba(79, 79, 79, 0.2)), 0 2px 8px 0 rgba(0, 0, 0, 0.2);
   /* LT PageFooter */
   --color-pagefooter-text: var(--color-text-light);
   --color-pagefooter-background: var(--color-white);
@@ -772,6 +775,7 @@
   /* DT Global */
   --color-global-bg: var(--color-juno-grey-blue-10);
   --color-border-default: var(--color-juno-grey-blue-3);
+  --color-border-high: var(--color-juno-grey-blue-1);
   --color-global-text: var(--color-juno-text-default);
   --color-content-area-bg: var(--color-background-lvl-0);
 
@@ -888,6 +892,7 @@
   /* DT Card */
   --color-card-background-default: var(--color-juno-grey-blue-10);
   --color-card-border-default: var(--color-border-default);
+  --color-card-border-hover: var(--color-border-high);
   /* DT Checkbox */
   --color-checkbox-bg: var(--color-background-lvl-5);
   --color-checkbox-checked-color: var(--color-accent);


### PR DESCRIPTION
## Summary

Adds interactive hover and active states to the `Card` component when rendered as a `<button>` (via `onClick`) or `<a>` (via `href`).

- Hover: elevated border (`border-theme-card-hover`) + stronger box shadow
- Active: accent border (`border-theme-accent`)
- Cursor changes to pointer on interactive cards; `cursor-not-allowed` still overrides when `disabled`
- Non-interactive cards (`<div>`) are unaffected

New CSS variables added to `global.css`:
- `--color-border-high` (light: `grey-light-9`, dark: `grey-blue-1`)
- `--color-card-border-hover` (component token)
- `--border-color-theme-card-hover` (theme token)

## Related Issues

Closes #1796

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created a changeset for my changes.

## PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.

<img width="340" height="114" alt="image" src="https://github.com/user-attachments/assets/41fad34a-d190-4ad1-9c49-17ec3268bbcc" />
<img width="329" height="104" alt="image" src="https://github.com/user-attachments/assets/8e7007db-9379-4a7c-b83e-2bc10ba93e83" />
