### PR TITLE
feat(ui): update authentication error msg on SignInForm

### DIFF
--- a/.changeset/forty-humans-swim.md
+++ b/.changeset/forty-humans-swim.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+feat(ui): update SignInForm authentication error message 

--- a/packages/ui-components/src/components/SignInForm/SignInForm.component.tsx
+++ b/packages/ui-components/src/components/SignInForm/SignInForm.component.tsx
@@ -70,7 +70,11 @@ export const SignInForm = ({
   ...props
 }: SignInFormProps): ReactNode => {
   const errorMessage =
-    error === true ? "Unable to authenticate the provided credentials." : typeof error === "string" ? error : null
+    error === true
+      ? "Authentication failed. Verify your credentials and try again."
+      : typeof error === "string"
+        ? error
+        : null
 
   return (
     <form className={`juno-sign-in-form ${className}`} {...props}>

--- a/packages/ui-components/src/components/SignInForm/SignInForm.component.tsx
+++ b/packages/ui-components/src/components/SignInForm/SignInForm.component.tsx
@@ -31,7 +31,7 @@ export interface SignInFormProps extends Omit<FormHTMLAttributes<HTMLFormElement
   /**
    * Error message to display when authentication fails.
    * Pass a string for a custom error message.
-   * Pass `true` to display the default error message "Unable to authenticate the provided credentials.".
+   * Pass `true` to display the default error message.
    * Pass `false` or omit to hide the error message.
    */
   error?: string | boolean

--- a/packages/ui-components/src/components/SignInForm/SignInForm.test.tsx
+++ b/packages/ui-components/src/components/SignInForm/SignInForm.test.tsx
@@ -76,23 +76,29 @@ describe("SignInForm Component Tests", () => {
   describe("Error Prop", () => {
     test("does not display error message by default", () => {
       render(<SignInForm data-testid="my-signin-form" />)
-      expect(screen.queryByText("Unable to authenticate the provided credentials.")).not.toBeInTheDocument()
+      expect(
+        screen.queryByText("Authentication failed. Verify your credentials and try again.")
+      ).not.toBeInTheDocument()
     })
 
     test("does not display error when error={false}", () => {
       render(<SignInForm data-testid="my-signin-form" error={false} />)
-      expect(screen.queryByText("Unable to authenticate the provided credentials.")).not.toBeInTheDocument()
+      expect(
+        screen.queryByText("Authentication failed. Verify your credentials and try again.")
+      ).not.toBeInTheDocument()
     })
 
     test("displays default error message when error={true}", () => {
       render(<SignInForm data-testid="my-signin-form" error={true} />)
-      expect(screen.getByText("Unable to authenticate the provided credentials.")).toBeInTheDocument()
+      expect(screen.getByText("Authentication failed. Verify your credentials and try again.")).toBeInTheDocument()
     })
 
     test("displays custom error message when error is a string", () => {
       render(<SignInForm data-testid="my-signin-form" error="Invalid credentials. Please try again." />)
       expect(screen.getByText("Invalid credentials. Please try again.")).toBeInTheDocument()
-      expect(screen.queryByText("Unable to authenticate the provided credentials.")).not.toBeInTheDocument()
+      expect(
+        screen.queryByText("Authentication failed. Verify your credentials and try again.")
+      ).not.toBeInTheDocument()
     })
 
     test("error message renders as Message component with error variant", () => {
@@ -104,7 +110,9 @@ describe("SignInForm Component Tests", () => {
 
     test("does not render error when error is empty string", () => {
       render(<SignInForm data-testid="my-signin-form" error="" />)
-      expect(screen.queryByText("Unable to authenticate the provided credentials.")).not.toBeInTheDocument()
+      expect(
+        screen.queryByText("Authentication failed. Verify your credentials and try again.")
+      ).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
# Summary

Update the `SignInForm` default authentication error message to be more aligned with other errors we show or plan on showing. The previous message was a stub sentence without a subject, overly technical, and did not provide any guidance on possible ways forward to the user. The updated one is a complete sentence, somewhat more "human" without being colloquial, and adheres to the pattern we will establish.

# Changes Made

Update the `SignInForm` default authentication error message from "Unable to authenticate the provided credentials" to "Authentication failed. Verify your credentials and try again."


# Related Issues

Closes #1820 

# Screenshots (if applicable)
<img width="542" height="361" alt="Bildschirmfoto 2026-07-22 um 08 36 53" src="https://github.com/user-attachments/assets/f8f51869-1a4a-44ef-b072-83170e617e5d" />

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test SignInForm`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
