### PR TITLE
feat(ui): remove `success` icon

### DIFF
--- a/.changeset/witty-meals-know.md
+++ b/.changeset/witty-meals-know.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+feat(ui): remove `success` icon, return `check circle´ instead when `success` is called

--- a/packages/ui-components/src/components/Icon/Icon.component.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.component.tsx
@@ -818,7 +818,7 @@ const getColoredSizedIcon = ({ icon, color, size, title, iconClassName, ...iconP
           width={size}
           height={size}
           className={iconClass}
-          alt="checkCircle"
+          alt="success"
           title={title ? title : "Success"}
           role="img"
           {...iconProps}

--- a/packages/ui-components/src/components/Icon/Icon.component.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.component.tsx
@@ -48,7 +48,6 @@ import NotificationsOff from "@material-design-icons/svg/outlined/notifications_
 import OpenInBrowser from "@material-design-icons/svg/outlined/open_in_browser.svg"
 import OpenInNew from "@material-design-icons/svg/outlined/open_in_new.svg"
 import Place from "./icons/place.svg"
-import Success from "@material-design-icons/svg/filled/check_box.svg"
 import Search from "@material-design-icons/svg/outlined/search.svg"
 import SeverityLow from "./icons/juno_severity_low.svg"
 import SeverityMedium from "./icons/juno_severity_medium.svg"
@@ -812,12 +811,14 @@ const getColoredSizedIcon = ({ icon, color, size, title, iconClassName, ...iconP
         />
       )
     case KnownIconsEnum.success:
+      // `success` (check_box.svg) has been sundown in favour of `checkCircle` to avoid visual inconsistency.
+      // The `success` name is kept as a valid alias so existing callers continue to work.
       return (
-        <Success
+        <CheckCircle
           width={size}
           height={size}
           className={iconClass}
-          alt="success"
+          alt="checkCircle"
           title={title ? title : "Success"}
           role="img"
           {...iconProps}

--- a/packages/ui-components/src/components/Icon/Icon.component.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.component.tsx
@@ -811,7 +811,7 @@ const getColoredSizedIcon = ({ icon, color, size, title, iconClassName, ...iconP
         />
       )
     case KnownIconsEnum.success:
-      // `success` (check_box.svg) has been sundown in favour of `checkCircle` to avoid visual inconsistency.
+      // `success` (check_box.svg) has been deprecated in favour of `checkCircle` to avoid visual inconsistency.
       // The `success` name is kept as a valid alias so existing callers continue to work.
       return (
         <CheckCircle

--- a/packages/ui-components/src/components/Icon/Icon.stories.ts
+++ b/packages/ui-components/src/components/Icon/Icon.stories.ts
@@ -160,6 +160,8 @@ export const Check: Story = {
 }
 
 export const CheckCircle: Story = {
+  // Note: `success` and `checkCircle` return the same icon. `success` (check_box.svg) has been sundown
+  // in favour of `checkCircle` to avoid visual inconsistency between two filled checkmark icons.
   args: {
     icon: "checkCircle",
   },
@@ -431,6 +433,8 @@ export const SeverityUnknown: Story = {
 }
 
 export const Success: Story = {
+  // Note: `success` and `checkCircle` return the same icon. `success` (check_box.svg) has been sundown
+  // in favour of `checkCircle` to avoid visual inconsistency between two filled checkmark icons.
   args: {
     ...Default.args,
     icon: "success",

--- a/packages/ui-components/src/components/Icon/Icon.stories.ts
+++ b/packages/ui-components/src/components/Icon/Icon.stories.ts
@@ -160,7 +160,7 @@ export const Check: Story = {
 }
 
 export const CheckCircle: Story = {
-  // Note: `success` and `checkCircle` return the same icon. `success` (check_box.svg) has been sundown
+  // Note: `success` and `checkCircle` return the same icon. `success` (check_box.svg) has been deprecated
   // in favour of `checkCircle` to avoid visual inconsistency between two filled checkmark icons.
   args: {
     icon: "checkCircle",
@@ -433,7 +433,7 @@ export const SeverityUnknown: Story = {
 }
 
 export const Success: Story = {
-  // Note: `success` and `checkCircle` return the same icon. `success` (check_box.svg) has been sundown
+  // Note: `success` and `checkCircle` return the same icon. `success` (check_box.svg) has been deprecated
   // in favour of `checkCircle` to avoid visual inconsistency between two filled checkmark icons.
   args: {
     ...Default.args,

--- a/packages/ui-components/src/components/Icon/Icon.test.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.test.tsx
@@ -276,7 +276,12 @@ describe("Icon (typescript)", () => {
   test("renders a success icon", () => {
     render(<Icon icon="success" />)
     expect(screen.getByRole("img")).toBeInTheDocument()
-    expect(screen.getByRole("img")).toHaveAttribute("alt", "success")
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "checkCircle")
+  })
+
+  test("renders checkCircle when calling success (success is an alias for checkCircle)", () => {
+    render(<Icon icon="success" />)
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "checkCircle")
   })
 
   test("renders a warning icon", () => {

--- a/packages/ui-components/src/components/Icon/Icon.test.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.test.tsx
@@ -276,12 +276,15 @@ describe("Icon (typescript)", () => {
   test("renders a success icon", () => {
     render(<Icon icon="success" />)
     expect(screen.getByRole("img")).toBeInTheDocument()
-    expect(screen.getByRole("img")).toHaveAttribute("alt", "checkCircle")
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "success")
   })
 
   test("renders checkCircle when calling success (success is an alias for checkCircle)", () => {
-    render(<Icon icon="success" />)
-    expect(screen.getByRole("img")).toHaveAttribute("alt", "checkCircle")
+    const { container: successContainer } = render(<Icon icon="success" />)
+    const { container: checkCircleContainer } = render(<Icon icon="checkCircle" />)
+    const successPath = successContainer.querySelector("svg path")?.getAttribute("d")
+    const checkCirclePath = checkCircleContainer.querySelector("svg path")?.getAttribute("d")
+    expect(successPath).toEqual(checkCirclePath)
   })
 
   test("renders a warning icon", () => {

--- a/packages/ui-components/src/components/Icon/Icon.test.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.test.tsx
@@ -279,7 +279,7 @@ describe("Icon (typescript)", () => {
     expect(screen.getByRole("img")).toHaveAttribute("alt", "success")
   })
 
-  test("renders checkCircle when calling success (success is an alias for checkCircle)", () => {
+  test("renders checkCircle when calling success (success has been deprecated in favour of checkCircle)", () => {
     const { container: successContainer } = render(<Icon icon="success" />)
     const { container: checkCircleContainer } = render(<Icon icon="checkCircle" />)
     const successPath = successContainer.querySelector("svg path")?.getAttribute("d")


### PR DESCRIPTION
This PR removes the `success` icon (for rationale see https://github.com/cloudoperators/juno/issues/1669), and returns `check circle` instead when calling `success`, and adds a test and necessary comments for the replacement.

# Summary

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Remove import of `success` icon
- Update the `Icon` component to return `check circle` when `success` is called
- Add test to make sure the replacement works as expected

# Related Issues

Closes #1669 

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test Icon`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
