### PR TITLE
chore(ui): add test for `juno-` identifier class to Status component

### DIFF
--- a/packages/ui-components/src/components/Status/Status.test.tsx
+++ b/packages/ui-components/src/components/Status/Status.test.tsx
@@ -14,6 +14,7 @@ describe("Status", () => {
   it("renders a Status", () => {
     render(<Status />)
     expect(screen.getByRole("alert")).toBeInTheDocument()
+    expect(screen.getByRole("alert")).toHaveClass("juno-status")
   })
 
   it("renders with role alert for error status", () => {


### PR DESCRIPTION
# Summary

This PR adds a test for the presence of a `juno-`-prefixed identifier class on the `Status` component that was missing.


# Related Issues

Closes #1875 



# Testing Instructions

<!-- Describe the steps needed to test this pull request. -->

1. `pnpm i`
2. `pnpm run test Status`

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
- [ ] I have created a changeset for my changes.

# PR Manifesto

Review the [PR Manifesto](https://github.com/cloudoperators/juno/blob/main/docs/pr_manifesto.md) for best practises.
