### PR TITLE
chore(docs): add scheduled alias for accessTime Icon 

### DIFF
--- a/.changeset/strong-pillows-worry.md
+++ b/.changeset/strong-pillows-worry.md
@@ -2,4 +2,4 @@
 "@cloudoperators/juno-ui-components": patch
 ---
 
-chore(docs): add `scheduled` alias for for `accessTime` Icon 
+chore(docs): add `schedule` alias for for `accessTime` Icon 

--- a/.changeset/strong-pillows-worry.md
+++ b/.changeset/strong-pillows-worry.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+chore(docs): add `scheduled` alias for for `accessTime` Icon 

--- a/packages/ui-components/src/components/Icon/Icon.component.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.component.tsx
@@ -186,6 +186,8 @@ export enum KnownIconsEnum {
   // eslint-disable-next-line no-unused-vars
   place = "place",
   // eslint-disable-next-line no-unused-vars
+  schedule = "schedule",
+  // eslint-disable-next-line no-unused-vars
   search = "search",
   // eslint-disable-next-line no-unused-vars
   severityLow = "severityLow",
@@ -242,6 +244,19 @@ const getColoredSizedIcon = ({ icon, color, size, title, iconClassName, ...iconP
           className={iconClass}
           alt="time"
           title={title ? title : "Time"}
+          role="img"
+          {...iconProps}
+        />
+      )
+    case KnownIconsEnum.schedule:
+      // `schedule` is an alias for `accessTime` — both use the same SVG.
+      return (
+        <AccessTime
+          width={size}
+          height={size}
+          className={iconClass}
+          alt="schedule"
+          title={title ? title : "Schedule"}
           role="img"
           {...iconProps}
         />

--- a/packages/ui-components/src/components/Icon/Icon.stories.ts
+++ b/packages/ui-components/src/components/Icon/Icon.stories.ts
@@ -111,6 +111,22 @@ export const IconAsButton: Story = {
   },
 }
 
+export const Access_Time: Story = {
+  // Note: `accessTime` and `schedule` return the same icon. `schedule` is an alias for `accessTime`.
+  args: {
+    ...Default.args,
+    icon: "accessTime",
+  },
+}
+
+export const Schedule: Story = {
+  // Note: `schedule` and `accessTime` return the same icon. `schedule` is an alias for `accessTime`.
+  args: {
+    ...Default.args,
+    icon: "schedule",
+  },
+}
+
 export const Account_Circle: Story = {
   args: {
     ...Default.args,

--- a/packages/ui-components/src/components/Icon/Icon.stories.ts
+++ b/packages/ui-components/src/components/Icon/Icon.stories.ts
@@ -119,14 +119,6 @@ export const Access_Time: Story = {
   },
 }
 
-export const Schedule: Story = {
-  // Note: `schedule` and `accessTime` return the same icon. `schedule` is an alias for `accessTime`.
-  args: {
-    ...Default.args,
-    icon: "schedule",
-  },
-}
-
 export const Account_Circle: Story = {
   args: {
     ...Default.args,
@@ -397,6 +389,14 @@ export const Search: Story = {
   args: {
     ...Default.args,
     icon: "search",
+  },
+}
+
+export const Schedule: Story = {
+  // Note: `schedule` and `accessTime` return the same icon. `schedule` is an alias for `accessTime`.
+  args: {
+    ...Default.args,
+    icon: "schedule",
   },
 }
 

--- a/packages/ui-components/src/components/Icon/Icon.test.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.test.tsx
@@ -80,6 +80,8 @@ describe("Icon (typescript)", () => {
     const { container: accessTimeContainer } = render(<Icon icon="accessTime" />)
     const schedulePath = scheduleContainer.querySelector("svg path")?.getAttribute("d")
     const accessTimePath = accessTimeContainer.querySelector("svg path")?.getAttribute("d")
+    expect(schedulePath).toEqual(expect.any(String))
+    expect(accessTimePath).toEqual(expect.any(String))
     expect(schedulePath).toEqual(accessTimePath)
   })
 

--- a/packages/ui-components/src/components/Icon/Icon.test.tsx
+++ b/packages/ui-components/src/components/Icon/Icon.test.tsx
@@ -69,6 +69,20 @@ describe("Icon (typescript)", () => {
     expect(screen.getByRole("img")).toHaveAttribute("alt", "time")
   })
 
+  test("renders a schedule icon", () => {
+    render(<Icon icon="schedule" />)
+    expect(screen.getByRole("img")).toBeInTheDocument()
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "schedule")
+  })
+
+  test("renders the same icon for schedule and accessTime (schedule is an alias for accessTime)", () => {
+    const { container: scheduleContainer } = render(<Icon icon="schedule" />)
+    const { container: accessTimeContainer } = render(<Icon icon="accessTime" />)
+    const schedulePath = scheduleContainer.querySelector("svg path")?.getAttribute("d")
+    const accessTimePath = accessTimeContainer.querySelector("svg path")?.getAttribute("d")
+    expect(schedulePath).toEqual(accessTimePath)
+  })
+
   test("renders an accountCircle icon", () => {
     render(<Icon icon="accountCircle" />)
     expect(screen.getByRole("img")).toBeInTheDocument()


### PR DESCRIPTION
# Summary

Add `scheduled` as an alias to the `accessTime` icon in the `Icon` component to mirror behaviour in MUI.

# Related Issues

Closes #1851 


# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test Icon`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
