### PR TITLE
feat(ui): add uxdocs section re persisting Datagrid filters

### DIFF
--- a/docs/ux/datagrid.md
+++ b/docs/ux/datagrid.md
@@ -62,6 +62,14 @@ More specifically, these are any combination of the following elements. Each ele
 
 All of the above elements are optional in the sense that none of them will be required for any given DataGrid. However, if you find yourself in a situation where none of the above options is needed or desired, reconsider whether using a DataGrid is the right choice to display the given data. This case can occur, but it is rare. In most cases a simple list is then a more appropriate option to display the data.
 
+## Filter and Sort Persistence on Navigation
+
+By default, filters and sorting applied in a DataGrid header should **not** persist when a user navigates away from the view and returns. Users generally do not expect state they configured in one session or context to still be active when they come back — stale filters can hide data and cause confusion that is hard to diagnose.
+
+An exception applies when the DataGrid is used as a **navigation mechanism**, such as browsing a folder or file structure. In this case, persisting filters and sorting is appropriate because the user is operating within a continuous navigational context, and clearing their configuration on each step would be disruptive and counterproductive.
+
+If persistence is implemented, make sure the active state is clearly communicated — active filter pills and any sort indicator must always be visible so the user is never left wondering why data appears to be missing or unexpectedly ordered.
+
 ## Column Order, Structure, and Layout
 
 - Columns should be ordered by relevance and scannability: the most identifying information (name, ID, title) should appear in the leftmost columns.

--- a/docs/ux/datagrid.md
+++ b/docs/ux/datagrid.md
@@ -64,7 +64,12 @@ All of the above elements are optional in the sense that none of them will be re
 
 ## Filter and Sort Persistence on Navigation
 
-By default, filters and sorting applied in a DataGrid header should **not** persist when a user navigates away from the view and returns. Users generally do not expect state they configured in one session or context to still be active when they come back — stale filters can hide data and cause confusion that is hard to diagnose.
+ There is no one default policy for whether filters and sorting in a DataGrid header should persist when users navigate — it ultimately depends on the user's goal, the navigation model, and the entities displayed in the DataGrid. 
+
+Generally, users do not expect state they configured in one session or context to still be active when they come back — stale filters can hide data and cause confusion that is hard to diagnose. However, there are cases where persisting filters and sorting may provide value and reduce frustration for users: when the grid is part of a continuous task or navigation flow (e.g. drilling through a folder/file hierarchy or returning via browser back/forward).
+
+If persistence is implemented, make sure the active state is clearly communicated — active filter pills and any sort indicator must always be visible so the user is never left wondering why data appears to be missing or unexpectedly ordered.
+
 
 An exception applies when the DataGrid is used as a **navigation mechanism**, such as browsing a folder or file structure. In this case, persisting filters and sorting is appropriate because the user is operating within a continuous navigational context, and clearing their configuration on each step would be disruptive and counterproductive.
 

--- a/docs/ux/datagrid.md
+++ b/docs/ux/datagrid.md
@@ -64,12 +64,11 @@ All of the above elements are optional in the sense that none of them will be re
 
 ## Filter and Sort Persistence on Navigation
 
- There is no one default policy for whether filters and sorting in a DataGrid header should persist when users navigate — it ultimately depends on the user's goal, the navigation model, and the entities displayed in the DataGrid. 
+There is no one default policy for whether filters and sorting in a DataGrid header should persist when users navigate — it ultimately depends on the user's goal, the navigation model, and the entities displayed in the DataGrid.
 
 Generally, users do not expect state they configured in one session or context to still be active when they come back — stale filters can hide data and cause confusion that is hard to diagnose. However, there are cases where persisting filters and sorting may provide value and reduce frustration for users: when the grid is part of a continuous task or navigation flow (e.g. drilling through a folder/file hierarchy or returning via browser back/forward).
 
 If persistence is implemented, make sure the active state is clearly communicated — active filter pills and any sort indicator must always be visible so the user is never left wondering why data appears to be missing or unexpectedly ordered.
-
 
 An exception applies when the DataGrid is used as a **navigation mechanism**, such as browsing a folder or file structure. In this case, persisting filters and sorting is appropriate because the user is operating within a continuous navigational context, and clearing their configuration on each step would be disruptive and counterproductive.
 


### PR DESCRIPTION
# Summary

Add a section that clarifies our recommendations regarding persisting `DataGrid` filters when a user navigates.

# Related Issues

Closes #1818 

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
