### PR TITLE
fix(ui): fix SideNavigationItem spacing and clean up Tailwind class syntax

### DIFF
--- a/.changeset/sidenavigation-spacing-fix.md
+++ b/.changeset/sidenavigation-spacing-fix.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+fix(SideNavigationItem): add vertical spacing between items to prevent visual overlap, align expand button, and replace arbitrary Tailwind value with standard scale equivalent

--- a/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.component.tsx
+++ b/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.component.tsx
@@ -125,7 +125,7 @@ export const SideNavigationItem = ({
         onClick={handleToggleOpen}
         aria-label={isOpen ? "Collapse section" : "Expand section"}
         disabled={disabled}
-        className="expand-icon jn:ml-0"
+        className="expand-icon jn:ml-0.5"
       >
         <Icon size="24" icon={isOpen ? "expandMore" : "chevronRight"} />
       </button>

--- a/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.component.tsx
+++ b/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.component.tsx
@@ -125,7 +125,7 @@ export const SideNavigationItem = ({
         onClick={handleToggleOpen}
         aria-label={isOpen ? "Collapse section" : "Expand section"}
         disabled={disabled}
-        className="expand-icon"
+        className="expand-icon jn:ml-0"
       >
         <Icon size="24" icon={isOpen ? "expandMore" : "chevronRight"} />
       </button>
@@ -133,7 +133,7 @@ export const SideNavigationItem = ({
 
   const renderLeft = () => (
     <span className={leftStyles}>
-      {icon && level === 0 ? <Icon className={"jn:mr-[0.25rem]"} icon={icon} size="24" /> : null}
+      {icon && level === 0 ? <Icon className={"jn:mr-1"} icon={icon} size="24" /> : null}
       <div className={`level-${level + 1}`}>{label || children}</div>
     </span>
   )
@@ -149,7 +149,7 @@ export const SideNavigationItem = ({
 
   return (
     <LevelContext.Provider value={level + 1}>
-      <li className="jn:flex jn:w-full jn:flex-col">
+      <li className="jn:flex jn:w-full jn:flex-col jn:py-0.5">
         <div className="jn:flex jn:w-full jn:items-start jn:justify-between">
           {href ? (
             <a


### PR DESCRIPTION
Closes #1801

## What and why

Nested `SideNavigationItem` elements were visually overlapping when a selected item was adjacent to a hovered one. The `<li>` wrapper had no vertical padding, causing the hover background of one item to visually bleed into the selected state of the adjacent item.

## Changes

- Add `jn:py-0.5` to the `<li>` wrapper to create consistent vertical spacing between items
- Add `jn:ml-0` to the expand button to align it correctly
- Replace arbitrary value `jn:mr-[0.25rem]` with standard scale `jn:mr-1` (identical value, cleaner syntax)

## Screenshots

<img width="684" height="448" alt="image" src="https://github.com/user-attachments/assets/dd1af06a-a682-497f-a692-d8cdcba6a11e" />

## Testing

- Verified in Storybook: `Navigation / SideNavigation / Item — Expandable`
- Items are no longer overlapping visually
- Icon spacing and expand button alignment unchanged