### PR TITLE
fix(ui): fix Select keyboard navigation — first arrow key press now highlights first item

### DIFF
--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -418,33 +418,34 @@ export const Select = ({
                       )
                     }}
                   </ListboxButton>
-                  {createPortal(
-                    <div
-                      ref={refs.setFloating}
-                      className={`
+                  {open &&
+                    createPortal(
+                      <div
+                        ref={refs.setFloating}
+                        className={`
                           juno-select-menu-container
                           ${menuStylesContainer}
                         `}
-                      style={{
-                        position: strategy,
-                        top: y ?? 0,
-                        left: x ?? 0,
-                        display: open ? "block" : "none",
-                      }}
-                      {...getFloatingProps()}
-                    >
-                      <ListboxOptions
-                        static
-                        className={`
-                          juno-select-menu
-                          ${menuStyles}
-                        `}
+                        style={{
+                          position: strategy,
+                          top: y ?? 0,
+                          left: x ?? 0,
+                        }}
+                        {...getFloatingProps()}
+                        tabIndex={-1}
                       >
-                        {children}
-                      </ListboxOptions>
-                    </div>,
-                    portalContainerRef ?? document.body
-                  )}
+                        <ListboxOptions
+                          static
+                          className={`
+                            juno-select-menu
+                            ${menuStyles}
+                          `}
+                        >
+                          {children}
+                        </ListboxOptions>
+                      </div>,
+                      portalContainerRef ?? document.body
+                    )}
                 </div>
               </>
             )

--- a/packages/ui-components/src/components/SelectOption/SelectOption.component.tsx
+++ b/packages/ui-components/src/components/SelectOption/SelectOption.component.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { Fragment, HTMLAttributes, ReactNode, useContext, useEffect } from "react"
+import React, { HTMLAttributes, ReactNode, useContext, useEffect } from "react"
 import { ListboxOption } from "@headlessui/react"
 import { SelectContext } from "../Select/Select.component"
 import { Icon } from "../Icon"
@@ -90,20 +90,23 @@ export const SelectOption = ({
   }, [value, label, children])
 
   return (
-    <ListboxOption as={Fragment} disabled={disabled} value={value || children}>
-      {({ selected }) => (
-        <li
-          className={`
-          juno-select-option 
-          jn:min-h-10
-          ${optionStyles}
-          ${selected ? "juno-select-option-selected " + selectedOptionStyles : unselectedOptionStyles}
-          ${disabled ? "juno-select-option-disabled jn:opacity-50 jn:cursor-not-allowed" : ""}
-          ${truncateOptions ? "juno-select-option-truncate" : ""}
-          ${className}
-        `}
-          {...props}
-        >
+    <ListboxOption
+      as="li"
+      disabled={disabled}
+      value={value || children}
+      className={({ selected }: { selected: boolean }) => `
+        juno-select-option
+        jn:min-h-10
+        ${optionStyles}
+        ${selected ? "juno-select-option-selected " + selectedOptionStyles : unselectedOptionStyles}
+        ${disabled ? "juno-select-option-disabled jn:opacity-50 jn:cursor-not-allowed" : ""}
+        ${truncateOptions ? "juno-select-option-truncate" : ""}
+        ${className}
+      `}
+      {...props}
+    >
+      {({ selected }: { selected: boolean }) => (
+        <>
           {selected ? <Icon icon="check" size="18" className={selectedIconStyles} /> : ""}
           <span
             className={`
@@ -113,7 +116,7 @@ export const SelectOption = ({
           >
             {children || label || value}
           </span>
-        </li>
+        </>
       )}
     </ListboxOption>
   )


### PR DESCRIPTION
**DO NOT MERGE YET – SEE COMMENT**

## Problem

When using the keyboard to navigate the menu of a `Select`, it takes hitting the `arrow-down`-key multiple times before the first item was visually focussed. With the hits before items were focussed, too, but without any visual display, which is highly confusing.

### Root Cause

Dropdown options were always mounted in the DOM, hidden via `display: none` on the Floating UI container. Headless UI's DOM-order sort ran against elements in a hidden subtree on page load, producing an unreliable option order. On first open, `goToOption` couldn't resolve the correct active index and the first few arrow-down presses had no visible effect.

## Fix

- Conditionally render the portal only when open (`{open && createPortal(...)}`)
  so options mount, register, and sort against visible DOM elements
- Switch `SelectOption` from `as={Fragment}` to `as="li"` so HUI owns the
  element and sets `data-active` natively
- Add `tabIndex={-1}` to the floating container to exclude it from sequential
  keyboard focus order

Closes #1781

## Test plan
- [ ] Open Select via keyboard, first arrow-down immediately highlights item 1
- [ ] Open Select via mouse, item 1 (or selected item) is highlighted immediately on open
- [ ] Arrow-up/down, Enter, Escape, Tab all behave correctly
- [ ] Multi-select keyboard navigation works
- [ ] No visual regressions in Select stories

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
