### PR TITLE
feat(ui): add Box pattern documentation to ux docs

### DIFF
--- a/docs/ux/0_contents.md
+++ b/docs/ux/0_contents.md
@@ -34,6 +34,7 @@
    6. [Modals](modals.md)
    7. [PopupMenus](popup-and-overflow-menus.md)
    8. [Messages & Notifications](messages-and-notifications.md)
+   9. [Box](box.md)
 5. [Application Design Guidelines](application-design-guidelines.md)
    1. Interaction Guidelines
    2. [UX Writing / Content Guidelines](ux-writing-content-design.md)

--- a/docs/ux/box.md
+++ b/docs/ux/box.md
@@ -1,0 +1,74 @@
+[← Back to Contents Overview](0_contents.md)
+
+# Box
+
+`Box` is a lightweight container component with a subtle border and background. It is intended for annotations, supplementary explanations, and contextual remarks — situations where content needs to be visually set apart from the surrounding layout without the stronger semantic weight of a `Message`.
+
+## When to Use Box
+
+Use `Box` to:
+
+- Present supplementary or contextual information that is related to nearby content but secondary to the main flow
+- Group and visually separate a block of content without implying urgency or status
+- Annotate a section of the UI with a note, hint, or explanation
+- Add subtle emphasis to a short block of text
+
+Do not use `Box` for system-generated feedback — operation results, errors, or status changes. Use `Message` for those cases.
+
+## Semantic Variants
+
+`Box` supports semantic variants (`info`, `success`, `warning`, `error`, `danger`) via the `variant` prop. Variants adjust the border and background color to communicate the nature of the content. Use them when the content of the Box carries a clear semantic meaning — for example, a caution note (`warning`) or a confirmation (`success`).
+
+When no variant is specified, `Box` renders in its default neutral style.
+
+Always choose the variant based on the meaning of the content, not for visual effect. See [Semantic Variants](semantic-variants.md) for guidance on which variant to use in a given situation.
+
+## Inline Action Box
+
+The **Inline Action Box** is a pattern built on `Box` for situations where a contextual message or notice needs to offer the user one or more follow-up actions — without interrupting the current flow with a Modal.
+
+### When to Use
+
+Use the Inline Action Box pattern when:
+
+- The user needs to be informed of a condition or state **and** offered a direct way to act on it, in context
+- The action is optional or secondary — the user should be able to ignore it and continue
+- The situation does not warrant the interruption and focus-lock of a Modal
+
+Do not use this pattern as a replacement for a Modal when the action requires user focus or a deliberate decision. If the action is destructive or requires confirmation, use a Modal instead.
+
+### Anatomy
+
+An Inline Action Box consists of:
+
+1. **Content area** — a short description of the condition or context. Keep it concise.
+2. **Divider** — visually separates the content from the actions below.
+3. **Action area** — one or two buttons, right-aligned. Prefer a single action. If two are present, one should be a secondary or tertiary option (e.g. "Learn more" or "Dismiss").
+
+### Variant
+
+Choose a semantic variant that matches the nature of the message in the content area. If the notice is purely informational, the default (no variant) or `info` is appropriate.
+
+### Example Structure
+
+```tsx
+<Box variant="warning">
+  <p>The current configuration has not been saved.</p>
+  <Divider />
+  <Stack distribution="end">
+    <Button variant="primary">Save Configuration</Button>
+  </Stack>
+</Box>
+```
+
+### Do
+
+- Keep the content area brief — one or two sentences at most
+- Use a single primary action where possible
+- Align actions to the right
+
+### Don't
+
+- Do not use more than two action buttons
+- Do not use the Inline Action Box for destructive actions that require confirmation — use a Modal
+- Do not nest Inline Action Boxes

--- a/docs/ux/box.md
+++ b/docs/ux/box.md
@@ -23,6 +23,10 @@ When no variant is specified, `Box` renders in its default neutral style.
 
 Always choose the variant based on the meaning of the content, not for visual effect. See [Semantic Variants](semantic-variants.md) for guidance on which variant to use in a given situation.
 
+## Title
+
+`Box` accepts an optional `title` prop. Use a title when the content needs a clear label to stand apart from surrounding content, or when the purpose of the Box is not immediately obvious from the content alone. Do not add a title by default — most Boxes are self-explanatory in context.
+
 ## Inline Action Box
 
 The **Inline Action Box** is a pattern built on `Box` for situations where a contextual message or notice needs to offer the user one or more follow-up actions — without interrupting the current flow with a Modal.
@@ -41,25 +45,14 @@ Do not use this pattern as a replacement for a Modal when the action requires us
 
 An Inline Action Box consists of:
 
-1. **Content area** — a short description of the condition or context. Keep it concise.
-2. **Divider** — visually separates the content from the actions below.
-3. **Action area** — one or two buttons, right-aligned. Prefer a single action. If two are present, one should be a secondary or tertiary option (e.g. "Learn more" or "Dismiss").
+1. **Title** (optional) — a short label identifying the condition or context.
+2. **Content area** — a short description of the condition or context. Keep it concise.
+3. **Divider** — visually separates the content from the actions below.
+4. **Action area** — one or two buttons, right-aligned. Prefer a single action. If two are present, one should be a secondary or tertiary option (e.g. "Learn more" or "Dismiss").
 
 ### Variant
 
 Choose a semantic variant that matches the nature of the message in the content area. If the notice is purely informational, the default (no variant) or `info` is appropriate.
-
-### Example Structure
-
-```tsx
-<Box variant="warning">
-  <p>The current configuration has not been saved.</p>
-  <Divider />
-  <Stack distribution="end">
-    <Button variant="primary">Save Configuration</Button>
-  </Stack>
-</Box>
-```
 
 ### Do
 

--- a/docs/ux/box.md
+++ b/docs/ux/box.md
@@ -2,6 +2,9 @@
 
 # Box
 
+> [!NOTE]
+> The `title` prop, semantic `variant` support, and the Inline Action Box pattern described in this document are not yet implemented. Currently `Box` renders as a plain neutral container only. We will remove this note once implementation is done.
+
 `Box` is a lightweight container component with a subtle border and background. It is intended for annotations, supplementary explanations, and contextual remarks — situations where content needs to be visually set apart from the surrounding layout without the stronger semantic weight of a `Message`.
 
 ## When to Use Box

--- a/docs/ux/messages-and-notifications.md
+++ b/docs/ux/messages-and-notifications.md
@@ -2,16 +2,11 @@
 
 # Messages and Notifications
 
-Juno provides two distinct mechanisms for communicating status, feedback, and
-information to users: Messages and Notifications. They serve different purposes
-and must not be used interchangeably.
+Juno provides two distinct mechanisms for communicating status, feedback, and information to users: Messages and Notifications. They serve different purposes and must not be used interchangeably.
 
 ## Messages
 
-A Message is a static UI element used to display contextual information,
-warnings, or feedback directly within the page or view. Messages are part of
-the rendered layout — they appear where placed and remain visible until the
-view changes or the condition that caused them is resolved.
+A Message is a static UI element for displaying system-generated feedback — operation results, status changes, errors, and warnings — directly within the page or view. Think of it as the inline counterpart to a Notification: where a Notification appears transiently as a toast, a Message is anchored in the layout and remains visible until the condition that caused it is resolved or the view changes.
 
 Use a Message to:
 
@@ -19,51 +14,31 @@ Use a Message to:
 - Surface a persistent warning or constraint relevant to the current view
 - Provide contextual guidance or information directly related to nearby content
 
-Messages use [Semantic Variants](semantic-variants.md) (`info`, `success`,
-`warning`, `error`, `danger`) to communicate intent. Always choose the variant
-that matches the nature of the message, not for visual effect. The default
-variant is `info`.
+Messages use [Semantic Variants](semantic-variants.md) (`info`, `success`, `warning`, `error`, `danger`) to communicate intent. Always choose the variant that matches the nature of the message, not for visual effect. The default variant is `info`.
 
 ### Title
 
-A Message may optionally include a title. Use one only when the message needs
-a clear heading to stand apart from surrounding content — for example, when
-the message is prominent or contains multiple sentences. Do not add a title by
-default.
+A Message may optionally include a title. Use one only when the message needs a clear heading to stand apart from surrounding content — for example, when the message is prominent or contains multiple sentences. Do not add a title by default.
 
 ### Content
 
-Pass simple text via the `text` prop. For content that requires formatting or
-includes links, pass it as children instead.
+Pass simple text via the `text` prop. For content that requires formatting or includes links, pass it as children instead.
 
 ### Placement
 
-Place a Message as close as possible to the content or action it relates to.
-For form-level feedback, place it at the top of the form. For page-level
-feedback, place it below the page header.
+Place a Message as close as possible to the content or action it relates to. For form-level feedback, place it at the top of the form. For page-level feedback, place it below the page header.
 
 ### Dismissible Messages
 
-A Message can be made dismissible by the user via a close button (`dismissible`
-prop). Use this for one-off feedback following a user action, where the message
-does not represent an ongoing condition.
+A Message can be made dismissible by the user via a close button (`dismissible` prop). Use this for one-off feedback following a user action, where the message does not represent an ongoing condition.
 
-Keep Messages persistent (non-dismissible) when they communicate a constraint
-or warning that remains relevant for the duration of the user's session on that
-view — for example, a permission limitation or a known degraded state.
+Keep Messages persistent (non-dismissible) when they communicate a constraint or warning that remains relevant for the duration of the user's session on that view — for example, a permission limitation or a known degraded state.
 
-Never make `error` or `warning` messages auto-dismissing. The `autoDismiss`
-prop (default timeout: 10 seconds) is available but should only be used for
-low-stakes `info` or `success` feedback that the user does not need to act on.
-Be aware that an auto-dismissed Message will cause a layout shift as it
-disappears.
+Never make `error` or `warning` messages auto-dismissing. The `autoDismiss` prop (default timeout: 10 seconds) is available but should only be used for low-stakes `info` or `success` feedback that the user does not need to act on. Be aware that an auto-dismissed Message will cause a layout shift as it disappears.
 
 ## Notifications
 
-Notifications are transient, dynamic messages that appear independently of the
-page layout — typically as "toasts" in a fixed position on screen. Unlike
-Messages, they are not tied to a specific location in the UI and dismiss
-automatically or on user interaction.
+Notifications are transient, dynamic messages that appear independently of the page layout — typically as "toasts" in a fixed position on screen. Unlike Messages, they are not tied to a specific location in the UI and dismiss automatically or on user interaction.
 
 Use Notifications to:
 
@@ -71,36 +46,26 @@ Use Notifications to:
 - Communicate events that occur outside the user's current focus
 - Provide low-interruption feedback that does not require user action
 
-Do not use Notifications for persistent errors or warnings that require user
-attention or action. Use a [Message](#messages) placed close to the relevant
-content instead.
+Do not use Notifications for persistent errors or warnings that require user attention or action. Use a [Message](#messages) placed close to the relevant content instead.
 
 ### Toast and NotificationManager
 
 Juno provides two components for notifications:
 
-**`NotificationManager`** handles all notification lifecycle — timers,
-auto-dismiss, queuing, and screen position. Place it once near the root of your
-application.
+**`NotificationManager`** handles all notification lifecycle — timers, auto-dismiss, queuing, and screen position. Place it once near the root of your application.
 
-**`Toast`** is the presentational component rendered by `NotificationManager`.
-Do not use `Toast` directly — trigger notifications via the `toast()` API
-instead.
+**`Toast`** is the presentational component rendered by `NotificationManager`. Do not use `Toast` directly — trigger notifications via the `toast()` API instead.
 
-Notifications use the same semantic variants as Messages: `info`, `success`,
-`warning`, `error`, and `danger`.
+Notifications use the same semantic variants as Messages: `info`, `success`, `warning`, `error`, and `danger`.
 
 ### Auto-Dismiss
 
-Notifications auto-dismiss after a default timeout. Do not rely on auto-dismiss
-alone for `error` or `warning` notifications that require user action — these should stay until acknowledged or actively dismissed. For these cases, a [Message](#messages) may be the better choice.
+Notifications auto-dismiss after a default timeout. Do not rely on auto-dismiss alone for `error` or `warning` notifications that require user action — these should stay until acknowledged or actively dismissed. For these cases, a [Message](#messages) may be the better choice.
 
 ### Dismissible
 
-By default, notifications include a close button. Dismissibility can be
-configured globally on `NotificationManager` or overridden per notification.
+By default, notifications include a close button. Dismissibility can be configured globally on `NotificationManager` or overridden per notification.
 
 ### Multiple Notifications
 
-`NotificationManager` supports displaying multiple notifications simultaneously.
-Additional notifications queue and appear as others close.
+`NotificationManager` supports displaying multiple notifications simultaneously. Additional notifications queue and appear as others close.


### PR DESCRIPTION
## Summary

Add `Box` pattern documentation to ux docs.

## Changes Made

<!-- List the changes that were made in this pull request. -->

- add Box pattern page
- update "Messages and Notifications" for better guidance on when to use Message


## Related Issues

Closes #1830 

- Issue 1: [link to issue]


## Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

## PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
