### PR TITLE
chore(ci): automate PR creation for minor and patch dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "extends": ["config:best-practices"],
   "enabledManagers": ["npm", "github-actions"],
   "includePaths": ["packages/**", "apps/**", "./package.json", ".github/workflows/**"],
-  "rangeStrategy": "update-lockfile",
+  "rangeStrategy": "pin",
+  "timezone": "Europe/Berlin",
   "respectLatest": false,
   "packageRules": [
     {
@@ -11,15 +12,18 @@
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["major", "minor", "patch"],
       "extends": ["helpers:pinGitHubActionDigests"],
-      "minimumReleaseAge": "14 days"
+      "dependencyDashboardApproval": false,
+      "minimumReleaseAge": "14 days",
+      "schedule": ["before 9am on Monday"]
     },
     {
       "groupName": "npm dependencies",
       "matchDatasources": ["npm"],
       "matchFileNames": ["packages/**", "apps/**", "./package.json"],
       "matchUpdateTypes": ["minor", "patch"],
+      "dependencyDashboardApproval": false,
       "minimumReleaseAge": "7 days",
-      "schedule": "every weekend"
+      "schedule": ["before 9am on Monday"]
     },
     {
       "groupName": "npm major updates",
@@ -27,7 +31,8 @@
       "matchFileNames": ["packages/**", "apps/**", "./package.json"],
       "matchUpdateTypes": ["major"],
       "recreateWhen": "never",
-      "minimumReleaseAge": "30 days"
+      "minimumReleaseAge": "30 days",
+      "schedule": ["before 9am on Monday"]
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
# Summary

Update Renovate configuration to automatically open PRs for minor and patch dependency updates, removing the need for the Dep Guardian to manually trigger them from the Renovate dashboard each week.

# Changes Made

- Added `dependencyDashboardApproval: false` to npm minor/patch and GitHub Actions rules so Renovate opens PRs automatically
- Switched `rangeStrategy` from `update-lockfile` to `pin` to enforce exact pinned versions
- Unified all rules to a `before 9am on Monday` schedule in `Europe/Berlin` timezone
- Major npm updates remain dashboard-gated as they require planning

# Related Issues

- Issue 1: [#1815](https://github.com/cloudoperators/juno/issues/1815)

# Screenshots (if applicable)

N/A

# Testing Instructions

1. Trigger a manual scan from the [Renovate dashboard](https://developer.mend.io/github/cloudoperators/juno) to verify PRs are opened automatically without requiring dashboard approval for minor/patch updates.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.