### PR TITLE
fix(ui): fix rules of hooks violations via useId

### DIFF
--- a/.changeset/tame-taxes-joke.md
+++ b/.changeset/tame-taxes-joke.md
@@ -1,0 +1,5 @@
+---
+"@cloudoperators/juno-ui-components": patch
+---
+
+Fix rules of hooks violation using ´useId`: Only Call Hooks at the Top Level (1589)

--- a/packages/ui-components/src/components/CheckboxGroup/CheckboxGroup.component.tsx
+++ b/packages/ui-components/src/components/CheckboxGroup/CheckboxGroup.component.tsx
@@ -83,11 +83,12 @@ export const CheckboxGroup = ({
     return !(typeof str === "string" && str.trim().length === 0)
   }
 
-  const uniqueId = () => "juno-checkboxgroup-" + useId()
+  const generatedName = useId()
+  const generatedId = useId()
 
   // Create unique identifiers for use with name and id of the group:
-  const groupName = name || uniqueId()
-  const groupId = id || uniqueId()
+  const groupName = name || "juno-checkboxgroup-" + generatedName
+  const groupId = id || "juno-checkboxgroup-" + generatedId
 
   // Init state variables:
   const [selectedOptions, setSelectedOptions] = useState<string[] | undefined>(selected)

--- a/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
+++ b/packages/ui-components/src/components/ComboBox/ComboBox.component.tsx
@@ -223,8 +223,9 @@ export const ComboBox = ({
     return !(typeof str === "string" && str.trim().length === 0)
   }
 
-  const theId = id || "juno-combobox-" + useId()
+  const generatedId = useId()
   const helptextId = "juno-combobox-helptext-" + useId()
+  const theId = id || "juno-combobox-" + generatedId
   const [isOpen, setIsOpen] = useState(false)
 
   const [optionValuesAndLabels, setOptionValuesAndLabels] = useState(

--- a/packages/ui-components/src/components/RadioGroup/RadioGroup.component.tsx
+++ b/packages/ui-components/src/components/RadioGroup/RadioGroup.component.tsx
@@ -99,11 +99,12 @@ export const RadioGroup = ({
     return !(typeof str === "string" && str.trim().length === 0)
   }
 
-  const uniqueId = () => "juno-radiogroup-" + useId()
+  const generatedName = useId()
+  const generatedId = useId()
 
   // Create unique identifiers for use with name and id of the group:
-  const groupName = name || uniqueId()
-  const groupId = id || uniqueId()
+  const groupName = name || "juno-radiogroup-" + generatedName
+  const groupId = id || "juno-radiogroup-" + generatedId
 
   const [selectedValue, setSelectedValue] = useState<string | undefined>(selected)
   const [isValid, setIsValid] = useState<boolean>(false)

--- a/packages/ui-components/src/components/SecretText/SecretText.component.tsx
+++ b/packages/ui-components/src/components/SecretText/SecretText.component.tsx
@@ -116,8 +116,8 @@ export const SecretText = ({
     return !(typeof str === "string" && str.trim().length === 0)
   }
 
-  const uniqueId = () => "juno-secrettext-" + useId()
-  const theId = id || uniqueId()
+  const generatedId = useId()
+  const theId = id || "juno-secrettext-" + generatedId
 
   const [isRevealed, setIsRevealed] = useState(false)
   const [val, setVal] = useState("")

--- a/packages/ui-components/src/components/Select/Select.component.tsx
+++ b/packages/ui-components/src/components/Select/Select.component.tsx
@@ -198,11 +198,11 @@ export const Select = ({
     return !(typeof value === "string" && value.trim().length === 0)
   }
 
-  const uniqueId = () => "juno-select-" + useId()
+  const generatedId = useId()
+  const helptextId = "juno-select-helptext-" + useId()
   const [isOpen, setIsOpen] = useState(false)
 
-  const theId = id || uniqueId()
-  const helptextId = "juno-select-helptext-" + useId()
+  const theId = id || "juno-select-" + generatedId
 
   const [optionValuesAndLabels, setOptionValuesAndLabels] = useState(new Map<unknown, unknown>())
   const [hasError, setHasError] = useState(false)

--- a/packages/ui-components/src/components/Switch/Switch.component.tsx
+++ b/packages/ui-components/src/components/Switch/Switch.component.tsx
@@ -230,7 +230,7 @@ export const Switch = ({
   wrapperClassName = "",
   ...props
 }: SwitchProps): ReactNode => {
-  const generateUniqueId = (): string => "juno-switch-" + useId()
+  const generatedId = useId()
 
   const [isOn, setIsOn] = useState<boolean>(on)
   const [isInvalid, setIsInvalid] = useState<boolean>(false)
@@ -264,7 +264,7 @@ export const Switch = ({
     if (onChange) onChange(event as unknown as ChangeEvent<HTMLButtonElement>)
   }
 
-  const generatedId: string = id || generateUniqueId()
+  const theId: string = id || "juno-switch-" + generatedId
 
   return (
     <div>
@@ -279,7 +279,7 @@ export const Switch = ({
           type="button"
           role="switch"
           name={name}
-          id={generatedId}
+          id={theId}
           aria-checked={isOn}
           disabled={disabled}
           onClick={handleSwitchClick}
@@ -301,7 +301,7 @@ export const Switch = ({
           ></span>
         </button>
 
-        <Label text={label} htmlFor={generatedId} className="jn:ml-2" disabled={disabled} required={required} />
+        <Label text={label} htmlFor={theId} className="jn:ml-2" disabled={disabled} required={required} />
 
         {renderValidationIcon(isInvalid, isValid, disabled)}
       </span>

--- a/packages/ui-components/src/components/TextInput/TextInput.component.tsx
+++ b/packages/ui-components/src/components/TextInput/TextInput.component.tsx
@@ -122,7 +122,7 @@ export const TextInput = ({
     return !(typeof str === "string" && str.trim().length === 0)
   }
 
-  const uniqueId = () => "juno-textinput-" + useId()
+  const generatedId = useId()
 
   const ref = useRef<HTMLInputElement | null>(null)
   const [val, setValue] = useState<string | number>("")
@@ -188,7 +188,7 @@ export const TextInput = ({
     }
   }
 
-  const theId = id || uniqueId()
+  const theId = id || "juno-textinput-" + generatedId
 
   return (
     <div className="juno-textinput-outer-wrapper">

--- a/packages/ui-components/src/components/Textarea/Textarea.component.tsx
+++ b/packages/ui-components/src/components/Textarea/Textarea.component.tsx
@@ -123,7 +123,7 @@ export const Textarea = ({
     return !(typeof str === "string" && str.trim().length === 0)
   }
 
-  const uniqueId = () => "juno-textarea-" + useId()
+  const generatedId = useId()
 
   const ref = useRef<HTMLTextAreaElement>(null)
   const [val, setValue] = useState<string>("")
@@ -189,7 +189,7 @@ export const Textarea = ({
     }
   }
 
-  const theId = id || uniqueId()
+  const theId = id || "juno-textarea-" + generatedId
 
   return (
     <div>


### PR DESCRIPTION
## Summary

Fix all `useId`-related violations of **Rules of Hooks**:  

**_Only Call Hooks at the Top Level_**

We called the `useId` hook in several components across our system. Before React doesn't, we fix this now.

## Changes Made

<!-- List the changes that were made in this pull request. -->

- **CheckboxGroup** — replaced `uniqueId()` wrapper with two top-level calls `generatedName = useId()` and `generatedId = useId()`; used inline in `groupName` and `groupId` assignments
- **ComboBox** — extracted `generatedId = useId()` to top level; split off from the conditional `theId` assignment; `helptextId` was already unconditional so unchanged
- **RadioGroup** — same as CheckboxGroup: two separate top-level `useId()` calls for `generatedName` and `generatedId`
- **SecretText** — removed `uniqueId` arrow function; replaced with top-level `generatedId = useId()` used in `theId` assignment
- **Select** — removed `uniqueId` arrow function; replaced with top-level `generatedId = useId()` used in `theId` assignment; `helptextId` was already unconditional so unchanged
- **Switch** — removed `generateUniqueId` arrow function; replaced with top-level `generatedId = useId()`; introduced `theId` combining `id` and `generatedId`; updated `id` and `htmlFor` usages in JSX from `generatedId` to `theId`
- **TextInput** — removed `uniqueId` arrow function; replaced with top-level `generatedId = useId()` used in `theId` assignment
- **Textarea** — removed `uniqueId` arrow function; replaced with top-level `generatedId = useId()` used in `theId` assignment


## Related Issues

Closes #1589 

# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [x] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
