### PR TITLE
feat(ui): add semantic variants to `Box`

### DIFF
--- a/.changeset/wet-mangos-wonder.md
+++ b/.changeset/wet-mangos-wonder.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+feat(ui): add semantic variants to `Box`

--- a/packages/ui-components/src/components/Box/Box.component.tsx
+++ b/packages/ui-components/src/components/Box/Box.component.tsx
@@ -5,12 +5,20 @@
 
 import React, { HTMLAttributes, ReactNode } from "react"
 
-const boxStyles = `
+const boxBaseStyles = `
   jn:text-sm
   jn:rounded
-  jn:bg-theme-box-default
   jn:border
+`
+
+const boxDefaultStyles = `
+  jn:bg-theme-box-default
   jn:border-theme-box-default
+`
+
+const boxTitleStyles = `
+  jn:font-bold
+  jn:mb-1
 `
 
 export type BoxVariantType = "info" | "warning" | "danger" | "error" | "success"
@@ -21,11 +29,24 @@ const boxPadding = `
   jn:px-2
 `
 
+const boxVariantStyles: Record<BoxVariantType, string> = {
+  info: "jn:bg-theme-box-info jn:border-theme-box-info",
+  success: "jn:bg-theme-box-success jn:border-theme-box-success",
+  warning: "jn:bg-theme-box-warning jn:border-theme-box-warning",
+  error: "jn:bg-theme-box-error jn:border-theme-box-error",
+  danger: "jn:bg-theme-box-danger jn:border-theme-box-danger",
+}
+
 export interface BoxProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * The child elements to be rendered inside the Box.
    */
   children?: ReactNode
+
+  /**
+   * Optional title rendered above the content in bold.
+   */
+  title?: string
 
   /**
    * Determines whether the Box should render without padding.
@@ -40,25 +61,27 @@ export interface BoxProps extends HTMLAttributes<HTMLDivElement> {
    */
   className?: string
 
-    /**
-     * Specify an optional semantic variant that determines the appearance of a Box. If not passed, the Box will appear neutral (default).
-     */
-    variant?: BoxVariantType
+  /**
+   * Specify an optional semantic variant that determines the appearance of a Box. If not passed, the Box will appear neutral (default).
+   */
+  variant?: BoxVariantType
 }
 
 /**
  * The `Box` component is a versatile container with optional padding and a subtle border.
  * It is perfect for annotations, supplementary explanations, and remarks where more visually
  * pronounced components like a MessageBox or InfoBox would be excessive.
- * This component typically displays small text but can contain any child elements as required.
+ * This component typically displays small text but can contain any child elements as required, which supports implementing the Inline Action Box pattern.
  * @see https://cloudoperators.github.io/juno/?path=/docs/components-box--docs
  * @see {@link BoxProps}
  */
-export const Box = ({ children, unpad = false, className = "", ...props }: BoxProps): ReactNode => {
-  const combinedClassName = `juno-box ${boxStyles} ${!unpad ? boxPadding : ""} ${className}`
+export const Box = ({ children, title, unpad = false, className = "", variant, ...props }: BoxProps): ReactNode => {
+  const colorStyles = variant ? boxVariantStyles[variant] : boxDefaultStyles
+  const combinedClassName = `juno-box ${variant ? `juno-box-${variant}` : "juno-box-default"} ${boxBaseStyles} ${colorStyles} ${!unpad ? boxPadding : ""} ${className}`
   return (
     <div className={combinedClassName} {...props}>
-      {children}
+      {title && <strong className={`juno-box-title ${boxTitleStyles}`}>{title}</strong>}
+      <div>{children}</div>
     </div>
   )
 }

--- a/packages/ui-components/src/components/Box/Box.component.tsx
+++ b/packages/ui-components/src/components/Box/Box.component.tsx
@@ -13,6 +13,8 @@ const boxStyles = `
   jn:border-theme-box-default
 `
 
+export type BoxVariantType = "info" | "warning" | "danger" | "error" | "success"
+
 // When adjusting the padding, make sure to update the tests to verify Box variations with and without padding correctly.
 const boxPadding = `
   jn:py-1
@@ -37,6 +39,11 @@ export interface BoxProps extends HTMLAttributes<HTMLDivElement> {
    * @default ""
    */
   className?: string
+
+    /**
+     * Specify an optional semantic variant that determines the appearance of a Box. If not passed, the Box will appear neutral (default).
+     */
+    variant?: BoxVariantType
 }
 
 /**

--- a/packages/ui-components/src/components/Box/Box.component.tsx
+++ b/packages/ui-components/src/components/Box/Box.component.tsx
@@ -80,8 +80,14 @@ export const Box = ({ children, title, unpad = false, className = "", variant, .
   const combinedClassName = `juno-box ${variant ? `juno-box-${variant}` : "juno-box-default"} ${boxBaseStyles} ${colorStyles} ${!unpad ? boxPadding : ""} ${className}`
   return (
     <div className={combinedClassName} {...props}>
-      {title && <strong className={`juno-box-title ${boxTitleStyles}`}>{title}</strong>}
-      <div>{children}</div>
+      {title ? (
+        <>
+          <strong className={`juno-box-title ${boxTitleStyles}`}>{title}</strong>
+          <div>{children}</div>
+        </>
+      ) : (
+        children
+      )}
     </div>
   )
 }

--- a/packages/ui-components/src/components/Box/Box.component.tsx
+++ b/packages/ui-components/src/components/Box/Box.component.tsx
@@ -76,7 +76,7 @@ export interface BoxProps extends HTMLAttributes<HTMLDivElement> {
  * @see {@link BoxProps}
  */
 export const Box = ({ children, title, unpad = false, className = "", variant, ...props }: BoxProps): ReactNode => {
-  const colorStyles = variant ? boxVariantStyles[variant] : boxDefaultStyles
+  const colorStyles = variant ? (boxVariantStyles[variant] ?? boxDefaultStyles) : boxDefaultStyles
   const combinedClassName = `juno-box ${variant ? `juno-box-${variant}` : "juno-box-default"} ${boxBaseStyles} ${colorStyles} ${!unpad ? boxPadding : ""} ${className}`
   return (
     <div className={combinedClassName} {...props}>

--- a/packages/ui-components/src/components/Box/Box.component.tsx
+++ b/packages/ui-components/src/components/Box/Box.component.tsx
@@ -76,7 +76,7 @@ export interface BoxProps extends HTMLAttributes<HTMLDivElement> {
  * @see {@link BoxProps}
  */
 export const Box = ({ children, title, unpad = false, className = "", variant, ...props }: BoxProps): ReactNode => {
-  const colorStyles = variant ? (boxVariantStyles[variant] ?? boxDefaultStyles) : boxDefaultStyles
+  const colorStyles = variant ? boxVariantStyles[variant] : boxDefaultStyles
   const combinedClassName = `juno-box ${variant ? `juno-box-${variant}` : "juno-box-default"} ${boxBaseStyles} ${colorStyles} ${!unpad ? boxPadding : ""} ${className}`
   return (
     <div className={combinedClassName} {...props}>

--- a/packages/ui-components/src/components/Box/Box.stories.tsx
+++ b/packages/ui-components/src/components/Box/Box.stories.tsx
@@ -3,8 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { Box } from "./index"
+import { Divider } from "../Divider"
+import { ButtonRow } from "../ButtonRow"
+import { Button } from "../Button"
 
 const meta: Meta<typeof Box> = {
   title: "Components/Box",
@@ -33,4 +37,135 @@ export const WithoutPadding: Story = {
     children: "A Box without padding",
     unpad: true,
   },
+}
+
+export const WithTitle: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: "Use the `title` prop to render a bold label above the content.",
+      },
+    },
+  },
+  args: {
+    title: "Box Title",
+    children: "Some content in a Box with a title.",
+  },
+}
+
+export const InfoBox: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Pass `variant="info"` to render an Info Box.',
+      },
+    },
+  },
+  args: {
+    variant: "info",
+    children: "This is a Info Box.",
+  },
+}
+
+export const WarningBox: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Pass `variant="warning"` to render an Info Box.',
+      },
+    },
+  },
+  args: {
+    variant: "warning",
+    children: "This is a Warning Box.",
+  },
+}
+
+export const SuccessBox: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Pass `variant="success"` to render an Info Box.',
+      },
+    },
+  },
+  args: {
+    variant: "success",
+    children: "This is a Success Box.",
+  },
+}
+
+export const ErrorBox: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Pass `variant="error"` to render an Info Box.',
+      },
+    },
+  },
+  args: {
+    variant: "error",
+    children: "This is a Error Box.",
+  },
+}
+
+export const DangerBox: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Pass `variant="danger"` to render an Info Box.',
+      },
+    },
+  },
+  args: {
+    variant: "danger",
+    children: "This is a Danger Box.",
+  },
+}
+
+export const InlineActionBox: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An Inline Action Box to offer one or more actions in the current context without interrupting the flow or implying urgency.",
+      },
+    },
+  },
+  render: (args) => (
+    <Box title="This is a Inline Action Box" {...args}>
+      <p>
+        Use it to offer one or more actions in the current context without interrupting the flow or implying urgency.
+      </p>
+      <Divider color="jn:border-theme-higher" />
+      <ButtonRow>
+        <Button size="small">Click me</Button>
+      </ButtonRow>
+    </Box>
+  ),
+}
+
+export const InlineInfoActionBox: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An Inline Action Box to offer one or more actions in the current context without interrupting the flow or implying urgency.",
+      },
+    },
+  },
+  render: (args) => (
+    <Box variant="info" title="This is a Inline Info Action Box" {...args}>
+      <p>
+        Use it to offer one or more actions in the current context without interrupting the flow or implying urgency.
+      </p>
+      <Divider color="jn:border-theme-higher" />
+      <ButtonRow>
+        <Button size="small">Click me</Button>
+        <Button size="small" variant="primary">
+          Click me
+        </Button>
+      </ButtonRow>
+    </Box>
+  ),
 }

--- a/packages/ui-components/src/components/Box/Box.stories.tsx
+++ b/packages/ui-components/src/components/Box/Box.stories.tsx
@@ -16,7 +16,8 @@ const meta: Meta<typeof Box> = {
   argTypes: {
     variant: {
       control: { type: "select" },
-      options: [undefined, "info", "success", "warning", "error", "danger"],
+      options: ["default", "info", "success", "warning", "error", "danger"],
+      mapping: { default: undefined },
     },
   },
 }

--- a/packages/ui-components/src/components/Box/Box.stories.tsx
+++ b/packages/ui-components/src/components/Box/Box.stories.tsx
@@ -63,7 +63,7 @@ export const InfoBox: Story = {
   },
   args: {
     variant: "info",
-    children: "This is a Info Box.",
+    children: "This is an Info Box.",
   },
 }
 
@@ -71,7 +71,7 @@ export const WarningBox: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Pass `variant="warning"` to render an Info Box.',
+        story: 'Pass `variant="warning"` to render a Warning Box.',
       },
     },
   },
@@ -85,7 +85,7 @@ export const SuccessBox: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Pass `variant="success"` to render an Info Box.',
+        story: 'Pass `variant="success"` to render a Success Box.',
       },
     },
   },
@@ -99,7 +99,7 @@ export const ErrorBox: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Pass `variant="error"` to render an Info Box.',
+        story: 'Pass `variant="error"` to render an Error Box.',
       },
     },
   },
@@ -113,7 +113,7 @@ export const DangerBox: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Pass `variant="danger"` to render an Info Box.',
+        story: 'Pass `variant="danger"` to render a Danger Box.',
       },
     },
   },

--- a/packages/ui-components/src/components/Box/Box.stories.tsx
+++ b/packages/ui-components/src/components/Box/Box.stories.tsx
@@ -13,7 +13,12 @@ import { Button } from "../Button"
 const meta: Meta<typeof Box> = {
   title: "Components/Box",
   component: Box,
-  argTypes: {},
+  argTypes: {
+    variant: {
+      control: { type: "select" },
+      options: [undefined, "info", "success", "warning", "error", "danger"],
+    },
+  },
 }
 
 export default meta
@@ -105,7 +110,7 @@ export const ErrorBox: Story = {
   },
   args: {
     variant: "error",
-    children: "This is a Error Box.",
+    children: "This is an Error Box.",
   },
 }
 
@@ -133,7 +138,7 @@ export const InlineActionBox: Story = {
     },
   },
   render: (args) => (
-    <Box title="This is a Inline Action Box" {...args}>
+    <Box title="This is an Inline Action Box" {...args}>
       <p>
         Use it to offer one or more actions in the current context without interrupting the flow or implying urgency.
       </p>
@@ -154,8 +159,11 @@ export const InlineInfoActionBox: Story = {
       },
     },
   },
+  args: {
+    variant: "info",
+  },
   render: (args) => (
-    <Box variant="info" title="This is a Inline Info Action Box" {...args}>
+    <Box title="This is an Inline Info Action Box" {...args}>
       <p>
         Use it to offer one or more actions in the current context without interrupting the flow or implying urgency.
       </p>

--- a/packages/ui-components/src/components/Box/Box.test.tsx
+++ b/packages/ui-components/src/components/Box/Box.test.tsx
@@ -42,12 +42,12 @@ describe("Box Component", () => {
     test("renders a title when the 'title' prop is passed", () => {
       render(<Box data-testid="box" title="My Box Title" />)
       expect(screen.getByTestId("box")).toHaveTextContent("My Box Title")
-      expect(screen.getByTestId("box").querySelector(".juno-box-title")).toBeInTheDocument()
+      expect(screen.getByText("My Box Title")).toHaveClass("juno-box-title")
     })
 
     test("does not render a title element when 'title' is not passed", () => {
       render(<Box data-testid="box" />)
-      expect(screen.getByTestId("box").querySelector(".juno-box-title")).not.toBeInTheDocument()
+      expect(screen.queryByText("My Box Title")).not.toBeInTheDocument()
     })
   })
 

--- a/packages/ui-components/src/components/Box/Box.test.tsx
+++ b/packages/ui-components/src/components/Box/Box.test.tsx
@@ -11,6 +11,12 @@ import { Box } from "./index"
 
 describe("Box Component", () => {
   describe("Basic Rendering", () => {
+    test("renders a box", () => {
+      render(<Box data-testid="box" />)
+      expect(screen.getByTestId("box")).toBeInTheDocument()
+      expect(screen.getByTestId("box")).toHaveClass("juno-box")
+    })
+
     test("renders a box with children", () => {
       render(<Box data-testid="box">Children inside</Box>)
       expect(screen.getByTestId("box")).toBeInTheDocument()
@@ -21,43 +27,77 @@ describe("Box Component", () => {
   describe("Padding", () => {
     test("renders a padded Box by default", () => {
       render(<Box data-testid="box" />)
-      expect(screen.getByTestId("box")).toBeInTheDocument()
       expect(screen.getByTestId("box")).toHaveClass("jn:py-1")
       expect(screen.getByTestId("box")).toHaveClass("jn:px-2")
     })
 
     test("renders a Box without padding when 'unpad' is true", () => {
       render(<Box data-testid="box" unpad />)
-      expect(screen.getByTestId("box")).toBeInTheDocument()
       expect(screen.getByTestId("box")).not.toHaveClass("jn:py-1")
       expect(screen.getByTestId("box")).not.toHaveClass("jn:px-2")
+    })
+  })
+
+  describe("Title", () => {
+    test("renders a title when the 'title' prop is passed", () => {
+      render(<Box data-testid="box" title="My Box Title" />)
+      expect(screen.getByTestId("box")).toHaveTextContent("My Box Title")
+      expect(screen.getByTestId("box").querySelector(".juno-box-title")).toBeInTheDocument()
+    })
+
+    test("does not render a title element when 'title' is not passed", () => {
+      render(<Box data-testid="box" />)
+      expect(screen.getByTestId("box").querySelector(".juno-box-title")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("Variants", () => {
+    test("renders with 'juno-box-default' class when no variant is passed", () => {
+      render(<Box data-testid="box" />)
+      expect(screen.getByTestId("box")).toHaveClass("juno-box-default")
+    })
+
+    test("renders with 'juno-box-info' class when variant is 'info'", () => {
+      render(<Box data-testid="box" variant="info" />)
+      expect(screen.getByTestId("box")).toHaveClass("juno-box-info")
+    })
+
+    test("renders with 'juno-box-success' class when variant is 'success'", () => {
+      render(<Box data-testid="box" variant="success" />)
+      expect(screen.getByTestId("box")).toHaveClass("juno-box-success")
+    })
+
+    test("renders with 'juno-box-warning' class when variant is 'warning'", () => {
+      render(<Box data-testid="box" variant="warning" />)
+      expect(screen.getByTestId("box")).toHaveClass("juno-box-warning")
+    })
+
+    test("renders with 'juno-box-error' class when variant is 'error'", () => {
+      render(<Box data-testid="box" variant="error" />)
+      expect(screen.getByTestId("box")).toHaveClass("juno-box-error")
+    })
+
+    test("renders with 'juno-box-danger' class when variant is 'danger'", () => {
+      render(<Box data-testid="box" variant="danger" />)
+      expect(screen.getByTestId("box")).toHaveClass("juno-box-danger")
     })
   })
 
   describe("Additional Class Names and Props", () => {
     test("renders additional classNames when passed", () => {
       render(<Box data-testid="box" className="my-custom-class" />)
-      expect(screen.getByTestId("box")).toBeInTheDocument()
       expect(screen.getByTestId("box")).toHaveClass("my-custom-class")
+    })
+
+    test("renders custom className after internal class names", () => {
+      render(<Box data-testid="box" className="my-custom-class" />)
+      const classes = screen.getByTestId("box").className
+      expect(classes.indexOf("my-custom-class")).toBeGreaterThan(classes.indexOf("juno-box"))
     })
 
     test("renders additional props when passed", () => {
       render(<Box data-testid="box" data-lolol={true} />)
-      expect(screen.getByTestId("box")).toBeInTheDocument()
       expect(screen.getByTestId("box")).toHaveAttribute("data-lolol")
-    })
-  })
-
-  describe("Edge Cases", () => {
-    test("renders without children", () => {
-      render(<Box data-testid="box" />)
-      expect(screen.getByTestId("box")).toBeInTheDocument()
-      expect(screen.getByTestId("box")).toBeEmptyDOMElement()
-    })
-
-    test("handles additional attributes without errors", () => {
-      render(<Box data-testid="box" data-extra="extra" />)
-      expect(screen.getByTestId("box")).toHaveAttribute("data-extra", "extra")
     })
   })
 })

--- a/packages/ui-components/src/components/Divider/index.ts
+++ b/packages/ui-components/src/components/Divider/index.ts
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Juno contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { Divider } from "./Divider.component"

--- a/packages/ui-components/src/global.css
+++ b/packages/ui-components/src/global.css
@@ -388,6 +388,11 @@
   --background-color-theme-textinput-autofill: var(--color-textinput-autofill-bg);
   --background-color-theme-topnavigation-item: var(--color-topnavigation-item-bg);
   --background-color-theme-topnavigation-item-active: var(--color-topnavigation-item-active-bg);
+  --border-color-theme-box-info: var(--color-box-info-border);
+  --border-color-theme-box-success: var(--color-box-success-border);
+  --border-color-theme-box-warning: var(--color-box-warning-border);
+  --border-color-theme-box-error: var(--color-box-error-border);
+  --border-color-theme-box-danger: var(--color-box-danger-border);
 
   /* Component Background Colors: */
   --background-color-theme-message-default: var(--color-message-default-bg);
@@ -395,6 +400,11 @@
   --background-color-theme-message-warning: var(--color-message-warning-bg);
   --background-color-theme-message-danger: var(--color-message-danger-bg);
   --background-color-theme-message-error: var(--color-message-error-bg);
+  --background-color-theme-box-info: var(--color-box-info-bg);
+  --background-color-theme-box-success: var(--color-box-success-bg);
+  --background-color-theme-box-warning: var(--color-box-warning-bg);
+  --background-color-theme-box-error: var(--color-box-error-bg);
+  --background-color-theme-box-danger: var(--color-box-danger-bg);
 
   /* Component Text Colors: */
   --text-color-theme-highest: var(--color-text-highest);
@@ -417,6 +427,8 @@
 
   /* Component Border Colors: */
   --border-color-theme-default: var(--color-border-default);
+  --border-color-theme-high: var(--color-border-high);
+  --border-color-theme-higher: var(--color-border-higher);
 
   --border-color-theme-box-default: var(--color-box-border);
 
@@ -535,6 +547,7 @@
   --color-global-bg: var(--color-juno-grey-light-1);
   --color-border-default: var(--color-juno-grey-light-7);
   --color-border-high: var(--color-juno-grey-light-9);
+  --color-border-higher: rgb(183, 183, 183);
   --color-global-text: var(--color-juno-text-default);
   --color-content-area-bg: var(--color-background-lvl-0);
   /* LT FOCUS */
@@ -549,6 +562,19 @@
 
   /* LT Badge */
   --color-badge-default-bg: var(--color-juno-grey-light-3);
+  /* LT Box */
+  --color-box-bg: var(--color-background-lvl-1);
+  --color-box-border: var(--color-background-lvl-3);
+  --color-box-info-bg: var(--color-info-bg);
+  --color-box-info-border: var(--color-info);
+  --color-box-success-bg: var(--color-success-bg);
+  --color-box-success-border: var(--color-success);
+  --color-box-warning-bg: var(--color-warning-bg);
+  --color-box-warning-border: var(--color-warning);
+  --color-box-error-bg: var(--color-error-bg);
+  --color-box-error-border: var(--color-error);
+  --color-box-danger-bg: var(--color-danger-bg);
+  --color-box-danger-border: var(--color-danger);
 
   /* LT Button */
   /* LT Primary Button */
@@ -624,17 +650,24 @@
   --color-icon-severityMedium: var(--color-severity-medium);
   --color-icon-severityLow: var(--color-severity-low);
 
+  /* LT Semantic Background Colors */
+  --color-info-bg: rgb(229, 241, 250);
+  --color-warning-bg: rgb(255, 247, 229);
+  --color-success-bg: rgb(237, 248, 232);
+  --color-danger-bg: rgb(249, 229, 229);
+  --color-error-bg: rgb(249, 229, 229);
+
   /* LT Message */
   --color-message-danger-border: var(--color-danger);
-  --color-message-danger-bg: rgb(249, 229, 229);
+  --color-message-danger-bg: var(--color-danger-bg);
   --color-message-default-border: var(--color-info);
-  --color-message-default-bg: rgb(229, 241, 250);
+  --color-message-default-bg: var(--color-info-bg);
   --color-message-error-border: var(--color-error);
-  --color-message-error-bg: rgb(249, 229, 229);
+  --color-message-error-bg: var(--color-error-bg);
   --color-message-warning-border: var(--color-warning);
-  --color-message-warning-bg: rgb(255, 247, 229);
+  --color-message-warning-bg: var(--color-warning-bg);
   --color-message-success-border: var(--color-success);
-  --color-message-success-bg: rgb(237, 248, 232);
+  --color-message-success-bg: var(--color-success-bg);
 
   /* LT Introbox */
   --color-introbox-bg: var(--color-background-lvl-2);
@@ -714,9 +747,6 @@
   --color-filter-pill-key-bg: var(--color-background-lvl-4);
   /* LT Modal */
   --color-modal-backdrop-bg: rgb(0 0 0 / 0.2);
-  /* LT Box */
-  --color-box-bg: var(--color-background-lvl-1);
-  --color-box-border: var(--color-background-lvl-3);
   /* LT SideNavigation */
   --color-sidenavigation-item-active: var(--color-black);
   --color-sidenavigation-item-active-bg: var(--color-background-lvl-0);
@@ -789,6 +819,7 @@
   --color-global-bg: var(--color-juno-grey-blue-10);
   --color-border-default: var(--color-juno-grey-blue-3);
   --color-border-high: var(--color-juno-grey-blue-1);
+  --color-border-higher: rgb(92, 92, 92);
   --color-global-text: var(--color-juno-text-default);
   --color-content-area-bg: var(--color-background-lvl-0);
 
@@ -879,17 +910,24 @@
   --color-icon-severityMedium: var(--color-severity-medium);
   --color-icon-severityLow: var(--color-severity-low);
 
+  /* DT Semantic Background Colors */
+  --color-info-bg: rgb(14, 48, 57);
+  --color-warning-bg: rgb(49, 47, 24);
+  --color-success-bg: rgb(20, 48, 34);
+  --color-danger-bg: rgb(49, 27, 26);
+  --color-error-bg: rgb(49, 27, 26);
+
   /* DT Message */
   --color-message-danger-border: var(--color-danger);
-  --color-message-danger-bg: rgb(49, 27, 26);
+  --color-message-danger-bg: var(--color-danger-bg);
   --color-message-default-border: var(--color-info);
-  --color-message-default-bg: rgb(14, 48, 57);
+  --color-message-default-bg: var(--color-info-bg);
   --color-message-error-border: var(--color-error);
-  --color-message-error-bg: rgb(49, 27, 26);
+  --color-message-error-bg: var(--color-error-bg);
   --color-message-warning-border: var(--color-warning);
-  --color-message-warning-bg: rgb(49, 47, 24);
+  --color-message-warning-bg: var(--color-warning-bg);
   --color-message-success-border: var(--color-success);
-  --color-message-success-bg: rgb(20, 48, 34);
+  --color-message-success-bg: var(--color-success-bg);
   /* DT Introbox */
   --color-introbox-bg: var(--color-background-lvl-2);
   --color-introbox-border: var(--color-accent);
@@ -972,6 +1010,16 @@
   /* DT Box */
   --color-box-bg: var(--color-background-lvl-1);
   --color-box-border: var(--color-background-lvl-3);
+  --color-box-info-bg: var(--color-info-bg);
+  --color-box-info-border: var(--color-info);
+  --color-box-success-bg: var(--color-success-bg);
+  --color-box-success-border: var(--color-success);
+  --color-box-warning-bg: var(--color-warning-bg);
+  --color-box-warning-border: var(--color-warning);
+  --color-box-error-bg: var(--color-error-bg);
+  --color-box-error-border: var(--color-error);
+  --color-box-danger-bg: var(--color-danger-bg);
+  --color-box-danger-border: var(--color-danger);
   /* DT SideNavigation */
   --color-sidenavigation-item-active: var(--color-white);
   --color-sidenavigation-item-active-bg: var(--color-background-lvl-0);

--- a/packages/ui-components/src/theme.css
+++ b/packages/ui-components/src/theme.css
@@ -276,6 +276,11 @@
   /* Component Background Colors: */
   --background-color-theme-badge-default: var(--color-badge-default-bg);
   --background-color-theme-box-default: var(--color-box-bg);
+  --background-color-theme-box-info: var(--color-box-info-bg);
+  --background-color-theme-box-success: var(--color-box-success-bg);
+  --background-color-theme-box-warning: var(--color-box-warning-bg);
+  --background-color-theme-box-error: var(--color-box-error-bg);
+  --background-color-theme-box-danger: var(--color-box-danger-bg);
 
   /* Side Navigation Background Colors */
   --background-color-theme-sidenav: var(--color-sidenav-background);
@@ -405,8 +410,15 @@
 
   /* Component Border Colors: */
   --border-color-theme-default: var(--color-border-default);
+  --border-color-theme-high: var(--color-border-high);
+  --border-color-theme-higher: var(--color-border-higher);
 
   --border-color-theme-box-default: var(--color-box-border);
+  --border-color-theme-box-info: var(--color-box-info-border);
+  --border-color-theme-box-success: var(--color-box-success-border);
+  --border-color-theme-box-warning: var(--color-box-warning-border);
+  --border-color-theme-box-error: var(--color-box-error-border);
+  --border-color-theme-box-danger: var(--color-box-danger-border);
 
   --border-color-theme-card-default: var(--color-card-border-default);
   --border-color-theme-card-hover: var(--color-card-border-hover);
@@ -524,6 +536,7 @@
   --color-global-bg: var(--color-juno-grey-light-1);
   --color-border-default: var(--color-juno-grey-light-7);
   --color-border-high: var(--color-juno-grey-light-9);
+  --color-border-higher: rgb(183, 183, 183);
   --color-global-text: var(--color-juno-text-default);
   --color-content-area-bg: var(--color-background-lvl-0);
   /* LT FOCUS */
@@ -609,17 +622,24 @@
   --color-icon-severityMedium: var(--color-severity-medium);
   --color-icon-severityLow: var(--color-severity-low);
 
+  /* LT Semantic Background Colors */
+  --color-info-bg: rgb(229, 241, 250);
+  --color-warning-bg: rgb(255, 247, 229);
+  --color-success-bg: rgb(237, 248, 232);
+  --color-danger-bg: rgb(249, 229, 229);
+  --color-error-bg: rgb(249, 229, 229);
+
   /* LT Message */
   --color-message-danger-border: var(--color-danger);
-  --color-message-danger-bg: rgb(249, 229, 229);
+  --color-message-danger-bg: var(--color-danger-bg);
   --color-message-default-border: var(--color-info);
-  --color-message-default-bg: rgb(229, 241, 250);
+  --color-message-default-bg: var(--color-info-bg);
   --color-message-error-border: var(--color-error);
-  --color-message-error-bg: rgb(249, 229, 229);
+  --color-message-error-bg: var(--color-error-bg);
   --color-message-warning-border: var(--color-warning);
-  --color-message-warning-bg: rgb(255, 247, 229);
+  --color-message-warning-bg: var(--color-warning-bg);
   --color-message-success-border: var(--color-success);
-  --color-message-success-bg: rgb(237, 248, 232);
+  --color-message-success-bg: var(--color-success-bg);
 
   /* LT Introbox */
   --color-introbox-bg: var(--color-background-lvl-2);
@@ -705,6 +725,16 @@
   /* LT Box */
   --color-box-bg: var(--color-background-lvl-1);
   --color-box-border: var(--color-background-lvl-3);
+  --color-box-info-bg: var(--color-info-bg);
+  --color-box-info-border: var(--color-info);
+  --color-box-success-bg: var(--color-success-bg);
+  --color-box-success-border: var(--color-success);
+  --color-box-warning-bg: var(--color-warning-bg);
+  --color-box-warning-border: var(--color-warning);
+  --color-box-error-bg: var(--color-error-bg);
+  --color-box-error-border: var(--color-error);
+  --color-box-danger-bg: var(--color-danger-bg);
+  --color-box-danger-border: var(--color-danger);
   /* LT SideNavigation */
   --color-sidenavigation-item-active: var(--color-black);
   --color-sidenavigation-item-active-bg: var(--color-background-lvl-0);
@@ -778,6 +808,7 @@
   --color-global-bg: var(--color-juno-grey-blue-10);
   --color-border-default: var(--color-juno-grey-blue-3);
   --color-border-high: var(--color-juno-grey-blue-1);
+  --color-border-higher: rgb(92, 92, 92);
   --color-global-text: var(--color-juno-text-default);
   --color-content-area-bg: var(--color-background-lvl-0);
 
@@ -866,17 +897,24 @@
   --color-icon-severityMedium: var(--color-severity-medium);
   --color-icon-severityLow: var(--color-severity-low);
 
+  /* DT Semantic Background Colors */
+  --color-info-bg: rgb(14, 48, 57);
+  --color-warning-bg: rgb(49, 47, 24);
+  --color-success-bg: rgb(20, 48, 34);
+  --color-danger-bg: rgb(49, 27, 26);
+  --color-error-bg: rgb(49, 27, 26);
+
   /* DT Message */
   --color-message-danger-border: var(--color-danger);
-  --color-message-danger-bg: rgb(49, 27, 26);
+  --color-message-danger-bg: var(--color-danger-bg);
   --color-message-default-border: var(--color-info);
-  --color-message-default-bg: rgb(14, 48, 57);
+  --color-message-default-bg: var(--color-info-bg);
   --color-message-error-border: var(--color-error);
-  --color-message-error-bg: rgb(49, 27, 26);
+  --color-message-error-bg: var(--color-error-bg);
   --color-message-warning-border: var(--color-warning);
-  --color-message-warning-bg: rgb(49, 47, 24);
+  --color-message-warning-bg: var(--color-warning-bg);
   --color-message-success-border: var(--color-success);
-  --color-message-success-bg: rgba(20, 48, 34);
+  --color-message-success-bg: var(--color-success-bg);
   /* DT Introbox */
   --color-introbox-bg: var(--color-background-lvl-2);
   --color-introbox-border: var(--color-accent);
@@ -961,6 +999,16 @@
   /* DT Box */
   --color-box-bg: var(--color-background-lvl-1);
   --color-box-border: var(--color-background-lvl-3);
+  --color-box-info-bg: var(--color-info-bg);
+  --color-box-info-border: var(--color-info);
+  --color-box-success-bg: var(--color-success-bg);
+  --color-box-success-border: var(--color-success);
+  --color-box-warning-bg: var(--color-warning-bg);
+  --color-box-warning-border: var(--color-warning);
+  --color-box-error-bg: var(--color-error-bg);
+  --color-box-error-border: var(--color-error);
+  --color-box-danger-bg: var(--color-danger-bg);
+  --color-box-danger-border: var(--color-danger);
   /* DT SideNavigation */
   --color-sidenavigation-item-active: var(--color-white);
   --color-sidenavigation-item-active-bg: var(--color-background-lvl-0);


### PR DESCRIPTION
# Summary

<!-- Provide a short summary explaining the purpose of this pull request. -->

# Changes Made

- add `variant` prop and stylistic / semantic variants to `Box``
- refactor semantic bg-colors to be generic and used by `Message` and `Box`
- add `border-higher` colors and variables

# Related Issues

Closes #1835



1. `pnpm i`
2. `pnpm run test Box`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
