### PR TITLE
feat(ui): update Modal docs object name in title recommendation

### DIFF
--- a/docs/ux/modals.md
+++ b/docs/ux/modals.md
@@ -58,19 +58,19 @@ When the user has to make a decision and the action can't be just cancelled or t
 
 ### General Confirmation Modals
 
-General Confirmation Modals that only confrim acknowledgement of a fact or state shpuld only have one button labelled "Close", "OK", or some similar generic wording.
+General Confirmation Modals that only confirm acknowledgement of a fact or state should only have one button labelled "Close", "OK", or some similar generic wording.
 
 The title should represent the action or fact that is to be confirmed. Reference the name or other identifying property of the affected entity in the Modal body, not the title.
 
 Confirmation Modals should not carry an additional Message element in the body.
 
-When the action affects mutliple items or entities, the number and type of the items should be reflected.
+When the action affects multiple items or entities, the number and type of the items should be reflected.
 
 ### Destructive Actions and Confirmation of Destructive Actions
 
 Modals may be used for destructive tasks, such as deleting an entity, or for confirming such tasks when triggered inline. In this case, the primary button must be styled as `primary-danger` (red).
 
-The Modal title should reflect the action clearly. To re-assure users they are not going to destroy or delete items they didn't mean to delete, reference the affected item by name or identifier in the Modal body. If multiple items are affected, state the number and type in the Modal body.
+The Modal title should reflect the action clearly. To reassure users they are not going to destroy or delete items they didn't mean to delete, reference the affected item by name or identifier in the Modal body. If multiple items are affected, state the number and type in the Modal body.
 
 Modals confirming destructive Actions should NOT have a Danger Message in the Modal body.
 

--- a/docs/ux/modals.md
+++ b/docs/ux/modals.md
@@ -60,9 +60,9 @@ When the user has to make a decision and the action can't be just cancelled or t
 
 General Confirmation Modals that only confrim acknowledgement of a fact or state shpuld only have one button labelled "Close", "OK", or some similar generic wording.
 
-The title should represent the action or fact that is to be cofirmed, ideally and if possible with refrence to the name or other idientifying property of the affected entity.
+The title should represent the action or fact that is to be confirmed. Reference the name or other identifying property of the affected entity in the Modal body, not the title.
 
-Confirmation Modals should not carry an addiotnal Message element in the body.
+Confirmation Modals should not carry an additional Message element in the body.
 
 When the action affects mutliple items or entities, the number and type of the items should be reflected.
 
@@ -70,7 +70,7 @@ When the action affects mutliple items or entities, the number and type of the i
 
 Modals may be used for destructive tasks, such as deleting an entity, or for confirming such tasks when triggered inline. In this case, the primary button must be styled as `primary-danger` (red).
 
-As in modals confirming non-destructive actions, the Modal title should reflect the action and identify the affected item to re-assure users they are not going to destroy or delete items they didn't mean to delete. If multiple items are affected, the action, number, and type of items should be stated in the Modal header.
+The Modal title should reflect the action clearly. To re-assure users they are not going to destroy or delete items they didn't mean to delete, reference the affected item by name or identifier in the Modal body. If multiple items are affected, state the number and type in the Modal body.
 
 Modals confirming destructive Actions should NOT have a Danger Message in the Modal body.
 
@@ -98,7 +98,9 @@ Some Modals may allow the user to cancel/close or choose from multiple actions. 
 
 Keep Modal content short, descriptive, and concise. Modals are not a good place for long texts.
 
-Each Modal should have a title that clearly reflects the task or action, ideally referencing the affected object(s) or entity in a way that conveys the expected outcome when the user confirms the action. Avoid unnecessary alarmism, use title case for the title, and stick to our [UX Writing and Content Design guidelines](ux-writing-content-design.md).
+Each Modal should have a title that clearly reflects the task or action. Avoid unnecessary alarmism, use title case for the title, and stick to our [UX Writing and Content Design guidelines](ux-writing-content-design.md).
+
+Object names in technical contexts are often long and may be truncated in a Modal title. State the action clearly in the title; reference the affected object by name or identifier in the Modal body instead.
 
 ### Don't
 
@@ -114,12 +116,12 @@ Avoid titles that are vague, alarmist, overly generic, or that fail to indicate 
 
 ### Do
 
-Use titles that clearly state the action and the affected object or entity:
+Use titles that clearly state the action. Identify the affected object in the Modal body:
 
-- "Delete Object 12aB9"
-- "Remove User 'ArnoldS' from Project"
-- "Add Organization 'frontend-devs' to Project"
-- "Revoke API Key 'dev-key-03'"
+- "Delete Object" (body: "Object 12aB9 will be permanently deleted.")
+- "Remove User from Project" (body: "User 'ArnoldS' will be removed from the project.")
+- "Add Organization to Project" (body: "Organization 'frontend-devs' will be added to the project.")
+- "Revoke API Key" (body: "API key 'dev-key-03' will be revoked.")
 
 ## Messages in Modals, Modal Semantics
 

--- a/docs/ux/modals.md
+++ b/docs/ux/modals.md
@@ -64,7 +64,7 @@ The title should represent the action or fact that is to be confirmed. Reference
 
 Confirmation Modals should not carry an additional Message element in the body.
 
-When the action affects multiple items or entities, the number and type of the items should be reflected.
+When the action affects multiple items or entities, the number and type of the items should be reflected in the message body.
 
 ### Destructive Actions and Confirmation of Destructive Actions
 

--- a/packages/ui-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui-components/src/components/Modal/Modal.stories.tsx
@@ -91,9 +91,9 @@ export const Default: Story = {
     },
   },
   args: {
-    title: "Maintenance Mode Enabled for 'cluster-eu-1'",
+    title: "Maintenance Mode Enabled",
     children:
-      "Automated alerts and health checks for this cluster have been suspended. Turn off maintenance mode to resume normal monitoring.",
+      "Automated alerts and health checks for cluster 'prod-eu-west-1' have been suspended. Turn off maintenance mode to resume normal monitoring.",
   },
 }
 
@@ -107,7 +107,7 @@ export const SimpleConfirmNonDestructiveAction: Story = {
     },
   },
   args: {
-    title: "Assign Role to user@example.com",
+    title: "Assign Role",
     children:
       "Assign the role Operator to user@example.com? This will grant access to all resources in the selected project.",
     cancelButtonLabel: "Cancel",
@@ -125,7 +125,7 @@ export const ConfirmDesctructiveActionLowRisk: Story = {
     },
   },
   args: {
-    title: "Delete Snapshot 'snap-20240115'",
+    title: "Delete Snapshot",
     children: "Snapshot 'snap-20240115' will be permanently deleted and cannot be recovered.",
     confirmButtonVariant: "primary-danger",
     confirmButtonLabel: "Delete Snapshot",
@@ -173,7 +173,7 @@ export const ConfirmDesctructiveActionMediumRisk: Story = {
     },
   },
   args: {
-    title: "Remove User 'jsmith'",
+    title: "Remove User",
     confirmButtonVariant: "primary-danger",
     confirmButtonLabel: "Remove User",
   },
@@ -223,7 +223,7 @@ export const ConfirmDestructiveActionHighRisk: Story = {
     },
   },
   args: {
-    title: "Delete Project 'production-eu'",
+    title: "Delete Project",
     confirmButtonVariant: "primary-danger",
     confirmButtonLabel: "Delete Project",
   },
@@ -240,7 +240,7 @@ export const SimpleConfirmDialogWithDisabledButtons: Story = {
     },
   },
   args: {
-    title: "Assign Role to user@example.com",
+    title: "Assign Role",
     children:
       "Assign the role Operator to user@example.com? This will grant access to all resources in the selected project.",
     cancelButtonLabel: "Cancel",


### PR DESCRIPTION
# Summary

Update [`Modal` docs](https://github.com/cloudoperators/juno/blob/main/docs/ux/modals.md) to **_not_** recommended to add the name of the object affected by the action of a Modal. The name is likely to be long, and will most likely be truncated. Recommended to reference the object name in the Modal body instead.

# Changes Made

- Update `Modal` docs page as described above
- Update `Modal` stories to reflect our new recommendation

# Related Issues

Closes #1817 

# Testing Instructions
Not applicable.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
