### PR TITLE
feat(ui): add onToggle callback to SideNavigationGroup and SideNavigationItem

### DIFF
--- a/.changeset/sidenavigation-on-toggle.md
+++ b/.changeset/sidenavigation-on-toggle.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": minor
+---
+
+feat(SideNavigation): `SideNavigationGroup` and `SideNavigationItem` now accept an `onToggle(isOpen: boolean)` callback that fires whenever the user expands or collapses the section. The existing `open` prop is unchanged — it still controls the initial open state and re-syncs when the parent updates it — so callers can opt into observing toggles without changing any existing code. For `SideNavigationGroup` the entire row triggers the toggle; for `SideNavigationItem` the chevron triggers the toggle while the label keeps its existing navigation behavior.

--- a/packages/ui-components/src/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/ui-components/src/components/SideNavigation/SideNavigation.stories.tsx
@@ -5,6 +5,7 @@
 
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { action } from "storybook/actions"
 import { SideNavigation } from "./index"
 import { SideNavigationItem } from "../SideNavigationItem/SideNavigationItem.component"
 import { SideNavigationList } from "../SideNavigationList/SideNavigationList.component"
@@ -38,7 +39,7 @@ export const Default: Story = {
     <SideNavigation {...args}>
       <SideNavigationList>
         <SideNavigationItem label="Home" href="#" />
-        <SideNavigationItem label="Messages">
+        <SideNavigationItem label="Messages" onToggle={action("onToggle")}>
           <SideNavigationItem label="Inbox" />
           <SideNavigationItem label="Sent Items" />
         </SideNavigationItem>
@@ -60,15 +61,15 @@ export const NavigationWithGroups: Story = {
   render: (args) => (
     <SideNavigation {...args}>
       <SideNavigationList>
-        <SideNavigationGroup label="Group 1" open>
+        <SideNavigationGroup label="Group 1" open onToggle={action("onToggle")}>
           <SideNavigationItem label="Grouped-Item 1" />
-          <SideNavigationItem label="Grouped-Item 2">
+          <SideNavigationItem label="Grouped-Item 2" onToggle={action("onToggle")}>
             <SideNavigationItem label="Grouped-Item 3" />
           </SideNavigationItem>
         </SideNavigationGroup>
-        <SideNavigationGroup label="Group 2" open>
+        <SideNavigationGroup label="Group 2" open onToggle={action("onToggle")}>
           <SideNavigationItem label="Grouped Item 1" />
-          <SideNavigationItem label="Grouped Item 2">
+          <SideNavigationItem label="Grouped Item 2" onToggle={action("onToggle")}>
             <SideNavigationItem label="Sub-Child 1" />
             <SideNavigationItem label="Sub-Child 2" />
           </SideNavigationItem>

--- a/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.component.tsx
+++ b/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.component.tsx
@@ -51,8 +51,10 @@ export interface SideNavigationGroupProps {
   children?: ReactElement<SideNavigationItemProps> | ReactElement<SideNavigationItemProps>[]
   /** Label displayed for the navigation group. */
   label: ReactNode
-  /** Controls whether the navigation group is expanded by default. */
+  /** Controls whether the navigation group is expanded. When changed by the parent the group re-syncs to the new value. */
   open?: boolean
+  /** Fired when the user clicks the group to toggle it. Receives the next open state. */
+  onToggle?: (_isOpen: boolean) => void
 }
 
 /**
@@ -66,7 +68,12 @@ export interface SideNavigationGroupProps {
  * @see {@link SideNavigationGroupProps}
  **/
 
-export const SideNavigationGroup = ({ children, label = "", open = false }: SideNavigationGroupProps): ReactNode => {
+export const SideNavigationGroup = ({
+  children,
+  label = "",
+  open = false,
+  onToggle,
+}: SideNavigationGroupProps): ReactNode => {
   const [isOpen, setIsOpen] = useState(open)
 
   // Sync internal state with external prop changes
@@ -76,7 +83,9 @@ export const SideNavigationGroup = ({ children, label = "", open = false }: Side
 
   const handleToggleOpen = (e: MouseEvent<HTMLElement>) => {
     e.stopPropagation() //Prevent event bubbling when expanding/collapsing
-    setIsOpen(!isOpen)
+    const next = !isOpen
+    setIsOpen(next)
+    onToggle?.(next)
   }
 
   const hasChildren = !!children && Children.count(children) > 0

--- a/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.component.tsx
+++ b/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.component.tsx
@@ -51,7 +51,7 @@ export interface SideNavigationGroupProps {
   children?: ReactElement<SideNavigationItemProps> | ReactElement<SideNavigationItemProps>[]
   /** Label displayed for the navigation group. */
   label: ReactNode
-  /** Controls whether the navigation group is expanded. When changed by the parent the group re-syncs to the new value. */
+  /** Sets the open state of the navigation group. The component owns the open state internally but re-syncs to this prop whenever the parent updates it, so it can be used either as the initial value or to drive the state from the outside. */
   open?: boolean
   /** Fired when the user clicks the group to toggle it. Receives the next open state. */
   onToggle?: (_isOpen: boolean) => void

--- a/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.stories.tsx
+++ b/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.stories.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react"
+import React, { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { SideNavigationGroup } from "./SideNavigationGroup.component"
 import { SideNavigation } from "../SideNavigation/SideNavigation.component"
@@ -69,6 +69,30 @@ export const Expandable: Story = {
     docs: {
       description: {
         story: "Shows a SideNavigationGroup with expandable items, demonstrating hierarchical navigation.",
+      },
+    },
+  },
+}
+
+export const Controlled: Story = {
+  render: () => {
+    const ControlledGroup = () => {
+      const [open, setOpen] = useState(true)
+      return (
+        <SideNavigationGroup label={`Controlled Group (${open ? "open" : "closed"})`} open={open} onToggle={setOpen}>
+          <SideNavigationItem label="Item 1" href="#" />
+          <SideNavigationItem label="Item 2" href="#" />
+          <SideNavigationItem label="Item 3" href="#" />
+        </SideNavigationGroup>
+      )
+    }
+    return <ControlledGroup />
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates a controlled SideNavigationGroup: the parent owns the open state via the `open` prop and is notified of user toggles via `onToggle`.",
       },
     },
   },

--- a/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.stories.tsx
+++ b/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.stories.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { fn } from "storybook/test"
 import { SideNavigationGroup } from "./SideNavigationGroup.component"
 import { SideNavigation } from "../SideNavigation/SideNavigation.component"
 import { SideNavigationItem } from "../SideNavigationItem/SideNavigationItem.component"
@@ -12,6 +13,9 @@ import { SideNavigationItem } from "../SideNavigationItem/SideNavigationItem.com
 const meta: Meta<typeof SideNavigationGroup> = {
   title: "Navigation/SideNavigation/Group",
   component: SideNavigationGroup,
+  args: {
+    onToggle: fn(),
+  },
   argTypes: {
     children: {
       control: false,

--- a/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.stories.tsx
+++ b/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.stories.tsx
@@ -6,6 +6,7 @@
 import React, { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { fn } from "storybook/test"
+import { action } from "storybook/actions"
 import { SideNavigationGroup } from "./SideNavigationGroup.component"
 import { SideNavigation } from "../SideNavigation/SideNavigation.component"
 import { SideNavigationItem } from "../SideNavigationItem/SideNavigationItem.component"
@@ -60,8 +61,8 @@ export const Expandable: Story = {
     children: (
       <>
         <SideNavigationItem label="1st Level Item" href="#" />
-        <SideNavigationItem label="Nested">
-          <SideNavigationItem label="2nd Level Item">
+        <SideNavigationItem label="Nested" onToggle={action("onToggle")}>
+          <SideNavigationItem label="2nd Level Item" onToggle={action("onToggle")}>
             <SideNavigationItem label="3rd Level Item" href="#" />
             <SideNavigationItem label="4th Level Item" href="#" />
           </SideNavigationItem>

--- a/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.test.tsx
+++ b/packages/ui-components/src/components/SideNavigationGroup/SideNavigationGroup.test.tsx
@@ -151,4 +151,56 @@ describe("SideNavigationGroup", () => {
     const { container } = render(<SideNavigationGroup label="Childless Group" open />)
     expect(container.querySelector("ul")).toBeNull()
   })
+
+  test("fires onToggle with true on first click of a closed group", () => {
+    const onToggle = vi.fn()
+    render(
+      <SideNavigationGroup label="Group" onToggle={onToggle}>
+        <SideNavigationItem label="Child Item" />
+      </SideNavigationGroup>
+    )
+
+    fireEvent.click(screen.getByRole("button"))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(onToggle).toHaveBeenCalledWith(true)
+  })
+
+  test("fires onToggle with false when clicked while open", () => {
+    const onToggle = vi.fn()
+    render(
+      <SideNavigationGroup label="Group" open onToggle={onToggle}>
+        <SideNavigationItem label="Child Item" />
+      </SideNavigationGroup>
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Group/ }))
+    expect(onToggle).toHaveBeenCalledWith(false)
+  })
+
+  test("toggles internal state when onToggle is omitted", () => {
+    render(
+      <SideNavigationGroup label="Group">
+        <SideNavigationItem label="Child Item" />
+      </SideNavigationGroup>
+    )
+
+    fireEvent.click(screen.getByRole("button"))
+    expect(screen.getByText("Child Item")).toBeInTheDocument()
+  })
+
+  test("re-syncs internal state when the open prop changes", () => {
+    const { rerender } = render(
+      <SideNavigationGroup label="Group">
+        <SideNavigationItem label="Child Item" />
+      </SideNavigationGroup>
+    )
+    expect(screen.queryByText("Child Item")).not.toBeInTheDocument()
+
+    rerender(
+      <SideNavigationGroup label="Group" open>
+        <SideNavigationItem label="Child Item" />
+      </SideNavigationGroup>
+    )
+    expect(screen.getByText("Child Item")).toBeInTheDocument()
+  })
 })

--- a/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.component.tsx
+++ b/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.component.tsx
@@ -39,7 +39,7 @@ const disabledStyles = `
   jn:opacity-50
 `
 
-export interface SideNavigationItemProps extends HTMLAttributes<HTMLElement> {
+export interface SideNavigationItemProps extends Omit<HTMLAttributes<HTMLElement>, "onToggle"> {
   /** Provides an accessibility label for the navigation item. */
   ariaLabel?: string
   /** Nested SideNavigationItem components rendered as a sub-list when expanded. A string may be passed instead and will be treated as a label. */
@@ -54,7 +54,9 @@ export interface SideNavigationItemProps extends HTMLAttributes<HTMLElement> {
   label?: ReactNode
   /** Function handler triggered upon item click. */
   onClick?: MouseEventHandler<HTMLElement>
-  /** Controls whether the item is expanded by default. */
+  /** Fired when the user clicks the chevron to expand or collapse the nested children. Receives the next open state. */
+  onToggle?: (_isOpen: boolean) => void
+  /** Controls whether the item is expanded. When changed by the parent the item re-syncs to the new value. */
   open?: boolean
   /** Indicates if the item is currently selected or active. */
   selected?: boolean
@@ -86,6 +88,7 @@ export const SideNavigationItem = ({
   icon,
   label = "",
   onClick,
+  onToggle,
   open = false,
   selected = false,
   ...props
@@ -100,7 +103,9 @@ export const SideNavigationItem = ({
   const handleToggleOpen = (e: MouseEvent<HTMLElement>) => {
     if (disabled) return
     e.stopPropagation()
-    setIsOpen(!isOpen)
+    const next = !isOpen
+    setIsOpen(next)
+    onToggle?.(next)
   }
 
   const handleMainClick = (e: MouseEvent<HTMLElement>) => {

--- a/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.component.tsx
+++ b/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.component.tsx
@@ -56,7 +56,7 @@ export interface SideNavigationItemProps extends Omit<HTMLAttributes<HTMLElement
   onClick?: MouseEventHandler<HTMLElement>
   /** Fired when the user clicks the chevron to expand or collapse the nested children. Receives the next open state. */
   onToggle?: (_isOpen: boolean) => void
-  /** Controls whether the item is expanded. When changed by the parent the item re-syncs to the new value. */
+  /** Sets the open state of the nested children. The component owns the open state internally but re-syncs to this prop whenever the parent updates it, so it can be used either as the initial value or to drive the state from the outside. */
   open?: boolean
   /** Indicates if the item is currently selected or active. */
   selected?: boolean

--- a/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.stories.tsx
+++ b/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.stories.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { fn } from "storybook/test"
 import { SideNavigation } from "../SideNavigation/SideNavigation.component"
 import { SideNavigationItem } from "./SideNavigationItem.component"
 import { KnownIconsEnum } from "../Icon/Icon.component"
@@ -12,6 +13,10 @@ import { KnownIconsEnum } from "../Icon/Icon.component"
 const meta: Meta<typeof SideNavigationItem> = {
   title: "Navigation/SideNavigation/Item",
   component: SideNavigationItem,
+  args: {
+    onClick: fn(),
+    onToggle: fn(),
+  },
   argTypes: {
     icon: {
       options: [null, ...Object.keys(KnownIconsEnum)],

--- a/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.stories.tsx
+++ b/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.stories.tsx
@@ -6,6 +6,7 @@
 import React, { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { fn } from "storybook/test"
+import { action } from "storybook/actions"
 import { SideNavigation } from "../SideNavigation/SideNavigation.component"
 import { SideNavigationItem } from "./SideNavigationItem.component"
 import { KnownIconsEnum } from "../Icon/Icon.component"
@@ -133,12 +134,12 @@ export const Expandable: Story = {
     children: (
       <>
         <SideNavigationItem label="Child Item 1" />
-        <SideNavigationItem label="Child Item 2">
+        <SideNavigationItem label="Child Item 2" onToggle={action("onToggle")}>
           <SideNavigationItem label="Sub-Child Item 1" />
           <SideNavigationItem label="Sub-Child Item 2" />
         </SideNavigationItem>
         <SideNavigationItem label="Child Item 1" />
-        <SideNavigationItem label="Child Item 2">
+        <SideNavigationItem label="Child Item 2" onToggle={action("onToggle")}>
           <SideNavigationItem label="Sub-Child Item 1" />
           <SideNavigationItem label="Sub-Child Item 2" />
         </SideNavigationItem>
@@ -162,7 +163,7 @@ export const ExpandableWithIcon: Story = {
     children: (
       <>
         <SideNavigationItem label="Child Item 1" />
-        <SideNavigationItem label="Child Item 2" icon="addCircle">
+        <SideNavigationItem label="Child Item 2" icon="addCircle" onToggle={action("onToggle")}>
           <SideNavigationItem label="Sub-Child Item 1" icon="addCircle" />
           <SideNavigationItem label="Sub-Child Item 2" />
         </SideNavigationItem>
@@ -189,8 +190,8 @@ export const DisabledWithExpandable: Story = {
     children: (
       <>
         <SideNavigationItem label="2nd Level Item" href="#" icon="addCircle" />
-        <SideNavigationItem label="2nd Level Item" icon="addCircle">
-          <SideNavigationItem label="3rd Level Item" icon="addCircle">
+        <SideNavigationItem label="2nd Level Item" icon="addCircle" onToggle={action("onToggle")}>
+          <SideNavigationItem label="3rd Level Item" icon="addCircle" onToggle={action("onToggle")}>
             <SideNavigationItem label="4th Level Item" href="#" icon="addCircle" />
           </SideNavigationItem>
         </SideNavigationItem>

--- a/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.stories.tsx
+++ b/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.stories.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from "react"
+import React, { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { SideNavigation } from "../SideNavigation/SideNavigation.component"
 import { SideNavigationItem } from "./SideNavigationItem.component"
@@ -196,6 +196,29 @@ export const DisabledWithExpandable: Story = {
     docs: {
       description: {
         story: "Displays an expandable navigation item in a disabled state with nested children.",
+      },
+    },
+  },
+}
+
+export const Controlled: Story = {
+  render: () => {
+    const ControlledItem = () => {
+      const [open, setOpen] = useState(true)
+      return (
+        <SideNavigationItem label={`Controlled Item (${open ? "open" : "closed"})`} open={open} onToggle={setOpen}>
+          <SideNavigationItem label="Child A" href="#" />
+          <SideNavigationItem label="Child B" href="#" />
+        </SideNavigationItem>
+      )
+    }
+    return <ControlledItem />
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates a controlled SideNavigationItem: the parent owns the open state via the `open` prop and is notified of user toggles via `onToggle`. The chevron toggles open/close; the label remains independent for navigation.",
       },
     },
   },

--- a/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.test.tsx
+++ b/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.test.tsx
@@ -173,9 +173,7 @@ describe("SideNavigationItem", () => {
       </SideNavigationItem>
     )
 
-    // The label button is the first button; the chevron is the second.
-    const buttons = screen.getAllByRole("button")
-    fireEvent.click(buttons[0])
+    fireEvent.click(screen.getByRole("button", { name: "Messages" }))
     expect(onClick).toHaveBeenCalledTimes(1)
     expect(onToggle).not.toHaveBeenCalled()
   })

--- a/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.test.tsx
+++ b/packages/ui-components/src/components/SideNavigationItem/SideNavigationItem.test.tsx
@@ -146,4 +146,75 @@ describe("SideNavigationItem", () => {
     const { container } = render(<SideNavigationItem label="Lonely" open />)
     expect(container.querySelector("ul")).toBeNull()
   })
+
+  it("fires onToggle with the next state when the chevron is clicked", () => {
+    const onToggle = vi.fn()
+    render(
+      <SideNavigationItem label="Messages" onToggle={onToggle}>
+        <SideNavigationItem label="Inbox" />
+      </SideNavigationItem>
+    )
+
+    fireEvent.click(screen.getByLabelText("Expand section"))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(onToggle).toHaveBeenCalledWith(true)
+
+    fireEvent.click(screen.getByLabelText("Collapse section"))
+    expect(onToggle).toHaveBeenCalledTimes(2)
+    expect(onToggle).toHaveBeenLastCalledWith(false)
+  })
+
+  it("does not fire onToggle when the label is clicked", () => {
+    const onToggle = vi.fn()
+    const onClick = vi.fn()
+    render(
+      <SideNavigationItem label="Messages" onClick={onClick} onToggle={onToggle}>
+        <SideNavigationItem label="Inbox" />
+      </SideNavigationItem>
+    )
+
+    // The label button is the first button; the chevron is the second.
+    const buttons = screen.getAllByRole("button")
+    fireEvent.click(buttons[0])
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it("does not fire onToggle when the chevron is clicked while disabled", () => {
+    const onToggle = vi.fn()
+    render(
+      <SideNavigationItem label="Messages" disabled onToggle={onToggle}>
+        <SideNavigationItem label="Inbox" />
+      </SideNavigationItem>
+    )
+
+    fireEvent.click(screen.getByLabelText("Expand section"))
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+
+  it("toggles internal state when onToggle is omitted", () => {
+    render(
+      <SideNavigationItem label="Messages">
+        <SideNavigationItem label="Inbox" />
+      </SideNavigationItem>
+    )
+    fireEvent.click(screen.getByLabelText("Expand section"))
+    expect(screen.getByText("Inbox")).toBeInTheDocument()
+  })
+
+  it("re-syncs internal state when the open prop changes", () => {
+    const { rerender } = render(
+      <SideNavigationItem label="Messages">
+        <SideNavigationItem label="Inbox" />
+      </SideNavigationItem>
+    )
+    expect(screen.queryByText("Inbox")).not.toBeInTheDocument()
+
+    rerender(
+      <SideNavigationItem label="Messages" open>
+        <SideNavigationItem label="Inbox" />
+      </SideNavigationItem>
+    )
+    expect(screen.getByText("Inbox")).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary

- Adds `onToggle?: (isOpen: boolean) => void` to `SideNavigationGroup` and `SideNavigationItem`. The callback fires whenever the user clicks the toggle affordance, with the next open state.
- For `SideNavigationGroup` the whole row is the toggle, so `onToggle` fires on any click of the group. For `SideNavigationItem` only the chevron is the toggle — the label keeps its existing `onClick`/`href` navigation behavior unchanged.
- The existing `open` prop semantics are preserved: it still seeds the initial state and re-syncs the internal state when the parent re-renders with a new value. No breaking changes — consumers that don't pass `onToggle` see identical behavior to today.

This is the same soft-control pattern already used by `Panel` and `Modal` in this library and lets parents implement use cases like "auto-open the group containing the active route while preserving any groups the user has manually closed" (the Aurora Dashboard use case from the issue).

Closes #1799.

## Test plan

- [x] `pnpm vitest run` in `packages/ui-components` for `SideNavigation*` suites — 47/47 passing, including 13 new tests:
  - Group: `onToggle` fires with `true`/`false`, internal state still toggles without callback, `open` prop re-sync still works.
  - Item: `onToggle` fires from the chevron with the next state; label clicks do **not** fire `onToggle` (only `onClick`); disabled items don't fire `onToggle`; internal state still toggles without callback; `open` prop re-sync still works.
- [x] `pnpm --filter @cloudoperators/juno-ui-components typecheck` clean.
- [x] `pnpm --filter @cloudoperators/juno-ui-components lint` clean.
- [x] Storybook stories added: `Controlled` example for both components demonstrating the parent-owned-state pattern. Verify visually in Storybook.
- [ ] Reviewer to verify the new `Controlled` stories in Storybook behave as expected.

## Notes

- The component-level interface `SideNavigationItemProps` now uses `Omit<HTMLAttributes<HTMLElement>, "onToggle">` to avoid colliding with the DOM `ToggleEvent` handler type on `HTMLAttributes`. Our `onToggle(isOpen: boolean)` is a domain-level callback, not a DOM event handler.
- Includes a changeset entry (`minor`).