### PR TITLE
feat(ui): make form elements error-, help-, and successtext editable in storybook

### DIFF
--- a/packages/ui-components/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui-components/src/components/Checkbox/Checkbox.stories.tsx
@@ -11,13 +11,16 @@ const meta: Meta<typeof Checkbox> = {
   component: Checkbox,
   argTypes: {
     errortext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     helptext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     successtext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
   },
 }

--- a/packages/ui-components/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/packages/ui-components/src/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -13,13 +13,16 @@ const meta: Meta<typeof CheckboxGroup> = {
   component: CheckboxGroup,
   argTypes: {
     errortext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     helptext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     successtext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     children: {
       control: false,

--- a/packages/ui-components/src/components/ComboBox/ComboBox.stories.tsx
+++ b/packages/ui-components/src/components/ComboBox/ComboBox.stories.tsx
@@ -28,19 +28,19 @@ const meta: Meta<typeof ComboBox> = {
       },
     },
     errortext: {
-      control: false,
+      control: "text",
       table: {
         type: { summary: "ReactNode" },
       },
     },
     helptext: {
-      control: false,
+      control: "text",
       table: {
         type: { summary: "ReactNode" },
       },
     },
     successtext: {
-      control: false,
+      control: "text",
       table: {
         type: { summary: "ReactNode" },
       },

--- a/packages/ui-components/src/components/DateTimePicker/DateTimePicker.stories.tsx
+++ b/packages/ui-components/src/components/DateTimePicker/DateTimePicker.stories.tsx
@@ -48,19 +48,19 @@ const meta: Meta<typeof DateTimePicker> = {
       },
     },
     errortext: {
-      control: false,
+      control: "text",
       table: {
         type: { summary: "ReactNode" },
       },
     },
     helptext: {
-      control: false,
+      control: "text",
       table: {
         type: { summary: "ReactNode" },
       },
     },
     successtext: {
-      control: false,
+      control: "text",
       table: {
         type: { summary: "ReactNode" },
       },

--- a/packages/ui-components/src/components/Radio/Radio.stories.tsx
+++ b/packages/ui-components/src/components/Radio/Radio.stories.tsx
@@ -12,13 +12,16 @@ const meta: Meta<typeof Radio> = {
   component: Radio,
   argTypes: {
     errortext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     helptext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     successtext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
   },
 }

--- a/packages/ui-components/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/ui-components/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -13,13 +13,16 @@ const meta: Meta<typeof RadioGroup> = {
   component: RadioGroup,
   argTypes: {
     errortext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     helptext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     successtext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     children: {
       control: false,

--- a/packages/ui-components/src/components/SecretText/SecretText.stories.tsx
+++ b/packages/ui-components/src/components/SecretText/SecretText.stories.tsx
@@ -10,6 +10,18 @@ const meta: Meta<typeof SecretText> = {
   title: "Forms/SecretText",
   component: SecretText,
   argTypes: {
+    errortext: {
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
+    },
+    helptext: {
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
+    },
+    successtext: {
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
+    },
     onBlur: {
       control: false,
     },

--- a/packages/ui-components/src/components/Select/Select.stories.tsx
+++ b/packages/ui-components/src/components/Select/Select.stories.tsx
@@ -25,13 +25,16 @@ const meta: Meta<typeof Select> = {
       control: { type: "select" },
     },
     errortext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     helptext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     successtext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     children: {
       control: false,

--- a/packages/ui-components/src/components/Switch/Switch.stories.tsx
+++ b/packages/ui-components/src/components/Switch/Switch.stories.tsx
@@ -12,13 +12,16 @@ const meta: Meta<typeof Switch> = {
   component: Switch,
   argTypes: {
     errortext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     helptext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     successtext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
   },
 }

--- a/packages/ui-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/ui-components/src/components/TextInput/TextInput.stories.tsx
@@ -21,13 +21,16 @@ const meta: Meta<TextInputProps> = {
   },
   argTypes: {
     errortext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     helptext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     successtext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     value: {
       control: { type: "text" },

--- a/packages/ui-components/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/ui-components/src/components/Textarea/Textarea.stories.tsx
@@ -21,13 +21,16 @@ const meta: Meta<TextareaProps> = {
   },
   argTypes: {
     errortext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     helptext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
     successtext: {
-      control: false,
+      control: "text",
+      table: { type: { summary: "ReactNode" } },
     },
   },
 }


### PR DESCRIPTION


## Summary

Make form elements error-, help-, and successtext editable in storybook using a text input field.


## Changes Made

Enable text controls for `errortext`, `helptext`, and `successtext` props in Storybook for all form components. Previously these were set to `control: false`, making it impossible to test these states interactively in the Controls panel. Changed to `control: "text"` and added `table: { type: { summary: "ReactNode" } }` annotations where missing.

### Affected components

- `Checkbox`
- `CheckboxGroup`
- `Radio`
- `RadioGroup`
- `Select`
- `Switch`
- `TextInput`
- `Textarea`
- `ComboBox`
- `DateTimePicker`
- `SecretText`

## Screenshots
<img width="1065" height="278" alt="Bildschirmfoto 2026-08-04 um 09 45 20" src="https://github.com/user-attachments/assets/fd6b3c50-067e-4241-a9b2-d12f740f965b" />

_`errortext`, `helptext`, and `successtext` props can now be edited in storybook_

## Related Issues

Closes #1812 

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
